### PR TITLE
po-language/DTHFUI-1229 - o provedin do PoLanguageService deve ser configurado como root

### DIFF
--- a/projects/ui/src/lib/services/po-language/po-language.service.ts
+++ b/projects/ui/src/lib/services/po-language/po-language.service.ts
@@ -12,7 +12,9 @@ const poLocaleKey = 'PO_USER_LOCALE';
  *
  * Serviço responsável por gerenciar as linguagens da aplicação.
  */
-@Injectable()
+@Injectable({
+  providedIn: 'root'
+})
 export class PoLanguageService {
 
   set languageDefault(language: string) {


### PR DESCRIPTION
### PO-LANGUAGE

***

[DTHFUI-1229](http://jiraproducao.totvs.com.br/browse/DTHFUI-1229)
- [DTHFUI-1253](http://jiraproducao.totvs.com.br/browse/DTHFUI-1253) - o provedin do PoLanguageService deve ser configurado como root

***

**Situação:** o *providedIn* do `PoLanguageService` não está configurado como *root*.

**Solução:** realizado definição do *providedIn* como *root*.

**Simulação:** *buildar o projeto UI e utiliza-lo em uma aplicação que utilize o serviço `i18n`.
> Além do próprio Portal que pode ser utilizado para teste, nos anexos da tarefa há uma aplicação que também pode ser utilizada para teste.

***