### PR TITLE
test(navbar): adiciona testes unitários ao componente

### DIFF
--- a/projects/ui/karma.conf.js
+++ b/projects/ui/karma.conf.js
@@ -22,10 +22,10 @@ module.exports = function (config) {
       thresholds: {
         emitWarning: false, // set to 'true' to not fail the test command when thresholds are not met
         global: {
-          statements: 95,
-          branches: 95,
-          functions: 95,
-          lines: 95
+          statements: 98,
+          branches: 98,
+          functions: 98,
+          lines: 98
         }, each: {
           statements: 80,
           branches: 80,

--- a/projects/ui/src/lib/components/po-navbar/po-navbar-actions/po-navbar-action-popup/po-navbar-action-popup.component.spec.ts
+++ b/projects/ui/src/lib/components/po-navbar/po-navbar-actions/po-navbar-action-popup/po-navbar-action-popup.component.spec.ts
@@ -1,0 +1,78 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { RouterModule } from '@angular/router';
+
+import { configureTestSuite } from 'projects/ui/src/lib/util-test/util-expect.spec';
+
+import { PoNavbarActionPopupComponent } from './po-navbar-action-popup.component';
+import { PoPopupModule } from '../../../po-popup';
+
+describe('PoNavbarActionPopupComponent:', () => {
+  let component: PoNavbarActionPopupComponent;
+  let fixture: ComponentFixture<PoNavbarActionPopupComponent>;
+  let nativeElement: any;
+
+  configureTestSuite(() => {
+    TestBed.configureTestingModule({
+      declarations: [ PoNavbarActionPopupComponent ],
+      imports: [ PoPopupModule, RouterModule.forRoot([]) ]
+    });
+  });
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(PoNavbarActionPopupComponent);
+    component = fixture.componentInstance;
+    nativeElement = fixture.debugElement.nativeElement;
+
+    fixture.detectChanges();
+  });
+
+  it('should be created', () => {
+    expect(component instanceof PoNavbarActionPopupComponent).toBeTruthy();
+  });
+
+  describe('Methods:', () => {
+
+    it('getLastIconAction: should return the last icon', () => {
+      component.iconActions = [
+        { label: 'eye', icon: 'po-icon-eye'},
+        { label: 'gas', icon: 'po-icon-gas'},
+        { label: 'mail', icon: 'po-icon-mail'},
+        { label: 'menu', icon: 'po-icon-menu'}
+      ];
+
+      expect(component.getLastIconAction()).toEqual('po-icon-menu');
+    });
+
+    it('getLastIconAction: should return `undefined` if `iconActions` is undefined', () => {
+      component.iconActions = undefined;
+
+      expect(component.getLastIconAction()).toBeUndefined();
+    });
+
+    it('getLastIconAction: should return `undefined` if `iconActions` is empty array', () => {
+      component.iconActions = [];
+
+      expect(component.getLastIconAction()).toBeUndefined();
+    });
+
+  });
+
+  describe('Templates:', () => {
+
+    it('should contain the last icon', () => {
+      component.iconActions = [
+        { label: 'eye', icon: 'po-icon-eye'},
+        { label: 'gas', icon: 'po-icon-gas'},
+        { label: 'mail', icon: 'po-icon-mail'},
+        { label: 'menu', icon: 'po-icon-menu'}
+      ];
+
+      fixture.detectChanges();
+
+      const icon = nativeElement.querySelector('span.po-icon');
+      expect(icon.classList).toContain('po-icon-menu');
+    });
+
+  });
+
+});

--- a/projects/ui/src/lib/components/po-navbar/po-navbar-actions/po-navbar-action-popup/po-navbar-action-popup.component.ts
+++ b/projects/ui/src/lib/components/po-navbar/po-navbar-actions/po-navbar-action-popup/po-navbar-action-popup.component.ts
@@ -11,7 +11,7 @@ export class PoNavbarActionPopupComponent {
   @Input('p-icon-actions') iconActions: Array<PoNavbarIconAction>;
 
   getLastIconAction() {
-    if (this.iconActions && this.iconActions.length > 0) {
+    if (this.iconActions && this.iconActions.length) {
       return this.iconActions[this.iconActions.length - 1].icon;
     }
   }

--- a/projects/ui/src/lib/components/po-navbar/po-navbar-actions/po-navbar-action/po-navbar-action.component.html
+++ b/projects/ui/src/lib/components/po-navbar/po-navbar-actions/po-navbar-action/po-navbar-action.component.html
@@ -1,10 +1,11 @@
-<div tabindex="0"
+<div 
+  tabindex="0"
   class="po-navbar-action-content po-clickable"
-  (click)="onActionClick()">
+  (click)="click()">
 
   <span
-  class="po-icon {{ icon }}"
-  [p-tooltip]="tooltip">
+    class="po-icon {{ icon }}"
+    [p-tooltip]="tooltip">
   </span>
 
 </div>

--- a/projects/ui/src/lib/components/po-navbar/po-navbar-actions/po-navbar-action/po-navbar-action.component.spec.ts
+++ b/projects/ui/src/lib/components/po-navbar/po-navbar-actions/po-navbar-action/po-navbar-action.component.spec.ts
@@ -1,0 +1,119 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { RouterModule } from '@angular/router';
+
+import { configureTestSuite } from 'projects/ui/src/lib/util-test/util-expect.spec';
+import * as utils from '../../../../utils/util';
+
+import { PoNavbarActionComponent } from './po-navbar-action.component';
+import { PoTooltipModule } from 'projects/ui/src/lib/directives';
+
+describe('PoNavbarActionComponent:', () => {
+  let component: PoNavbarActionComponent;
+  let fixture: ComponentFixture<PoNavbarActionComponent>;
+
+  configureTestSuite(() => {
+    TestBed.configureTestingModule({
+      declarations: [ PoNavbarActionComponent ],
+      imports: [ PoTooltipModule, RouterModule.forRoot([]) ]
+    });
+  });
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(PoNavbarActionComponent);
+    component = fixture.componentInstance;
+
+    fixture.detectChanges();
+  });
+
+  it('should be created', () => {
+    expect(component instanceof PoNavbarActionComponent).toBeTruthy();
+  });
+
+  describe('Methods:', () => {
+
+    it('click: should call `callFunction` with `action` and `this` if `action` is defined and `parentRef` is undefined', () => {
+      component.action = () => 'action';
+      component['parentRef'] = undefined;
+
+      spyOn(utils, 'callFunction');
+
+      component.click();
+
+      expect(utils.callFunction).toHaveBeenCalledWith(component.action, component);
+    });
+
+    it('click: should call `callFunction` with `action` and `parentRef` if `action` and `parentRef` are defined', () => {
+      component.action = () => 'action';
+      component['parentRef'] = '<po-navbar></po-navbar>';
+
+      spyOn(utils, 'callFunction');
+
+      component.click();
+
+      expect(utils.callFunction).toHaveBeenCalledWith(component.action, component['parentRef']);
+    });
+
+    it('click: should call and return `openUrl` with `link` if `action` is undefined and `link` is defined', () => {
+      component.action = undefined;
+      component.link = 'http://test.com';
+      const linkReturn = 'test';
+
+      spyOn(utils, 'callFunction');
+      spyOn(component, <any>'openUrl').and.returnValue(linkReturn);
+
+      const result = <any> component.click();
+
+      expect(utils.callFunction).not.toHaveBeenCalled();
+      expect(component['openUrl']).toHaveBeenCalledWith(component.link);
+      expect(result).toBe(linkReturn);
+    });
+
+    it('click: shouldn`t call `callFunction` and `openUrl` if `action` and `link` is undefined', () => {
+      component.action = undefined;
+      component.link = undefined;
+
+      spyOn(utils, 'callFunction');
+      spyOn(component, <any>'openUrl');
+
+      component.click();
+
+      expect(utils.callFunction).not.toHaveBeenCalled();
+      expect(component['openUrl']).not.toHaveBeenCalled();
+    });
+
+    it('openUrl: should call `openExternalLink` if url is external link', () => {
+      const url = 'http://www.google.com';
+
+      spyOn(utils, 'openExternalLink');
+      spyOn(component['router'], 'navigate');
+
+      component['openUrl'](url);
+
+      expect(utils.openExternalLink).toHaveBeenCalledWith(url);
+      expect(component['router'].navigate).not.toHaveBeenCalled();
+    });
+
+    it('openUrl: should call `router.navigate` if url is internal link', () => {
+      const url = '/customers';
+
+      spyOn(component['router'], 'navigate');
+      spyOn(utils, 'openExternalLink');
+
+      component['openUrl'](url);
+
+      expect(component['router'].navigate).toHaveBeenCalled();
+      expect(utils.openExternalLink).not.toHaveBeenCalledWith(url);
+    });
+
+    it('openUrl: shouldn`t call `router.navigate` and `openExternalLink` if url is undefined ', () => {
+      spyOn(component['router'], 'navigate');
+      spyOn(utils, 'openExternalLink');
+
+      component['openUrl'](undefined);
+
+      expect(component['router'].navigate).not.toHaveBeenCalled();
+      expect(utils.openExternalLink).not.toHaveBeenCalled();
+    });
+
+  });
+});

--- a/projects/ui/src/lib/components/po-navbar/po-navbar-actions/po-navbar-action/po-navbar-action.component.ts
+++ b/projects/ui/src/lib/components/po-navbar/po-navbar-actions/po-navbar-action/po-navbar-action.component.ts
@@ -9,8 +9,7 @@ import { callFunction, isExternalLink, openExternalLink } from '../../../../util
 })
 export class PoNavbarActionComponent {
 
-  private param;
-  private parentRef;
+  private parentRef: any;
 
   @Input('p-action') action?: Function;
 
@@ -26,9 +25,10 @@ export class PoNavbarActionComponent {
     this.parentRef = viewContainerRef['_view']['component'];
   }
 
-  onActionClick() {
+  click() {
     if (this.action) {
-      return callFunction(this.action, this.parentRef, this.param || this);
+      callFunction(this.action, this.parentRef || this);
+      return;
     }
 
     if (this.link) {
@@ -37,6 +37,7 @@ export class PoNavbarActionComponent {
   }
 
   private openUrl(url: string) {
+
     if (isExternalLink(url)) {
       return openExternalLink(url);
     }

--- a/projects/ui/src/lib/components/po-navbar/po-navbar-actions/po-navbar-actions.component.spec.ts
+++ b/projects/ui/src/lib/components/po-navbar/po-navbar-actions/po-navbar-actions.component.spec.ts
@@ -1,0 +1,58 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { RouterModule } from '@angular/router';
+
+import { configureTestSuite, expectPropertiesValues } from '../../../util-test/util-expect.spec';
+
+import { PoNavbarActionsComponent } from './po-navbar-actions.component';
+import { PoNavbarActionsModule } from './po-navbar-actions.module';
+import { PoNavbarIconAction } from '../interfaces/po-navbar-icon-action.interface';
+import { PoTooltipModule } from '../../../directives';
+
+describe('PoNavbarActionsComponent:', () => {
+  let component: PoNavbarActionsComponent;
+  let fixture: ComponentFixture<PoNavbarActionsComponent>;
+
+  configureTestSuite(() => {
+    TestBed.configureTestingModule({
+      imports: [
+        PoTooltipModule,
+        PoNavbarActionsModule,
+        RouterModule.forRoot([])
+      ]
+    });
+  });
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(PoNavbarActionsComponent);
+    component = fixture.componentInstance;
+
+    fixture.detectChanges();
+  });
+
+  it('should be created', () => {
+    expect(component instanceof PoNavbarActionsComponent).toBeTruthy();
+  });
+
+  describe('Properties:', () => {
+
+    it('iconActions: should return valid values', () => {
+      const icons: Array<PoNavbarIconAction> = [
+        { label: 'eye', icon: 'po-icon-eye', link: 'test/'},
+        { label: 'gas', icon: 'po-icon-gas', link: 'test/'},
+        { label: 'mail', icon: 'po-icon-mail', link: 'test/'},
+        { label: 'menu', icon: 'po-icon-menu', link: 'test/'}
+      ];
+
+      const expectedIcons = [
+        { label: 'eye', icon: 'po-icon-eye', link: 'test/', separator: true, url: 'test/'},
+        { label: 'gas', icon: 'po-icon-gas', link: 'test/', separator: true, url: 'test/'},
+        { label: 'mail', icon: 'po-icon-mail', link: 'test/', separator: true, url: 'test/'},
+        { label: 'menu', icon: 'po-icon-menu', link: 'test/', separator: true, url: 'test/'}
+      ];
+
+      expectPropertiesValues(component, 'iconActions', [icons], [expectedIcons]);
+    });
+
+  });
+
+});

--- a/projects/ui/src/lib/components/po-navbar/po-navbar-actions/po-navbar-actions.component.ts
+++ b/projects/ui/src/lib/components/po-navbar/po-navbar-actions/po-navbar-actions.component.ts
@@ -8,7 +8,7 @@ import { PoNavbarIconAction } from '../interfaces/po-navbar-icon-action.interfac
 })
 export class PoNavbarActionsComponent {
 
-  private _iconActions;
+  private _iconActions: Array<PoNavbarIconAction>;
 
   @Input('p-icon-actions') set iconActions(actions: Array<PoNavbarIconAction>) {
     this._iconActions = actions.map(action => ({ ...action, separator: true, url: action.link }));

--- a/projects/ui/src/lib/components/po-navbar/po-navbar-base.component.spec.ts
+++ b/projects/ui/src/lib/components/po-navbar/po-navbar-base.component.spec.ts
@@ -1,0 +1,108 @@
+import { expectPropertiesValues } from '../../util-test/util-expect.spec';
+
+import * as utilsFunctions from '../../utils/util';
+
+import { PoNavbarBaseComponent, poNavbarLiteralsDefault } from './po-navbar-base.component';
+
+describe('PoNavbarBaseComponent:', () => {
+
+  const component = new PoNavbarBaseComponent();
+
+  it('should be created', () => {
+    expect(component instanceof PoNavbarBaseComponent).toBeTruthy();
+  });
+
+  describe('Properties:', () => {
+
+    it('iconActions: should update iconActions to `[]` if pass invalid values', () => {
+      const invalidValues = [undefined, null, '', true, false, 0, 1, 'string'];
+
+      expectPropertiesValues(component, 'iconActions', invalidValues, []);
+    });
+
+    it('iconActions: should update iconActions` with valid value', () => {
+      const validValue = [[{label: 'action1', action: () => {}}], [{label: 'action2'}]];
+
+      expectPropertiesValues(component, 'iconActions', validValue, validValue);
+    });
+
+    it('items: should update items to `[]` if pass invalid values', () => {
+      const invalidValues = [undefined, null, '', true, false, 0, 1, 'string'];
+
+      expectPropertiesValues(component, 'items', invalidValues, []);
+    });
+
+    it('items: should update items` with valid value', () => {
+      const validValue = [[{label: 'item1'}, {label: 'item2'}]];
+
+      expectPropertiesValues(component, 'items', validValue, validValue);
+    });
+
+    it('literals: should be in portuguese if browser is setted with an unsupported language', () => {
+      spyOn(utilsFunctions, <any>'browserLanguage').and.returnValue('ru');
+
+      component.literals = {};
+
+      expect(component.literals).toEqual(poNavbarLiteralsDefault[utilsFunctions.poLocaleDefault]);
+    });
+
+    it('literals: should be in portuguese if browser is setted with `pt`', () => {
+      spyOn(utilsFunctions, <any>'browserLanguage').and.returnValue('pt');
+
+      component.literals = {};
+
+      expect(component.literals).toEqual(poNavbarLiteralsDefault.pt);
+    });
+
+    it('literals: should be in english if browser is setted with `en`', () => {
+      spyOn(utilsFunctions, <any>'browserLanguage').and.returnValue('en');
+
+      component.literals = {};
+
+      expect(component.literals).toEqual(poNavbarLiteralsDefault.en);
+    });
+
+    it('literals: should be in spanish if browser is setted with `es`', () => {
+      spyOn(utilsFunctions, <any>'browserLanguage').and.returnValue('es');
+
+      component.literals = {};
+
+      expect(component.literals).toEqual(poNavbarLiteralsDefault.es);
+    });
+
+    it('literals: should accept custom literals', () => {
+      spyOn(utilsFunctions, <any>'browserLanguage').and.returnValue(utilsFunctions.poLocaleDefault);
+
+      const customLiterals = Object.assign({}, poNavbarLiteralsDefault[utilsFunctions.poLocaleDefault]);
+
+      // Custom some literals
+      customLiterals.navbarLinks = 'links';
+
+      component.literals = customLiterals;
+
+      expect(component.literals).toEqual(customLiterals);
+    });
+
+    it('literals: should update property with default literals if is setted with invalid values', () => {
+      const invalidValues = [null, undefined, false, true, '', 'literals', 0, 10, [], [1, 2], () => {}];
+
+      spyOn(utilsFunctions, <any>'browserLanguage').and.returnValue(utilsFunctions.poLocaleDefault);
+
+      expectPropertiesValues(component, 'literals', invalidValues, poNavbarLiteralsDefault[utilsFunctions.poLocaleDefault]);
+    });
+
+    it('shadow: should update property with true if valid values', () => {
+      const validValues = [true, '', 'true'];
+
+      expectPropertiesValues(component, 'shadow', validValues, true);
+    });
+
+    it('shadow: should update property with false if invalid values', () => {
+      const invalidValues = [false, 'po', null, undefined, NaN];
+
+      expectPropertiesValues(component, 'shadow', invalidValues, false);
+    });
+
+  });
+
+});

--- a/projects/ui/src/lib/components/po-navbar/po-navbar-base.component.ts
+++ b/projects/ui/src/lib/components/po-navbar/po-navbar-base.component.ts
@@ -2,6 +2,7 @@ import { Input } from '@angular/core';
 
 import { browserLanguage, convertToBoolean, poLocaleDefault } from '../../utils/util';
 
+import { PoMenuComponent } from '../po-menu';
 import { PoNavbarIconAction } from './interfaces/po-navbar-icon-action.interface';
 import { PoNavbarItem } from './interfaces/po-navbar-item.interface';
 import { PoNavbarLiterals } from './interfaces/po-navbar-literals.interface';
@@ -39,7 +40,7 @@ export class PoNavbarBaseComponent {
    * Define uma lista de ações apresentadas em ícones no lado direito do `po-navbar`.
    */
   @Input('p-icon-actions') set iconActions(value: Array<PoNavbarIconAction>) {
-    this._iconActions = value || [];
+    this._iconActions = Array.isArray(value) ? value : [];
   }
 
   get iconActions(): Array<PoNavbarIconAction> {
@@ -54,7 +55,7 @@ export class PoNavbarBaseComponent {
    * Define uma lista de items do `po-navbar`.
    */
   @Input('p-items') set items(value: Array<PoNavbarItem>) {
-    this._items = value || [];
+    this._items = Array.isArray(value) ? value : [];
   }
 
   get items(): Array<PoNavbarItem> {
@@ -133,7 +134,7 @@ export class PoNavbarBaseComponent {
    * </div>
    * ```
    */
-  @Input('p-menu') menu?: any;
+  @Input('p-menu') menu?: PoMenuComponent;
 
   /**
    * @optional

--- a/projects/ui/src/lib/components/po-navbar/po-navbar-item-navigation/po-navbar-item-navigation-icon/po-navbar-item-navigation-icon.component.html
+++ b/projects/ui/src/lib/components/po-navbar/po-navbar-item-navigation/po-navbar-item-navigation-icon/po-navbar-item-navigation-icon.component.html
@@ -1,0 +1,6 @@
+<div
+  [ngClass]="{'po-navbar-item-navigation-icon-disabled': disabled , 'po-clickable': !disabled }"
+  tabindex="0"
+  (click)="disabled ? undefined : click.emit(icon)" >
+  <span class="po-icon po-icon-arrow-{{icon}}"></span>
+</div>

--- a/projects/ui/src/lib/components/po-navbar/po-navbar-item-navigation/po-navbar-item-navigation-icon/po-navbar-item-navigation-icon.component.spec.ts
+++ b/projects/ui/src/lib/components/po-navbar/po-navbar-item-navigation/po-navbar-item-navigation-icon/po-navbar-item-navigation-icon.component.spec.ts
@@ -1,0 +1,95 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { configureTestSuite } from 'projects/ui/src/lib/util-test/util-expect.spec';
+
+import { PoNavbarItemNavigationIconComponent } from './po-navbar-item-navigation-icon.component';
+
+describe('PoNavbarItemNavigationIconComponent:', () => {
+  let component: PoNavbarItemNavigationIconComponent;
+  let fixture: ComponentFixture<PoNavbarItemNavigationIconComponent>;
+  let nativeElement: any;
+
+  configureTestSuite(() => {
+    TestBed.configureTestingModule({
+      declarations: [ PoNavbarItemNavigationIconComponent ]
+    });
+  });
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(PoNavbarItemNavigationIconComponent);
+    component = fixture.componentInstance;
+
+    nativeElement = fixture.debugElement.nativeElement;
+
+    fixture.detectChanges();
+  });
+
+  it('should be created', () => {
+    expect(component instanceof PoNavbarItemNavigationIconComponent).toBeTruthy();
+  });
+
+  describe('Templates: ', () => {
+
+    it('should contain `po-navbar-item-navigation-icon-disabled` if disabled is true', () => {
+      component.disabled = true;
+
+      fixture.detectChanges();
+
+      const element = nativeElement.querySelector('.po-navbar-item-navigation-icon-disabled');
+      const element2 = nativeElement.querySelector('.po-clickable');
+
+      expect(element).toBeTruthy();
+      expect(element2).toBeFalsy();
+    });
+
+    it('should contain `po-clickable` if disabled is false', () => {
+      component.disabled = false;
+
+      fixture.detectChanges();
+
+      const element = nativeElement.querySelector('.po-navbar-item-navigation-icon-disabled');
+      const element2 = nativeElement.querySelector('.po-clickable');
+
+      expect(element).toBeFalsy();
+      expect(element2).toBeTruthy();
+    });
+
+    it('should emit the icon if disabled is false', () => {
+      spyOn(component.click, 'emit');
+
+      const icon = true;
+      component.disabled = false;
+      component.icon = icon;
+
+      fixture.detectChanges();
+
+      const eventClick = document.createEvent('MouseEvents');
+      eventClick.initEvent('click', false, true);
+
+      const element = nativeElement.querySelector('.po-clickable');
+      element.dispatchEvent(eventClick);
+
+      expect(component.click.emit).toHaveBeenCalledWith(icon);
+    });
+
+    it('shouldn`t emit the icon if disabled is true', () => {
+      spyOn(component.click, 'emit');
+
+      const icon = true;
+      component.disabled = true;
+      component.icon = icon;
+
+      fixture.detectChanges();
+
+      const eventClick = document.createEvent('MouseEvents');
+      eventClick.initEvent('click', false, true);
+
+      const element = nativeElement.querySelector('.po-navbar-item-navigation-icon-disabled');
+      element.dispatchEvent(eventClick);
+
+      expect(component.click.emit).not.toHaveBeenCalled();
+    });
+
+  });
+
+});

--- a/projects/ui/src/lib/components/po-navbar/po-navbar-item-navigation/po-navbar-item-navigation-icon/po-navbar-item-navigation-icon.component.ts
+++ b/projects/ui/src/lib/components/po-navbar/po-navbar-item-navigation/po-navbar-item-navigation-icon/po-navbar-item-navigation-icon.component.ts
@@ -1,0 +1,15 @@
+import { Component, EventEmitter, Input, Output } from '@angular/core';
+
+@Component({
+  selector: 'po-navbar-item-navigation-icon',
+  templateUrl: './po-navbar-item-navigation-icon.component.html'
+})
+export class PoNavbarItemNavigationIconComponent {
+
+  @Input('p-disabled') disabled: boolean;
+
+  @Input('p-icon') icon: boolean;
+
+  @Output('p-click') click: EventEmitter<any> = new EventEmitter<any>();
+
+}

--- a/projects/ui/src/lib/components/po-navbar/po-navbar-item-navigation/po-navbar-item-navigation.component.html
+++ b/projects/ui/src/lib/components/po-navbar/po-navbar-item-navigation/po-navbar-item-navigation.component.html
@@ -1,12 +1,11 @@
-<div class="po-navbar-item-navigation-icon"
-  [ngClass]="{'po-navbar-item-navigation-icon-disabled': disableLeft , 'po-clickable': !disableLeft }"
-  tabindex="0"
-  (click)="disableLeft ? undefined : click.emit('left')" >
-  <span class="po-icon po-icon-arrow-left"></span>
-</div>
-<div class="po-navbar-item-navigation-icon"
-  [ngClass]="{'po-navbar-item-navigation-icon-disabled': disableRight , 'po-clickable': !disableRight }"  
-  tabindex="0"
-  (click)="disableRight ? undefined : click.emit('right')">
-  <span class="po-icon po-icon-arrow-right"></span>
-</div>
+<po-navbar-item-navigation-icon class="po-navbar-item-navigation-icon"
+  p-icon="left"
+  [p-disabled]="disableLeft"
+  (p-click)="click.emit($event)">
+</po-navbar-item-navigation-icon>
+
+<po-navbar-item-navigation-icon class="po-navbar-item-navigation-icon"
+  p-icon="right"
+  [p-disabled]="disableRight"
+  (p-click)="click.emit($event)">
+</po-navbar-item-navigation-icon>

--- a/projects/ui/src/lib/components/po-navbar/po-navbar-item-navigation/po-navbar-item-navigation.component.spec.ts
+++ b/projects/ui/src/lib/components/po-navbar/po-navbar-item-navigation/po-navbar-item-navigation.component.spec.ts
@@ -1,0 +1,45 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { configureTestSuite } from 'projects/ui/src/lib/util-test/util-expect.spec';
+
+import { PoNavbarItemNavigationComponent } from './po-navbar-item-navigation.component';
+import { PoNavbarItemNavigationIconComponent } from './po-navbar-item-navigation-icon/po-navbar-item-navigation-icon.component';
+
+describe('PoNavbarItemNavigationComponent:', () => {
+  let component: PoNavbarItemNavigationComponent;
+  let fixture: ComponentFixture<PoNavbarItemNavigationComponent>;
+  let nativeElement: any;
+
+  configureTestSuite(() => {
+    TestBed.configureTestingModule({
+      declarations: [ PoNavbarItemNavigationComponent, PoNavbarItemNavigationIconComponent ]
+    });
+  });
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(PoNavbarItemNavigationComponent);
+    component = fixture.componentInstance;
+
+    nativeElement = fixture.debugElement.nativeElement;
+
+    fixture.detectChanges();
+  });
+
+  it('should be created', () => {
+    expect(component instanceof PoNavbarItemNavigationComponent).toBeTruthy();
+  });
+
+  describe('Templates:', () => {
+
+    it('should contain two `po-navbar-item-navigation-icon` elements', () => {
+      const elements = nativeElement.querySelectorAll('po-navbar-item-navigation-icon');
+
+      expect(elements.length).toBe(2);
+
+      expect(elements[0].classList).toContain('po-navbar-item-navigation-icon');
+      expect(elements[1].classList).toContain('po-navbar-item-navigation-icon');
+    });
+
+  });
+
+});

