### PR TITLE
fix(table): corrige sobreposição do popup em dispositivos mobile iOS

### DIFF
--- a/projects/ui/src/lib/components/po-table/po-table.component.html
+++ b/projects/ui/src/lib/components/po-table/po-table.component.html
@@ -136,7 +136,7 @@
           [class.po-table-column-icons]="column.type === 'icon'"
           [ngClass]="getClassColor(row, column)"
           (click)="checkbox ? selectRow(row) : 'javascript:;'">
-          <div 
+          <div
             class="po-table-column-cell"
             [class.po-table-body-ellipsis]="hideTextOverflow"
             [ngSwitch]="column.type"
@@ -213,10 +213,9 @@
       </tr>
     </tbody>
   </table>
-
-  <po-popup #popup
-    [p-actions]="actions"
-    [p-target]="popupTarget">
-  </po-popup>
-
 </ng-template>
+
+<po-popup #popup
+  [p-actions]="actions"
+  [p-target]="popupTarget">
+</po-popup>


### PR DESCRIPTION
**PO-TABLE**

**DTHFUI-1221**
_____________________________________________________________________________

**PR Checklist**

- [x] Código
- [ ] Testes unitários
- [ ] Documentação
- [ ] Samples

**Qual o comportamento atual?**
O clicar na action da linha da table, o menu abre por baixo da borda da tabela no iPad.

**Qual o novo comportamento?**
Alterada a hierarquia do componente de popup para que o mesmo fique acima do componente de tabela quando for aberto.

**Simulação**
Executar sample labs, incluir um 2~3 itens e definir o `Actions`, clicar nas _actions_ do item da tabela e verificar sobreposição.