### PR TITLE
fix(modal): corrige fechamento da modal ao selecionar uma opção no combo

### DIFF
--- a/projects/ui/src/lib/components/po-field/po-combo/po-combo.component.html
+++ b/projects/ui/src/lib/components/po-field/po-combo/po-combo.component.html
@@ -58,7 +58,7 @@
   <ul #contentElement class="po-combo-container-content">
     <li *ngFor="let option of visibleOptions"
       [class.po-combo-item-selected]="compareObjects(selectedView, option)"
-      (click)="onOptionClick(option)">
+      (click)="onOptionClick(option, $event)">
       <a class="po-combo-item" [innerHTML]="getLabelFormatted(option?.label)"></a>
     </li>
   </ul>

--- a/projects/ui/src/lib/components/po-field/po-combo/po-combo.component.spec.ts
+++ b/projects/ui/src/lib/components/po-field/po-combo/po-combo.component.spec.ts
@@ -466,6 +466,14 @@ describe('PoComboComponent:', () => {
 
   describe('Methods:', () => {
 
+    const fakeEvent = {
+      target: {
+        value: 'ab'
+      },
+      preventDefault: () => {},
+      stopPropagation: () => {}
+    };
+
     describe('onKeyUp:', () => {
 
       function fakeKeypressEvent(code: number, target: any = 1) {
@@ -682,13 +690,6 @@ describe('PoComboComponent:', () => {
     });
 
     describe('onKeyDown: ', () => {
-      const fakeEvent = {
-        target: {
-          value: 'ab'
-        },
-        preventDefault: () => {},
-        stopPropagation: () => {}
-      };
 
       it('should call `selectPreviousOption` and not call `selectNextOption`', () => {
         component.comboOpen = true;
@@ -911,6 +912,26 @@ describe('PoComboComponent:', () => {
         expect(spyControlComboVisibility).toHaveBeenCalledWith(true);
       });
 
+    });
+
+    it('onOptionClick: should call `stopPropagation` if has an event parameter', () => {
+      const option: PoComboOption = { value: 'value', label: 'label' };
+
+      spyOn(fakeEvent, 'stopPropagation');
+
+      component.onOptionClick(option, fakeEvent);
+
+      expect(fakeEvent.stopPropagation).toHaveBeenCalled();
+    });
+
+    it('onOptionClick: shouldn`t call `stopPropagation` if doesn`t have an event parameter', () => {
+      const option: PoComboOption = { value: 'value', label: 'label' };
+
+      spyOn(fakeEvent, 'stopPropagation');
+
+      component.onOptionClick(option);
+
+      expect(fakeEvent.stopPropagation).not.toHaveBeenCalled();
     });
 
     it('onOptionClick: should call `updateSelectedValue` and `updateComboList` when `option.value` different than `selectedValue`', () => {

--- a/projects/ui/src/lib/components/po-field/po-combo/po-combo.component.ts
+++ b/projects/ui/src/lib/components/po-field/po-combo/po-combo.component.ts
@@ -395,9 +395,13 @@ export class PoComboComponent extends PoComboBaseComponent implements DoCheck, O
     toOpen ? this.open() : this.close();
   }
 
-  onOptionClick(option: PoComboOption) {
+  onOptionClick(option: PoComboOption, event?: any) {
     const inputValue = this.getInputValue();
     const isUpdateModel = (option.value !== this.selectedValue) || !!(this.selectedView && inputValue !== this.selectedView.label);
+
+    if (event) {
+      event.stopPropagation();
+    }
 
     this.updateSelectedValue(option, isUpdateModel);
     this.controlComboVisibility(false);

--- a/projects/ui/src/lib/components/po-modal/po-modal.component.html
+++ b/projects/ui/src/lib/components/po-modal/po-modal.component.html
@@ -4,7 +4,7 @@
   (keydown.esc)="closeModalOnEscapeKey($event)">
 
   <div class="po-modal-overlay">
-    <div class="po-modal-container po-pb-2 po-pt-2" (click)="onClickOut($event)">
+    <div class="po-modal-container po-pb-2 po-pt-2" (mousedown)="onClickOut($event)">
 
       <div class="po-modal-vertical-align">
         <div #modalContent

--- a/projects/ui/src/lib/components/po-modal/po-modal.component.spec.ts
+++ b/projects/ui/src/lib/components/po-modal/po-modal.component.spec.ts
@@ -507,6 +507,19 @@ describe('PoModalComponent:', () => {
       expect(getModalActionDisabled()).toBeTruthy();
       expect(getModalActionIconLoading()).toBeTruthy();
     });
+
+    it('should call `onClickOut` on mousedown', () => {
+      component.open();
+      fixture.detectChanges();
+
+      const containerElement = fixture.debugElement.query(By.css('.po-modal-container')).nativeElement;
+
+      spyOn(component, 'onClickOut');
+
+      containerElement.dispatchEvent(new Event('mousedown'));
+
+      expect(component.onClickOut).toHaveBeenCalled();
+    });
   });
 
 });


### PR DESCRIPTION
**PO-COMBO**

**DTHFUI-1421**
_____________________________________________________________________________

**PR Checklist**

- [X] Código
- [X] Testes unitários
- [ ] Documentação
- [ ] Samples

**Qual o comportamento atual?**
Quando habilita a propriedade t-click-out na modal e tem um combo dentro, ao selecionar uma opção no combo a modal fecha automaticamente.

**Qual o novo comportamento?**
Ao selecionar um item no combo, não deve fechar a modal, a mesma deverá permanecer aberta até que o usuário feche clicando nas ações ou utilizando o click-out.

**Simulação**
Abaixo como reproduzir.

````
<po-button
  p-label="Open modal"
  (p-click)="modal.open()">
</po-button>

<po-modal #modal
  p-title="Totvs Modal"
  [p-click-out]="true">
  <po-combo
    name="combo"
    p-label="Totvs Combo"
    [p-options]="[{ value: 'Option 1' }, { value: 'Option 2' }]">
  </po-combo>
</po-modal>
````

OBS.: Conforme solicitação comentada na tarefa, foram efetuados testes com `po-select` e `po-multiselect` e ambos comportam-se normalmente dentro de uma modal.