--- a/projects/ui/src/lib/components/po-navbar/po-navbar-item-navigation/po-navbar-item-navigation.module.ts
+++ b/projects/ui/src/lib/components/po-navbar/po-navbar-item-navigation/po-navbar-item-navigation.module.ts
@@ -1,0 +1,21 @@
+import { CommonModule } from '@angular/common';
+import { NgModule } from '@angular/core';
+import { RouterModule } from '@angular/router';
+
+import { PoNavbarItemNavigationComponent } from './po-navbar-item-navigation.component';
+import { PoNavbarItemNavigationIconComponent } from './po-navbar-item-navigation-icon/po-navbar-item-navigation-icon.component';
+
+@NgModule({
+  imports: [
+    CommonModule,
+    RouterModule
+  ],
+  declarations: [
+    PoNavbarItemNavigationComponent,
+    PoNavbarItemNavigationIconComponent
+  ],
+  exports: [
+    PoNavbarItemNavigationComponent,
+  ]
+})
+export class PoNavbarItemNavigationModule { }

--- a/projects/ui/src/lib/components/po-navbar/po-navbar-items/po-navbar-item/po-navbar-item.component.html
+++ b/projects/ui/src/lib/components/po-navbar/po-navbar-items/po-navbar-item/po-navbar-item.component.html
@@ -11,6 +11,6 @@
     class="po-navbar-item-link"
     [class.po-clickable]="clickable"
     [routerLink]="link"
