### PR TITLE
fix(lookup) corrige descrição dos registros

### DIFF
--- a/projects/ui/src/lib/components/po-field/po-lookup/po-lookup.component.spec.ts
+++ b/projects/ui/src/lib/components/po-field/po-lookup/po-lookup.component.spec.ts
@@ -233,6 +233,15 @@ describe('PoLookupComponent: ', () => {
       expect(component['setInputValueWipoieldFormat']).not.toHaveBeenCalled();
     });
 
+    it('setViewValue: should set nativeElement value with value if not have a formatField and valueToModel is 0', () => {
+      component.fieldFormat = undefined;
+      component['valueToModel'] = 0;
+
+      component.setViewValue('valueTeste', objectSelected);
+
+      expect(component.inputEl.nativeElement.value).toBe('valueTeste');
+    });
+
     it('setViewValue: should set nativeElement value with `` when not have a formatField and not have a valueToModel', () => {
       component.fieldFormat = undefined;
       component['valueToModel'] = undefined;

--- a/projects/ui/src/lib/components/po-field/po-lookup/po-lookup.component.ts
+++ b/projects/ui/src/lib/components/po-field/po-lookup/po-lookup.component.ts
@@ -113,7 +113,7 @@ export class PoLookupComponent extends PoLookupBaseComponent implements OnDestro
     if (this.fieldFormat) {
       this.setInputValueWipoieldFormat(object);
     } else {
-      this.inputEl.nativeElement.value = this.valueToModel ? value : '';
+      this.inputEl.nativeElement.value = this.valueToModel || this.valueToModel === 0 ? value : '';
     }
   }
 


### PR DESCRIPTION
**PO-LOOKUP**

**DTHFUI-1286**
_____________________________________________________________________________

**PR Checklist**

- [x] Código
- [x] Testes unitários
- [ ] Documentação
- [ ] Samples

**Qual o comportamento atual?**
Ao informar um código 0 a descrição do registro está ficando em branco.

**Qual o novo comportamento?**
O componente permite informar um código 0 e ao filtrar a descrição aparece corretamente.

**Simulação**
Acessar uma API que tenha retorno o value como 0.
    • Para simulação, utilizei o pacote json-server para simular uma API (https://www.npmjs.com/package/json-server);

Arquivo json:
```
{
  "lookup": {
    "items": [{
      "label": "00000",
      "value": 0
    }, {
      "label": "11111",
      "value": 1
    }, {
      "label": "22222",
      "value": 2
    }],
    "hasNext": true
  }
}
```
Arquivo app.component.html

```
<thf-lookup
  name="lookup"
  t-field-label="label"
  t-field-value="value"
  t-filter-service="http://localhost:3000/lookup"
  t-label="Totvs Lookup">
</thf-lookup>
```