### PR TITLE
feat(modal): criação do novo valor "full" para a propriedade `p-size`

### DIFF
--- a/projects/ui/src/lib/components/po-modal/po-modal-base.component.spec.ts
+++ b/projects/ui/src/lib/components/po-modal/po-modal-base.component.spec.ts
@@ -25,7 +25,7 @@ describe('PoModalBaseComponent:', () => {
   });
 
   it('should update property `p-size` with valid values', () => {
-    const validValues = ['sm', 'md', 'lg', 'xl', 'auto'];
+    const validValues = ['sm', 'md', 'lg', 'xl', 'auto', 'full'];
 
     expectPropertiesValues(component, 'size', validValues, validValues);
   });

--- a/projects/ui/src/lib/components/po-modal/po-modal-base.component.ts
+++ b/projects/ui/src/lib/components/po-modal/po-modal-base.component.ts
@@ -44,15 +44,18 @@ export class PoModalBaseComponent {
    *  - `md` (médio)
    *  - `lg` (grande)
    *  - `xl` (extra grande)
-   *  - `auto` (automático)
+   *  - `auto` (automático, com limitação da largura)
+   *  - `full` (automático, sem limitação da largura)
    *
-   * > Quando informado `auto` a modal calculará automaticamente seu tamanho baseado em seu conteúdo.
+   * > Quando informado `auto` a modal calculará automaticamente seu tamanho baseado em seu conteúdo. Porém limitado a largura
+   * máxima de `768px`.
+   *
    * Caso não seja informado um valor, a modal terá o tamanho definido como `md`.
    *
    * > Todas as opções de tamanho possuem uma largura máxima de **768px**.
    */
   @Input('p-size') set size(value: string) {
-    const sizes = ['sm', 'md', 'lg', 'xl', 'auto'];
+    const sizes = ['sm', 'md', 'lg', 'xl', 'auto', 'full'];
     this._size = sizes.indexOf(value) > -1 ? value : 'md';
   }
 

--- a/projects/ui/src/lib/components/po-modal/samples/sample-po-modal-labs/sample-po-modal-labs.component.ts
+++ b/projects/ui/src/lib/components/po-modal/samples/sample-po-modal-labs/sample-po-modal-labs.component.ts
@@ -57,6 +57,7 @@ export class SamplePoModalLabsComponent implements OnInit {
     { label: 'Large', value: 'lg' },
     { label: 'Extra large', value: 'xl' },
     { label: 'Automatic', value: 'auto' },
+    { label: 'Full', value: 'full' },
   ];
 
   openModal() {


### PR DESCRIPTION
**PO-MODAL**
[DTHFUI-894](http://jiraproducao.totvs.com.br/browse/DTHFUI-894)

DTHFUI-1245 - permitir modal com tamanho maior que 768px

**Situação:**
A modal estava limitando o tamanho do valor "auto" para `768px`.

**Solução:**
Criação do novo valor "full" na propriedade `p-size`.
Este valor serve para poder deixar a modal ter o tamanho conforme o conteúdo sem a limitação de tamanho.

**Simulação:** 
Utilizar o sample labs da modal

**PR relacionada:** https://github.com/portinariui/portinari-style/pull/2

**OBS.:** Não foi possível testar no IE, pois o App.component do repositório não está com os polyfills corretos.