-    (click)="itemClick()">{{ label }}</a>
+    (click)="itemClick(label, link)">{{ label }}</a>
 
 </ng-container>

--- a/projects/ui/src/lib/components/po-navbar/po-navbar-items/po-navbar-item/po-navbar-item.component.spec.ts
+++ b/projects/ui/src/lib/components/po-navbar/po-navbar-items/po-navbar-item/po-navbar-item.component.spec.ts
@@ -1,0 +1,132 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { RouterModule } from '@angular/router';
+
+import { configureTestSuite } from 'projects/ui/src/lib/util-test/util-expect.spec';
+
+import { PoNavbarItemComponent } from './po-navbar-item.component';
+
+describe('PoNavbarItemComponent:', () => {
+  let component: PoNavbarItemComponent;
+  let fixture: ComponentFixture<PoNavbarItemComponent>;
+  let nativeElement: any;
+
+  configureTestSuite(() => {
+    TestBed.configureTestingModule({
+      declarations: [ PoNavbarItemComponent ],
+      imports: [ RouterModule.forRoot([]) ]
+    });
+  });
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(PoNavbarItemComponent);
+    component = fixture.componentInstance;
+
+    nativeElement = fixture.debugElement.nativeElement;
+
+    fixture.detectChanges();
+  });
+
+  it('should be created', () => {
+    expect(component instanceof PoNavbarItemComponent).toBeTruthy();
+  });
+
+  describe('Properties:', () => {
+
+    it('type: should return `externalLink` if link is external link', () => {
+      component.link = 'http://test.com';
+
+      expect(component.type).toBe('externalLink');
+    });
+
+    it('type: should return `internalLink` if link is internal link', () => {
+      component.link = 'test/';
+
+      expect(component.type).toBe('internalLink');
+    });
+
+  });
+
+  describe('Methods:', () => {
+
+    it('itemClick: should call `action` with `link` and `label` if `action` is defined', () => {
+      component.action = () => {};
+
+      const label = 'label test';
+      const link = 'test/';
+
+      spyOn(component, 'action');
+
+      component.itemClick(label, link);
+
+      expect(component.action).toHaveBeenCalledWith({ label, link });
+    });
+
+    it('itemClick: should call `click.emit`', () => {
+
+      spyOn(component.click, 'emit');
+
+      component.itemClick(undefined, undefined);
+
+      expect(component.click.emit).toHaveBeenCalled();
+    });
+
+  });
+
+  describe('Templates: ', () => {
+
+    it('should contain `a` element with href if `type` is `externalLink`', () => {
+      component.link = 'http://test.com';
+
+      fixture.detectChanges();
+
+      const anchor = nativeElement.querySelector('a');
+
+      expect(anchor.attributes.getNamedItem('href').name).toEqual('href');
+    });
+
+    it('should call `itemClick` without parameters if `type` is `externalLink`', () => {
+      component.link = 'http://test.com';
+
+      fixture.detectChanges();
+
+      spyOn(component, 'itemClick');
+
+      const eventClick = document.createEvent('MouseEvents');
+      eventClick.initEvent('click', false, true);
+
+      const anchor = nativeElement.querySelector('a');
+      anchor.dispatchEvent(eventClick);
+
+      expect(component.itemClick).toHaveBeenCalledWith();
+    });
+
+    it('should contain `a` element with `ng-reflect-router-link` if `type` is `internalLink`', () => {
+      component.link = 'test/';
+
+      fixture.detectChanges();
+
+      const anchor = nativeElement.querySelector('a');
+
+      expect(anchor.attributes.getNamedItem('ng-reflect-router-link').name).toEqual('ng-reflect-router-link');
+    });
+
+    it('should call `itemClick` with label and link if `type` is `internalLink`', () => {
+      component.link = 'test/';
+      component.label = 'label test';
+
+      fixture.detectChanges();
+
+      spyOn(component, 'itemClick');
+
+      const eventClick = document.createEvent('MouseEvents');
+      eventClick.initEvent('click', false, true);
+
+      const anchor = nativeElement.querySelector('a');
+      anchor.dispatchEvent(eventClick);
+
+      expect(component.itemClick).toHaveBeenCalledWith(component.label, component.link);
+    });
+
+  });
+
+});

