### PR TITLE
fix(table): corrige a exibição do botão de visualizar legenda

### DIFF
--- a/projects/ui/src/lib/components/po-table/po-table-subtitle-footer/po-table-subtitle-footer.component.spec.ts
+++ b/projects/ui/src/lib/components/po-table/po-table-subtitle-footer/po-table-subtitle-footer.component.spec.ts
@@ -61,6 +61,43 @@ describe('PoTableSubtitleFooterComponent:', () => {
       expect(component['removeResizeListener']).toHaveBeenCalled();
     });
 
+    describe('ngDoCheck', () => {
+
+      it(`should call 'toggleShowCompleteSubtitle' and set 'isVisible' to 'true' if 'getContainerSize' returns a value greater than 0
+      and 'isVisible' is  'false'`, () => {
+        component['isVisible'] = false;
+
+        spyOn(component, <any>'getContainerSize').and.returnValue(100);
+        spyOn(component, <any>'toggleShowCompleteSubtitle');
+
+        component.ngDoCheck();
+
+        expect(component['toggleShowCompleteSubtitle']).toHaveBeenCalled();
+        expect(component['isVisible']).toBe(true);
+      });
+
+      it('shouldn`t call `toggleShowCompleteSubtitle` if `isVisible` is `true`', () => {
+        component['isVisible'] = true;
+
+        spyOn(component, <any>'toggleShowCompleteSubtitle');
+
+        component.ngDoCheck();
+
+        expect(component['toggleShowCompleteSubtitle']).not.toHaveBeenCalled();
+      });
+
+      it('shouldn`t call `toggleShowCompleteSubtitle` if `getContainerSize` returns 0', () => {
+        component['isVisible'] = false;
+
+        spyOn(component, <any>'getContainerSize').and.returnValue(0);
+        spyOn(component, <any>'toggleShowCompleteSubtitle');
+
+        component.ngDoCheck();
+
+        expect(component['toggleShowCompleteSubtitle']).not.toHaveBeenCalled();
+      });
+    });
+
     // Teste com problemas intermitentes
     // Uncaught Error: macroTask 'setTimeout': can not transition to 'running', expecting state 'scheduled', was 'notScheduled'.
     // O problema pode estar associada a forma que o componente e está estruturado e o uso do setTimeout.

--- a/projects/ui/src/lib/components/po-table/po-table-subtitle-footer/po-table-subtitle-footer.component.ts
+++ b/projects/ui/src/lib/components/po-table/po-table-subtitle-footer/po-table-subtitle-footer.component.ts
@@ -1,4 +1,4 @@
-import { AfterViewInit, Component, ElementRef, Input, OnDestroy, Renderer2 } from '@angular/core';
+import { AfterViewInit, Component, DoCheck, ElementRef, Input, OnDestroy, Renderer2 } from '@angular/core';
 
 import { PoTableSubtitleColumn } from './po-table-subtitle-column.interface';
 
@@ -13,10 +13,11 @@ import { PoTableSubtitleColumn } from './po-table-subtitle-column.interface';
   selector: 'po-table-subtitle-footer',
   templateUrl: './po-table-subtitle-footer.component.html'
 })
-export class PoTableSubtitleFooterComponent implements AfterViewInit, OnDestroy {
+export class PoTableSubtitleFooterComponent implements AfterViewInit, DoCheck, OnDestroy {
 
   showSubtitle: boolean;
 
+  private isVisible: boolean;
   private timeoutResize;
   protected resizeListener: () => void;
 
@@ -31,6 +32,15 @@ export class PoTableSubtitleFooterComponent implements AfterViewInit, OnDestroy 
   ngAfterViewInit() {
     this.initializeResizeListener();
     this.debounceResize();
+  }
+
+  ngDoCheck() {
+
+    if (!this.isVisible && this.getContainerSize() > 0) {
+      this.toggleShowCompleteSubtitle();
+      this.isVisible = true;
+    }
+
   }
 
   ngOnDestroy() {

--- a/projects/ui/src/lib/components/po-table/samples/sample-po-table-airfare/sample-po-table-airfare.component.ts
+++ b/projects/ui/src/lib/components/po-table/samples/sample-po-table-airfare/sample-po-table-airfare.component.ts
@@ -14,7 +14,7 @@ import { SamplePoTableAirfareService } from './sample-po-table-airfare.service';
 @Component({
   selector: 'sample-po-table-airfare',
   templateUrl: './sample-po-table-airfare.component.html',
-  providers: [ SamplePoTableAirfareService ]
+  providers: [ SamplePoTableAirfareService, PoDialogService ]
 })
 export class SamplePoTableAirfareComponent {
 


### PR DESCRIPTION
**PO TABLE**

**DTHFUI-864**
_____________________________________________________________________________

**PR Checklist**

- [x] Código
- [x] Testes unitários
- [ ] Documentação
- [ ] Samples

**Qual o comportamento atual?**
Quando utilizado dentro de um po-tab o botão `visualizar legenda` sempre ficava visível e quando dava resize ele desaparecia.

**Qual o novo comportamento?**
Apenas fica visível quando necessário (se não houver espaço para os itens)

**Simulação**
Utilizar o sample `thf-table-airfare` dentro de um po-tab, validar também o funcionamento fora do tab para validar se nada aconteceu.

Exemplo de código:
```
<po-tabs>
  <po-tab p-label="Totvs Tabs 1">
    <sample-po-table-airfare></sample-po-table-airfare>
  </po-tab>
</po-tabs>

```