### PR TITLE
test(page-blocked-user-contacts): remove o x do describe

### DIFF
--- a/projects/templates/src/lib/components/po-page-blocked-user/po-page-blocked-user-contacts/po-page-blocked-user-contacts.component.spec.ts
+++ b/projects/templates/src/lib/components/po-page-blocked-user/po-page-blocked-user-contacts/po-page-blocked-user-contacts.component.spec.ts
@@ -8,7 +8,7 @@ import { PoPageBlockedUserContactsComponent } from './po-page-blocked-user-conta
 
 import { configureTestSuite } from '../../../util-test/util-expect.spec';
 
-xdescribe('PoPageBlockedUserContactsComponent: ', () => {
+describe('PoPageBlockedUserContactsComponent: ', () => {
   let component: PoPageBlockedUserContactsComponent;
   let fixture: ComponentFixture<PoPageBlockedUserContactsComponent>;
   let debugElement;


### PR DESCRIPTION
**PO PAGE BLOCKED USER CONTACTS**

**DTHFUI-1129**
_____________________________________________________________________________

**PR Checklist**

- [ ] Código
- [x] Testes unitários
- [ ] Documentação
- [ ] Samples

**Qual o comportamento atual?**
Os testes do componente estavam quebrando por causa de um setTimeout e por isso os testes estavam sendo pulados.

**Qual o novo comportamento?**
Foi verificado que os testes não estão mais quebrando, por isso foi retirado o "x" dos testes unitários.

**Simulação**
Executar os comandos de testes várias vezes e em  diferentes sistemas operacionais.