--- a/projects/ui/src/lib/components/po-navbar/po-navbar-items/po-navbar-item/po-navbar-item.component.ts
+++ b/projects/ui/src/lib/components/po-navbar/po-navbar-items/po-navbar-item/po-navbar-item.component.ts
@@ -21,17 +21,13 @@ export class PoNavbarItemComponent {
   @Output('p-click') click: EventEmitter<PoNavbarItem> = new EventEmitter<PoNavbarItem>();
 
   get type() {
-    if (isExternalLink(this.link)) {
-      return 'externalLink';
-    }
-
-    return 'internalLink';
+    return isExternalLink(this.link) ? 'externalLink' : 'internalLink';
   }
 
-  itemClick() {
+  itemClick(label: string, link: string) {
 
     if (this.action) {
-      this.action({ label: this.label, link: this.link });
+      this.action({ label, link });
     }
 
     this.click.emit();

--- a/projects/ui/src/lib/components/po-navbar/po-navbar-items/po-navbar-items.component.spec.ts
+++ b/projects/ui/src/lib/components/po-navbar/po-navbar-items/po-navbar-items.component.spec.ts
@@ -1,0 +1,230 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { NavigationCancel, NavigationEnd, RouterModule } from '@angular/router';
+
+import { configureTestSuite } from 'projects/ui/src/lib/util-test/util-expect.spec';
+import { Subscription } from 'rxjs';
+
+import { PoNavbarItemComponent } from './po-navbar-item/po-navbar-item.component';
+import { PoNavbarItemsComponent } from './po-navbar-items.component';
+
+describe('PoNavbarItemsComponent:', () => {
+  let component: PoNavbarItemsComponent;
+  let fixture: ComponentFixture<PoNavbarItemsComponent>;
+  let nativeElement: any;
+
+  configureTestSuite(() => {
+    TestBed.configureTestingModule({
+      declarations: [ PoNavbarItemsComponent, PoNavbarItemComponent ],
+      imports: [ RouterModule.forRoot([]) ]
+    });
+  });
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(PoNavbarItemsComponent);
+    component = fixture.componentInstance;
+
+    nativeElement = fixture.debugElement.nativeElement;
+
+    fixture.detectChanges();
+  });
+
+  it('should be created', () => {
+    expect(component instanceof PoNavbarItemsComponent).toBeTruthy();
+  });
+
+  describe('Methods:', () => {
+
+    it('ngOnDestroy: should call `unsubscribe` of the `routeSubscription`', () => {
+      spyOn(component['routeSubscription'], 'unsubscribe');
+
+      component.ngOnDestroy();
+
+      expect(component['routeSubscription'].unsubscribe).toHaveBeenCalled();
+    });
+
+    it('ngOnInit: should call `subscribeToRoute`', () => {
+      spyOn(component, <any>'subscribeToRoute');
+
+      component.ngOnInit();
+
+      expect(component['subscribeToRoute']).toHaveBeenCalled();
+    });
+
+    it('selectItem: should set `selectedItem` with `item` parameter', () => {
+      const item = { label: 'home', link: 'home/' };
+      component.selectedItem = undefined;
+
+      component.selectItem(item);
+
+      expect(component.selectedItem).toEqual(item);
+    });
+
+    it('checkActiveItemByUrl: should set `selectedItem` with the route item', () => {
+      const urlItem = 'http://test3.com';
+      const selectedItem = { label: 'test 3', link: 'http://test3.com' };
+      component.selectedItem = undefined;
+
+      component.items = [
+        { label: 'test 1', link: 'http://test1.com' },
+        { label: 'test 2', link: 'http://test2.com' },
+        selectedItem,
+        { label: 'test 4', link: 'http://test4.com' },
+        { label: 'test 5', link: 'http://test5.com' }
+      ];
+
+      component['checkActiveItemByUrl'](urlItem);
+
+      expect(component.selectedItem).toEqual(selectedItem);
+    });
+
+    it('checkActiveItemByUrl: should set `selectedItem` with undefined if item url is not included in `items`', () => {
+      const urlItem = 'http://test6.com';
+      component.selectedItem = { label: 'test 3', link: 'http://test3.com' };
+
+      component.items = [
+        { label: 'test 1', link: 'http://test1.com' },
+        { label: 'test 2', link: 'http://test2.com' },
+        { label: 'test 3', link: 'http://test3.com' },
+        { label: 'test 4', link: 'http://test4.com' },
+        { label: 'test 5', link: 'http://test5.com' }
+      ];
+
+      component['checkActiveItemByUrl'](urlItem);
+
+      expect(component.selectedItem).toBeUndefined();
+    });
+
+    it('checkRouterChildrenFragments: should return url without params and `#`', () => {
+      spyOnProperty(component['router'], 'url').and.returnValue('test/label#fragment?param=1');
+
+      const result = component['checkRouterChildrenFragments']();
+
+      expect(result).toBe('/test/label');
+    });
+
+    it('checkRouterChildrenFragments: should return empty string if `url` is `undefined`', () => {
+      spyOnProperty(component['router'], 'url').and.returnValue(undefined);
+
+      const result = component['checkRouterChildrenFragments']();
+
+      expect(result).toBe('');
+    });
+
+    it('checkRouterChildrenFragments: should return same url', () => {
+      spyOnProperty(component['router'], 'url').and.returnValue('test/label');
+
+      const result2 = component['checkRouterChildrenFragments']();
+
+      expect(result2).toBe('/test/label');
+    });
+
+    it(`subscribeToRoute: should call checkActiveItemByUrl with url router if router events return an instance of NavigationEnd`, () => {
+      const navigation = new NavigationEnd(1, 'url/', undefined);
+
+      spyOn(component, <any>'checkRouterChildrenFragments').and.returnValue('test');
+      spyOn(component, <any>'checkActiveItemByUrl');
+
+      // Mock para poder entrar no subscribe
+      spyOn(component['router'].events, 'subscribe').and.callFake(callback => {
+        callback(navigation);
+        return new Subscription();
+      });
+
+      component['subscribeToRoute']();
+
+      expect(component['checkActiveItemByUrl']).toHaveBeenCalledWith('test');
+    });
+
+    it(`subscribeToRoute: should call checkActiveItemByUrl with url router if router events return an instance of NavigationCancel`, () => {
+      const navigation = new NavigationCancel(1, 'url/', undefined);
+
+      spyOn(component, <any>'checkRouterChildrenFragments').and.returnValue('test');
+      spyOn(component, <any>'checkActiveItemByUrl');
+
+      // Mock para poder entrar no subscribe
+      spyOn(component['router'].events, 'subscribe').and.callFake(callback => {
+        callback(navigation);
+        return new Subscription();
+      });
+
+      component['subscribeToRoute']();
+
+      expect(component['checkActiveItemByUrl']).toHaveBeenCalledWith('test');
+    });
+
+    it(`subscribeToRoute: shouldn't call checkActiveItemByUrl with url router if router events not return an instance of
+      NavigationCancel or NavigationEnd`, () => {
+
+      spyOn(component, <any>'checkRouterChildrenFragments').and.returnValue('test');
+      spyOn(component, <any>'checkActiveItemByUrl');
+
+      // Mock para poder entrar no subscribe
+      spyOn(component['router'].events, 'subscribe').and.callFake(callback => {
+        callback(undefined);
+        return new Subscription();
+      });
+
+      component['subscribeToRoute']();
+
+      expect(component['checkActiveItemByUrl']).not.toHaveBeenCalled();
+    });
+
+  });
+
+  describe('Templates:', () => {
+
+    it('should set `po-navbar-item-selected` class in active item', () => {
+      component.selectedItem = { label: 'test 3', link: 'http://test3.com' };
+
+      component.items = [
+        { label: 'test 1', link: 'http://test1.com' },
+        { label: 'test 2', link: 'http://test2.com' },
+        component.selectedItem,
+        { label: 'test 4', link: 'http://test4.com' },
+        { label: 'test 5', link: 'http://test5.com' }
+      ];
+
+      fixture.detectChanges();
+
+      const selectedItemLi = nativeElement.querySelector('.po-navbar-item-selected');
+      expect(selectedItemLi).toBeTruthy();
+
+      const selectedItem = selectedItemLi.querySelector('po-navbar-item');
+      expect(selectedItem.innerText).toBe('test 3');
+    });
+
+    it('should set `ng-reflect-clickable` with false if it is active element', () => {
+      component.selectedItem = { label: 'test 3', link: 'http://test3.com' };
+
+      component.items = [
+        { label: 'test 1', link: 'http://test1.com' },
+        { label: 'test 2', link: 'http://test2.com' },
+        component.selectedItem,
+        { label: 'test 4', link: 'http://test4.com' }
+      ];
+
+      fixture.detectChanges();
+
+      const selectedItemLi = nativeElement.querySelector('.po-navbar-item-selected');
+
+      const selectedItem = selectedItemLi.querySelector('po-navbar-item');
+      expect(selectedItem.getAttribute('ng-reflect-clickable')).toBe('false');
+    });
+
+    it('should set `ng-reflect-clickable` with true if it not is active element', () => {
+      component.selectedItem = undefined;
+
+      component.items = [
+        { label: 'test 1', link: 'http://test1.com' },
+        { label: 'test 2', link: 'http://test2.com' },
+        { label: 'test 4', link: 'http://test4.com' }
+      ];
+
+      fixture.detectChanges();
+
+      const selectedItem = nativeElement.querySelector('po-navbar-item');
+      expect(selectedItem.getAttribute('ng-reflect-clickable')).toBe('true');
+    });
+  });
+
+});

--- a/projects/ui/src/lib/components/po-navbar/po-navbar-logo/po-navbar-logo.component.spec.ts
+++ b/projects/ui/src/lib/components/po-navbar/po-navbar-logo/po-navbar-logo.component.spec.ts
@@ -1,0 +1,50 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { configureTestSuite } from '../../../util-test/util-expect.spec';
+
+import { PoNavbarLogoComponent } from './po-navbar-logo.component';
+
+describe('PoNavbarLogoComponent:', () => {
+  let component: PoNavbarLogoComponent;
+  let fixture: ComponentFixture<PoNavbarLogoComponent>;
+
+  configureTestSuite(() => {
+    TestBed.configureTestingModule({
+      declarations: [
+        PoNavbarLogoComponent
+      ]
+    });
+  });
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(PoNavbarLogoComponent);
+    component = fixture.componentInstance;
+
+    fixture.detectChanges();
+  });
+
+  it('should be created', () => {
+    expect(component instanceof PoNavbarLogoComponent).toBeTruthy();
+  });
+
+  describe('Templates:', () => {
+
+    it('should create tag img if `logo` has value', () => {
+      component.logo = 'http://lorempixel.com/200/200/';
+
+      fixture.detectChanges();
+
+      expect(fixture.debugElement.nativeElement.querySelector('.po-navbar-logo-image')).toBeTruthy();
+    });
+
+    it('shouldn`t create tag img if `logo` is undefined', () => {
+      component.logo = undefined;
+
+      fixture.detectChanges();
+
+      expect(fixture.debugElement.nativeElement.querySelector('.po-navbar-logo-image')).toBeNull();
+    });
+
+  });
+
+});

