### PR TITLE
fix(app): corrige os erros ao utilizar os samples

### DIFF
--- a/angular.json
+++ b/angular.json
@@ -107,7 +107,12 @@
           "options": {
             "browserTarget": "app:build",
             "open": true,
-            "host": "0.0.0.0"
+            "host": "0.0.0.0",
+            "sourceMap": {
+              "scripts": true,
+              "styles": true,
+              "vendor": true
+            }
           },
           "configurations": {
             "production": {

--- a/projects/app/src/app/app.module.ts
+++ b/projects/app/src/app/app.module.ts
@@ -3,7 +3,7 @@ import { FormsModule } from '@angular/forms';
 import { NgModule } from '@angular/core';
 import { RouterModule } from '@angular/router';
 
-import { PoModule } from './../../../ui/src/public-api';
+import { PoModule } from '@portinari/portinari-ui';
 
 import { AppComponent } from './app.component';
 


### PR DESCRIPTION
**APP COMPONENT**

**DTHFUI-1290**
_____________________________________________________________________________

**PR Checklist**

- [x] Código
- [ ] Testes unitários
- [ ] Documentação
- [ ] Samples

**Qual o comportamento atual?**
Ao utilizar o repositório do portinari para executar os samples, ele não consegue encontrar os códigos fontes utilizando `@portinari/portinari-ui`, por exemplo.

Para conseguir utilizar, está sendo necessário alterar de `@portinari/portinari-ui ` para colocar o caminho relativo.

Outro problema que acontece é que em alguns componentes, não estava sendo encontrado os componentes internos. Por exemplo, ao utilizar o sample do ` po-button`, ele não conseguia encontrar o loading e acabava gerando erro no console.

**Qual o novo comportamento?**
O que estava gerando estes erros era a forma como o módulo estava sendo importado no `app.component.
`
Segundo as instruções do angular, a forma correta é utilizar o caminho da biblioteca que será gerada no build(dist).

Com esta nova arquitetura de libs, quando utilizamos no `app.component` o `@portinari/portinari-angular`, ele não consegue fazer o _livereload_ das libs quando elas são modificadas. Para poder fazer esta atualização, o angular disponibiliza o comando:

`ng build <library> --watch`

Por exemplo:
`ng build ui --watch`

que deve ser executado durante a criação/modificação da biblioteca. Podendo ser executada em paralelo com o comando `ng serve`.

**Simulação**
1) Baixar a branch
2) Colocar os samples no app.module e executar os comandos `ng build ui --watch` e `ng serve`
3) Fazer modificações nos componentes e nos samples e ver se as mudanças estão sendo refletidas
4) Testar em outros sistemas operacionais
5) Fazer o `npm run build` e colocar em um projeto para ver se os componentes continuam funcionando normalmente.

**Referências:**

Como criar e usar libs e como usar o watch:
https://angular.io/guide/creating-libraries

Utilizar o vendor:
https://stackoverflow.com/questions/42141313/having-source-code-for-third-party-javascript-libraries-available-whilst-debuggi

Não indica usar o caminho que não é o dist:
https://stackoverflow.com/questions/50775520/how-do-you-debug-an-angular-6-library/51115775

Como usar o sourceMap:
https://stackoverflow.com/questions/55690465/vendorsourcemap-deprecated-in-angular-cli-7-2