--- a/projects/ui/src/lib/components/po-navbar/po-navbar-logo/po-navbar-logo.component.ts
+++ b/projects/ui/src/lib/components/po-navbar/po-navbar-logo/po-navbar-logo.component.ts
@@ -5,7 +5,5 @@ import { Component, Input } from '@angular/core';
   templateUrl: './po-navbar-logo.component.html'
 })
 export class PoNavbarLogoComponent {
-
   @Input('p-logo') logo?: string;
-
 }

--- a/projects/ui/src/lib/components/po-navbar/po-navbar.component.html
+++ b/projects/ui/src/lib/components/po-navbar/po-navbar.component.html
@@ -3,6 +3,7 @@
 
   <po-navbar-logo
     class="po-navbar-logo"
+    [ngClass]="{'po-navbar-logo-menu' : !!menu, 'po-navbar-no-logo' : !logo }"
     [p-logo]="logo">
   </po-navbar-logo>
 
@@ -13,8 +14,8 @@
 
   <po-navbar-item-navigation *ngIf="showItemsNavigation"
     class="po-navbar-item-navigation"
-    [p-disable-left]="offset === 0"
-    [p-disable-right]="disableRight && offset !== 0"
+    [p-disable-left]="navbarItemNavigationDisableLeft"
+    [p-disable-right]="navbarItemNavigationDisableRight"
     (p-click)="navigateItems($event)">
   </po-navbar-item-navigation>
 

--- a/projects/ui/src/lib/components/po-navbar/po-navbar.component.spec.ts
+++ b/projects/ui/src/lib/components/po-navbar/po-navbar.component.spec.ts
@@ -1,0 +1,608 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { RouterModule } from '@angular/router';
+
+import { configureTestSuite } from 'projects/ui/src/lib/util-test/util-expect.spec';
+
+import { PoNavbarActionsModule } from './po-navbar-actions/po-navbar-actions.module';
+import { PoNavbarItemsModule } from './po-navbar-items/po-navbar-items.module';
+import { PoNavbarItemNavigationModule } from './po-navbar-item-navigation/po-navbar-item-navigation.module';
+import { PoMenuModule } from '../po-menu/po-menu.module';
+import { PoNavbarLogoComponent } from './po-navbar-logo/po-navbar-logo.component';
+import { PoNavbarComponent } from './po-navbar.component';
+import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
+import { changeBrowserInnerWidth } from 'projects/templates/src/lib/util-test/util-expect.spec';
+
+describe('PoNavbarComponent:', () => {
+  let component: PoNavbarComponent;
+  let fixture: ComponentFixture<PoNavbarComponent>;
+
+  configureTestSuite(() => {
+    TestBed.configureTestingModule({
+      declarations: [ PoNavbarComponent, PoNavbarLogoComponent ],
+      imports: [
+        BrowserAnimationsModule,
+        PoNavbarActionsModule,
+        PoNavbarItemsModule,
+        PoNavbarItemNavigationModule,
+        PoMenuModule,
+        RouterModule.forRoot([]) ]
+    });
+  });
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(PoNavbarComponent);
+    component = fixture.componentInstance;
+
+    fixture.detectChanges();
+  });
+
+  it('should be created', () => {
+    expect(component instanceof PoNavbarComponent).toBeTruthy();
+  });
+
+  describe('Properties:', () => {
+
+    it('navbarItemNavigationDisableLeft: should return true if offset is equal to 0`', () => {
+      component['offset'] = 0;
+
+      expect(component.navbarItemNavigationDisableLeft).toBe(true);
+    });
+
+    it('navbarItemNavigationDisableLeft: should return undefined if offset is different to 0`', () => {
+      component['offset'] = 10;
+
+      expect(component.navbarItemNavigationDisableLeft).toBe(false);
+    });
+
+    it('navbarItemNavigationDisableRight: should return true if disableRight is true and offset is different to 0`', () => {
+      component['offset'] = 10;
+      component.disableRight = true;
+
+      expect(component.navbarItemNavigationDisableRight).toBe(true);
+    });
+
+    it('navbarItemNavigationDisableRight: should return false if disableRight is false`', () => {
+      component.disableRight = false;
+
+      expect(component.navbarItemNavigationDisableRight).toBe(false);
+    });
+
+    it('navbarItemNavigationDisableRight: should return false if disableRight is true and offset is equal to 0`', () => {
+      component.disableRight = true;
+      component['offset'] = 0;
+
+      expect(component.navbarItemNavigationDisableRight).toBe(false);
+    });
+
+  });
+
+  describe('Methods:', () => {
+
+    describe('ngAfterViewInit', () => {
+
+      it('should call `displayItemsNavigation`', () => {
+        spyOn(component, <any>'displayItemsNavigation');
+
+        component.ngAfterViewInit();
+
+        expect(component['displayItemsNavigation']).toHaveBeenCalled();
+      });
+
+      it('should call `initNavbarMenu` if has `menu`', () => {
+        spyOn(component, <any>'initNavbarMenu');
+        component.menu = <any>{ menus: [] };
+
+        component.ngAfterViewInit();
+
+        expect(component['initNavbarMenu']).toHaveBeenCalled();
+      });
+
+      it('shouldn`t call `initNavbarMenu` if doesn`t have `menu`', () => {
+        spyOn(component, <any>'initNavbarMenu');
+        component.menu = undefined;
+
+        component.ngAfterViewInit();
+
+        expect(component['initNavbarMenu']).not.toHaveBeenCalled();
+      });
+    });
+
+    it('ngOnDestroy: should call `mediaQuery.removeListener` if has `mediaQuery` listener', () => {
+      component['mediaQuery'] = { removeListener : () => {} };
+
+      spyOn(component['mediaQuery'], 'removeListener');
+
+      component.ngOnDestroy();
+
+      expect(component['mediaQuery']['removeListener']).toHaveBeenCalled();
+    });
+
+    describe('navigateItems', () => {
+
+      it('should call `navigateLeft` if orientation is `left`', () => {
+        const orientation = 'left';
+
+        spyOn(component, <any>'navigateLeft');
+
+        component.navigateItems(orientation);
+
+        expect(component['navigateLeft']).toHaveBeenCalled();
+      });
+
+      it('should call `navigateRight` if orientation isn`t `left`', () => {
+        const orientation = 'right';
+
+        spyOn(component, <any>'navigateRight');
+
+        component.navigateItems(orientation);
+
+        expect(component['navigateRight']).toHaveBeenCalled();
+      });
+
+      it('should call `animate` with `offset`', () => {
+        const orientation = 'right';
+
+        spyOn(component, <any>'animate');
+
+        component.navigateItems(orientation);
+
+        expect(component['animate']).toHaveBeenCalledWith(component['offset']);
+      });
+    });
+
+    it(`allNavbarItemsWidth: should return the sum of the width of all items`, () => {
+      const fakeThis = {
+        navbarItems: {
+          allNavbarItems: [
+            {
+              nativeElement: {
+                offsetWidth: 10
+              }
+            }, {
+              nativeElement: {
+                offsetWidth: 25
+              }
+            },
+          ]
+        }
+      };
+
+      expect(component['allNavbarItemsWidth'].call(fakeThis)).toBe(35);
+    });
+
+    it(`animate: should call 'buildTransitionAnimation' with offset if has elements`, () => {
+      const offset = 400;
+
+      spyOn(component, <any>'buildTransitionAnimation').and.callThrough();
+
+      component['animate'](offset);
+
+      expect(component['buildTransitionAnimation']).toHaveBeenCalledWith(offset);
+    });
+
+    it(`buildTransitionAnimation: should call builder`, () => {
+      const offset = 400;
+
+      spyOn(component['builder'], 'build').and.callThrough();
+
+      component['buildTransitionAnimation'](offset);
+
+      expect(component['builder'].build).toHaveBeenCalled();
+    });
+
+    describe('changeNavbarMenuItems', () => {
+
+      it('should set `menus` with `menuItems` if `isCollapsedMedia` is `false`', () => {
+        const isCollapsedMedia = false;
+        const menuItems = [{ label: 'menu' }];
+
+        component.menu = <any>{ menus: [] };
+
+        component['changeNavbarMenuItems'](isCollapsedMedia, menuItems, [], '');
+
+        expect(component.menu.menus).toEqual(menuItems);
+      });
+
+      it('should set `menu.menus` with `navbarItems`, `menuItems` and label if `isCollapsedMedia` is `true`', () => {
+        const isCollapsedMedia = true;
+        const menuItems = [{ label: 'menu' }];
+        const navbarItems = [{ label: 'navbar' }];
+        const label = 'Navbar Links';
+
+        const expectedResult = [{ label, subItems: navbarItems }, ...menuItems];
+
+        component.menu = <any>{ menus: [] };
+
+        component['changeNavbarMenuItems'](isCollapsedMedia, menuItems, navbarItems, label);
+
+        expect(component.menu.menus).toEqual(expectedResult);
+      });
+    });
+
+    describe('calculateLeftNavigation', () => {
+
+      it('should return `undefined` if `offset` is greater than `navbarItemOffset`', () => {
+        const expectedResult = undefined;
+
+        component['offset'] = 1000;
+
+        const fakeNavbarItems = {
+          allNavbarItems: [
+            { nativeElement : { offsetLeft: 10, offsetWidth: 15 }}
+          ]
+        };
+
+        component.navbarItems = <any>fakeNavbarItems;
+
+        expect(component['calculateLeftNavigation']()).toBe(expectedResult);
+      });
+
+      it('should return calculated value if `offset` is less than `navbarItemOffset`', () => {
+        const expectedResult = -175;
+
+        component['offset'] = 5;
+
+        spyOn(component, <any>'navbarItemsWidth').and.returnValue(200);
+
+        const fakeNavbarItems = {
+          allNavbarItems: [
+            { nativeElement : { offsetLeft: 10, offsetWidth: 15 }}
+          ]
+        };
+
+        component.navbarItems = <any>fakeNavbarItems;
+
+        expect(component['calculateLeftNavigation']()).toBe(expectedResult);
+      });
+
+    });
+
+    describe('calculateRightNavigation', () => {
+
+      it('should return `undefined` if `itemBreakpoint` is greater than `finalPosition`', () => {
+        const expectedResult = undefined;
+        const fakeItemBreakpoint = 500;
+
+        const fakeNavbarItems = {
+          allNavbarItems: [
+            { nativeElement : { offsetLeft: 10, offsetWidth: 15 }}
+          ]
+        };
+
+        component.navbarItems = <any>fakeNavbarItems;
+
+        expect(component['calculateRightNavigation'](fakeItemBreakpoint)).toBe(expectedResult);
+      });
+
+      it('should return `offsetLeft` value if `itemBreakpoint` is less than `finalPosition`', () => {
+        const expectedResult = 10;
+        const fakeItemBreakpoint = 8;
+
+        const fakeNavbarItems = {
+          allNavbarItems: [
+            { nativeElement : { offsetLeft: 10, offsetWidth: 15 }}
+          ]
+        };
+
+        component.navbarItems = <any>fakeNavbarItems;
+
+        expect(component['calculateRightNavigation'](fakeItemBreakpoint)).toBe(expectedResult);
+      });
+
+    });
+
+    describe('displayItemsNavigation', () => {
+
+      it(`should set 'showItemsNavigation' to 'true' if 'navbarItemsWidth' is less than the sum of the 'allNavbarItemsWidth'
+      and 'poNavbarNavigationWidth' and call 'detectChanges'`, () => {
+        spyOn(component, <any>'navbarItemsWidth').and.returnValue(100);
+        spyOn(component, <any>'allNavbarItemsWidth').and.returnValue(120);
+        spyOn(component['changeDetector'], 'detectChanges');
+
+        component['displayItemsNavigation']();
+
+        expect(component['showItemsNavigation']).toBe(true);
+        expect(component['changeDetector'].detectChanges).toHaveBeenCalled();
+      });
+
+      it(`should set 'showItemsNavigation' to 'false' if 'navbarItemsWidth' is greater than the sum of the 'allNavbarItemsWidth'
+      and 'poNavbarNavigationWidth' and call 'detectChanges'`, () => {
+        spyOn(component, <any>'navbarItemsWidth').and.returnValue(500);
+        spyOn(component, <any>'allNavbarItemsWidth').and.returnValue(120);
+        spyOn(component['changeDetector'], 'detectChanges');
+
+        component['displayItemsNavigation']();
+
+        expect(component['showItemsNavigation']).toBe(false);
+        expect(component['changeDetector'].detectChanges).toHaveBeenCalled();
+      });
+
+      it(`should call 'setOffsetToZero' and 'animate' with offset value if offset is different to 0`, () => {
+        const offset = 100;
+        component['offset'] = offset;
+
+        spyOn(component, <any>'setOffsetToZero');
+        spyOn(component, <any>'animate');
+
+        component['displayItemsNavigation']();
+
+        expect(component['setOffsetToZero']).toHaveBeenCalled();
+        expect(component['animate']).toHaveBeenCalledWith(offset);
+      });
+
+      it(`shouldn't call setOffsetToZero and animate if offset is equal to 0`, () => {
+        component['offset'] = 0;
+
+        spyOn(component, <any>'setOffsetToZero');
+        spyOn(component, <any>'animate');
+
+        component['displayItemsNavigation']();
+
+        expect(component['setOffsetToZero']).not.toHaveBeenCalled();
+        expect(component['animate']).not.toHaveBeenCalled();
+      });
+
+    });
+
+    it(`initNavbarMenu: should call changeNavbarMenuItems if match in listener`, () => {
+      const fakeMediaQuery: any = {
+        addListener: (cb: any) => {
+          const matches = true;
+          cb({ matches });
+        },
+        removeListener: () => { }
+      };
+
+      component.menu = <any> { menus: [] };
+
+      spyOn(component, <any> 'changeNavbarMenuItems');
+      spyOn(window, 'matchMedia').and.returnValue(fakeMediaQuery);
+
+      component['initNavbarMenu']();
+
+      expect(component['changeNavbarMenuItems']).toHaveBeenCalled();
+    });
+
+    it(`initNavbarMenu: should call changeNavbarMenuItems if window.innerWidth is less than poNavbarMenuMedia`, () => {
+      component.menu = <any> { menus: [] };
+
+      spyOn(component, <any> 'changeNavbarMenuItems');
+
+      changeBrowserInnerWidth(700);
+
+      component['initNavbarMenu']();
+
+      expect(component['changeNavbarMenuItems']).toHaveBeenCalled();
+    });
+
+    it(`initNavbarMenu: shouldn't call changeNavbarMenuItems if window.innerWidth is greater than poNavbarMenuMedia`, () => {
+      component.menu = <any> { menus: [] };
+
+      spyOn(component, <any> 'changeNavbarMenuItems');
+
+      changeBrowserInnerWidth(1500);
+
+      component['initNavbarMenu']();
+
+      expect(component['changeNavbarMenuItems']).not.toHaveBeenCalled();
+    });
+
+    it(`navbarItemsWidth: should return navbar items width`, () => {
+      const itemsWidth = 50;
+      const fakeThis = {
+        navbarItemsElement: {
+          nativeElement: {
+            offsetWidth: itemsWidth
+          }
+        }
+      };
+
+      expect(component['navbarItemsWidth'].call(fakeThis)).toBe(itemsWidth);
+    });
+
+    describe('navigateLeft', () => {
+
+      it(`should set 'disableRight' to 'false' and call 'calculateLeftNavigation'`, () => {
+        component.disableRight = true;
+        spyOn(component, <any>'calculateLeftNavigation');
+
+        component['navigateLeft']();
+
+        expect(component.disableRight).toBe(false);
+        expect(component['calculateLeftNavigation']).toHaveBeenCalled();
+      });
+
+      it(`should call 'setOffsetToZero' if 'offset' is less than 0`, () => {
+        spyOn(component, <any>'calculateLeftNavigation').and.returnValue(-50);
+        spyOn(component, <any>'setOffsetToZero');
+
+        component['navigateLeft']();
+
+        expect(component['setOffsetToZero']).toHaveBeenCalled();
+      });
+
+      it(`shouldn't call 'setOffsetToZero' if 'offset' is equal 0`, () => {
+        spyOn(component, <any>'calculateLeftNavigation').and.returnValue(0);
+        spyOn(component, <any>'setOffsetToZero');
+
+        component['navigateLeft']();
+
+        expect(component['setOffsetToZero']).not.toHaveBeenCalled();
+      });
+
+      it(`shouldn't call 'setOffsetToZero' if 'offset' is greater than 0`, () => {
+        spyOn(component, <any>'calculateLeftNavigation').and.returnValue(100);
+        spyOn(component, <any>'setOffsetToZero');
+
+        component['navigateLeft']();
+
+        expect(component['setOffsetToZero']).not.toHaveBeenCalled();
+      });
+
+    });
+
+    describe('navigateRight', () => {
+
+      it(`should call 'calculateRightNavigation' with 'itemBreakPoint'`, () => {
+        const fakeOffset = 100;
+        const fakeNavbarItemsWidth = 50;
+        const fakeItemBreakpoint = fakeOffset + fakeNavbarItemsWidth;
+
+        component['offset'] = fakeOffset;
+        spyOn(component, <any>'navbarItemsWidth').and.returnValue(fakeNavbarItemsWidth);
+        spyOn(component, <any>'calculateRightNavigation');
+
+        component['navigateRight']();
+
+        expect(component['calculateRightNavigation']).toHaveBeenCalledWith(fakeItemBreakpoint);
+      });
+
+      it(`should call 'validateMaxOffset' with 'maxAllowedOffset'`, () => {
+        const fakeNavbarItemsWidth = 50;
+        const fakeAllNavbarItemsWidth = 100;
+        const fakeMaxAllowedOffset = fakeAllNavbarItemsWidth - fakeNavbarItemsWidth;
+
+        spyOn(component, <any>'navbarItemsWidth').and.returnValue(fakeNavbarItemsWidth);
+        spyOn(component, <any>'allNavbarItemsWidth').and.returnValue(fakeAllNavbarItemsWidth);
+        spyOn(component, <any>'validateMaxOffset');
+
+        component['navigateRight']();
+
+        expect(component['validateMaxOffset']).toHaveBeenCalledWith(fakeMaxAllowedOffset);
+      });
+
+    });
+
+    it(`onMediaQueryChange: should call 'changeNavbarMenuItems'`, () => {
+      component.menu = <any>{ menus: [] };
+      spyOn(component, <any>'changeNavbarMenuItems');
+
+      component['onMediaQueryChange']({changed: false});
+
+      expect(component['changeNavbarMenuItems']).toHaveBeenCalled();
+    });
+
+    it(`setOffsetToZero: should set 'offset' to 0`, () => {
+      component['offset'] = 100;
+
+      component['setOffsetToZero']();
+
+      expect(component['offset']).toBe(0);
+    });
+
+    describe('validateMaxOffset', () => {
+
+      it(`should set 'offset' with 'maxAllowedOffset' value and set 'disableRight' to 'true' if 'offset' is greater than
+      'maxAllowedOffset'`, () => {
+        const maxAllowedOffset = 20;
+        component['offset'] = 50;
+        component.disableRight = false;
+
+        component['validateMaxOffset'](maxAllowedOffset);
+
+        expect(component['offset']).toBe(maxAllowedOffset);
+        expect(component.disableRight).toBe(true);
+      });
+
+      it(`should set 'offset' with 'maxAllowedOffset' value and set 'disableRight' to 'true' if 'offset' is equal to
+      'maxAllowedOffset'`, () => {
+        const maxAllowedOffset = 20;
+        component['offset'] = maxAllowedOffset;
+        component.disableRight = false;
+
+        component['validateMaxOffset'](maxAllowedOffset);
+
+        expect(component['offset']).toBe(maxAllowedOffset);
+        expect(component.disableRight).toBe(true);
+      });
+
+      it(`shouldn't set 'offset' with 'maxAllowedOffset' value and not set 'disableRight' to 'true' if 'offset' is less than
+      'maxAllowedOffset'`, () => {
+        const maxAllowedOffset = 50;
+        component['offset'] = 20;
+        component.disableRight = false;
+
+        component['validateMaxOffset'](maxAllowedOffset);
+
+        expect(component['offset']).toBe(20);
+        expect(component.disableRight).toBe(false);
+      });
+
+    });
+
+  });
+
+  describe('Template:', () => {
+    let nativeElement: any;
+
+    beforeEach(() => {
+      nativeElement = fixture.debugElement.nativeElement;
+    });
+
+    it(`should apply class 'po-navbar-shadow' if 'shadow' is true`, () => {
+      component.shadow = true;
+
+      fixture.detectChanges();
+
+      expect(nativeElement.querySelector('.po-navbar-shadow')).toBeTruthy();
+    });
+
+    it(`shouldn't apply class 'po-navbar-shadow' if 'shadow' is false`, () => {
+      component.shadow = false;
+
+      fixture.detectChanges();
+
+      expect(nativeElement.querySelector('.po-navbar-shadow')).toBeNull();
+    });
+
+    it(`should apply class 'po-navbar-logo-menu' if have menu`, () => {
+      component.menu = <any> [{ label: 'Item 1' }];
+
+      fixture.detectChanges();
+
+      expect(nativeElement.querySelector('.po-navbar-logo-menu')).toBeTruthy();
+    });
+
+    it(`shouldn't apply class 'po-navbar-logo-menu' if menu is undefined`, () => {
+      component.menu = undefined;
+
+      fixture.detectChanges();
+
+      expect(nativeElement.querySelector('.po-navbar-logo-menu')).toBeNull();
+    });
+
+    it(`should create 'po-navbar-item-navigation' if 'showItemsNavigation' is true`, () => {
+      component.showItemsNavigation = true;
+
+      fixture.detectChanges();
+
+      expect(nativeElement.querySelector('.po-navbar-item-navigation')).toBeTruthy();
+    });
+
+    it(`shouldn't create 'po-navbar-item-navigation' if 'showItemsNavigation' is false`, () => {
+      component.showItemsNavigation = false;
+
+      fixture.detectChanges();
+
+      expect(nativeElement.querySelector('.po-navbar-item-navigation')).toBeNull();
+    });
+
+    it(`should create 'po-menu' if menu is undefined`, () => {
+      component.menu = undefined;
+
+      fixture.detectChanges();
+
+      expect(nativeElement.querySelector('po-menu')).toBeTruthy();
+    });
+
+    it(`shouldn't create 'po-menu' if has menu`, () => {
+      component.menu = <any> [{ label: 'Item 1' }];
+
+      fixture.detectChanges();
+
+      expect(nativeElement.querySelector('po-menu')).toBeNull();
+    });
+
+  });
+
+});

--- a/projects/ui/src/lib/components/po-navbar/po-navbar.module.ts
+++ b/projects/ui/src/lib/components/po-navbar/po-navbar.module.ts
@@ -5,19 +5,50 @@ import { PoMenuModule } from '../po-menu/po-menu.module';
 import { PoNavbarActionsModule } from './po-navbar-actions/po-navbar-actions.module';
 import { PoNavbarComponent } from './po-navbar.component';
 import { PoNavbarItemsModule } from './po-navbar-items/po-navbar-items.module';
-import { PoNavbarItemNavigationComponent } from './po-navbar-item-navigation/po-navbar-item-navigation.component';
 import { PoNavbarLogoComponent } from './po-navbar-logo/po-navbar-logo.component';
+import { PoNavbarItemNavigationModule } from './po-navbar-item-navigation/po-navbar-item-navigation.module';
 
+/**
+ * @description
+ *
+ * Módulo do componente `po-navbar`.
+ *
+ * > Para o correto funcionamento do componente `po-navbar`, deve ser importado o módulo `BrowserAnimationsModule` no
+ * > módulo principal da sua aplicação.
+ *
+ * Módulo da aplicação:
+ * ```
+ * import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
+ * import { PoModule } from '@portinari/portinari-ui';
+ * ...
+ *
+ * @NgModule({
+ *   imports: [
+ *     BrowserModule,
+ *     BrowserAnimationsModule,
+ *     ...
+ *     PoModule
+ *   ],
+ *   declarations: [
+ *     AppComponent,
+ *     ...
+ *   ],
+ *   providers: [],
+ *   bootstrap: [AppComponent]
+ * })
+ * export class AppModule { }
+ * ```
+ */
 @NgModule({
   imports: [
     CommonModule,
     PoNavbarActionsModule,
     PoNavbarItemsModule,
+    PoNavbarItemNavigationModule,
     PoMenuModule
   ],
   declarations: [
     PoNavbarComponent,
-    PoNavbarItemNavigationComponent,
     PoNavbarLogoComponent
   ],
   exports: [


### PR DESCRIPTION
**PO NAVBAR**

**DTHFUI-1065**
_____________________________________________________________________________

**PR Checklist**

- [x] Código
- [x] Testes unitários
- [x] Documentação
- [ ] Samples

**Qual o comportamento atual?**
Não haviam testes unitários e o código precisava de melhorias.

**Qual o novo comportamento?**
A logo do navbar está com espaçamento correto, refactor do código e testes unitários adicionados.

**Simulação**

Utilizar a [PR do repositório style](https://github.com/portinariui/portinari-style/pull/5)

Validar diversas situações do navbar:

- com menu do usuário
- sem menu do usuário
- abrindo mobile e depois crescendo
- abrindo grande e depois entrando em mobile
- varios itens da navbar (navegação)
- sem logo
- com logo

- quando tem menu de usuário em telas menores que 768px:
deve criar um subItem de menu chamado "navbar links" no menu do usuário

** Lembrando que a classe po-wrapper é para uso do po-menu com o po-page, sem menu utilizamos o page normalmente