### PR TITLE
fix(build): corrige erros de compilação com --prod

### DIFF
--- a/projects/templates/src/lib/components/po-modal-password-recovery/po-modal-password-recovery-base.component.ts
+++ b/projects/templates/src/lib/components/po-modal-password-recovery/po-modal-password-recovery-base.component.ts
@@ -76,7 +76,7 @@ export abstract class PoModalPasswordRecoveryBaseComponent {
     emailSentConfirmationPhrase: string, emailSentTitle: string, forgotPasswordTitle: string,
     insertCode: string, insertEmail: string, insertPhone: string, phoneErrorMessagePhrase: string,
     prepositionIn: string, prepositionOr: string, recoveryPasswordPhrase: string, resendEmailButton: string,
-    resendSmsCodePhrase: string, sendAgain: string, sendButton: string, sms: string, smsCode: string,
+    resendSmsCodePhrase: string, sendAgain: string, sendAgainPhrase: string, sendButton: string, sms: string, smsCode: string,
     smsCodeErrorMessagePhrase: string, sentSmsCodePhrase: string, supportContact: string, telephone: string, typeCodeTitle: string } =
     {
       ...poModalPasswordRecoveryLiterals[poLocaleDefault],

--- a/projects/templates/src/lib/components/po-modal-password-recovery/po-modal-password-recovery.component.spec.ts
+++ b/projects/templates/src/lib/components/po-modal-password-recovery/po-modal-password-recovery.component.spec.ts
@@ -994,9 +994,7 @@ describe('PoModalPasswordRecoveryComponent:', () => {
     });
 
     it('should show `email/sms` fields content if modalType value is `Email`', () => {
-      component.emailModalPhrases = {
-        firstPhrase: 'Phrase'
-      };
+      component.emailModalPhrases.firstPhrase = 'Phrase';
       component.modalType = PoModalPasswordRecoveryModalContent.Email;
       component.type = PoModalPasswordRecoveryType.All;
 
@@ -1005,15 +1003,14 @@ describe('PoModalPasswordRecoveryComponent:', () => {
 
       const expectedContent = fixture.debugElement.query(By.css('.po-modal-password-recovery-text')).nativeElement;
 
-      expect(expectedContent.innerHTML).toContain(component.emailModalPhrases['firstPhrase']);
+      expect(expectedContent.innerHTML).toContain(component.emailModalPhrases.firstPhrase);
       expect(expectedContent.innerHTML).not.toContain(component.literals.sentSmsCodePhrase);
       expect(expectedContent.innerHTML).not.toContain(component.literals.emailSentConfirmationPhrase);
     });
 
     it('should show `smsCode` field content if modalType value is `SMSCode`', () => {
-      component.emailModalPhrases = {
-        firstPhrase: 'Phrase'
-      };
+      component.emailModalPhrases.firstPhrase = 'Phrase';
+
       component.modalType = PoModalPasswordRecoveryModalContent.SMSCode;
       component.type = PoModalPasswordRecoveryType.Email;
 
@@ -1023,14 +1020,12 @@ describe('PoModalPasswordRecoveryComponent:', () => {
       const expectedContent = fixture.debugElement.query(By.css('.po-modal-password-recovery-text')).nativeElement;
 
       expect(expectedContent.innerHTML).toContain(component.literals.sentSmsCodePhrase);
-      expect(expectedContent.innerHTML).not.toContain(component.emailModalPhrases['firstPhrase']);
+      expect(expectedContent.innerHTML).not.toContain(component.emailModalPhrases.firstPhrase);
       expect(expectedContent.innerHTML).not.toContain(component.literals.emailSentConfirmationPhrase);
     });
 
     it('should show `smsCode` field content if modalType value is `Confirmation`', () => {
-      component.emailModalPhrases = {
-        firstPhrase: 'Phrase'
-      };
+      component.emailModalPhrases.firstPhrase = 'Phrase';
       component.modalType = PoModalPasswordRecoveryModalContent.Confirmation;
       component.type = PoModalPasswordRecoveryType.Email;
 
@@ -1041,7 +1036,7 @@ describe('PoModalPasswordRecoveryComponent:', () => {
 
       expect(expectedContent.innerHTML).toContain(component.literals.emailSentConfirmationPhrase);
       expect(expectedContent.innerHTML).not.toContain(component.literals.sentSmsCodePhrase);
-      expect(expectedContent.innerHTML).not.toContain(component.emailModalPhrases['firstPhrase']);
+      expect(expectedContent.innerHTML).not.toContain(component.emailModalPhrases.firstPhrase);
     });
 
     it('should contain `po-field-container-error-text` class if `invalidEmail` and control are true', () => {

--- a/projects/templates/src/lib/components/po-modal-password-recovery/po-modal-password-recovery.component.ts
+++ b/projects/templates/src/lib/components/po-modal-password-recovery/po-modal-password-recovery.component.ts
@@ -44,7 +44,7 @@ export class PoModalPasswordRecoveryComponent extends PoModalPasswordRecoveryBas
   codeMask: string = '9 9 9 9 9 9';
   control: AbstractControl;
   emailModal: boolean = true;
-  emailModalPhrases = {};
+  emailModalPhrases = { firstPhrase: null as string, secondPhrase: null as string };
   endpoint: string = '.';
   invalidCode: boolean = false;
   invalidEmail: boolean = false;
@@ -196,11 +196,11 @@ export class PoModalPasswordRecoveryComponent extends PoModalPasswordRecoveryBas
 
   private pipeModalPhrases() {
     if (this.type === PoModalPasswordRecoveryType.SMS) {
-      this.emailModalPhrases['firstPhrase'] = this.setPipeArguments(this.literals.recoveryPasswordPhrase, this.literals.sms);
-      this.emailModalPhrases['secondPhrase'] = this.setPipeArguments(this.literals.supportContact, this.literals.telephone);
+      this.emailModalPhrases.firstPhrase = this.setPipeArguments(this.literals.recoveryPasswordPhrase, this.literals.sms);
+      this.emailModalPhrases.secondPhrase = this.setPipeArguments(this.literals.supportContact, this.literals.telephone);
     } else {
-      this.emailModalPhrases['firstPhrase'] = this.setPipeArguments(this.literals.recoveryPasswordPhrase, this.literals.email);
-      this.emailModalPhrases['secondPhrase'] = this.setPipeArguments(this.literals.supportContact, this.literals.email);
+      this.emailModalPhrases.firstPhrase = this.setPipeArguments(this.literals.recoveryPasswordPhrase, this.literals.email);
+      this.emailModalPhrases.secondPhrase = this.setPipeArguments(this.literals.supportContact, this.literals.email);
     }
   }
 

--- a/projects/templates/src/lib/components/po-page-change-password/po-page-change-password.component.ts
+++ b/projects/templates/src/lib/components/po-page-change-password/po-page-change-password.component.ts
@@ -58,8 +58,8 @@ export class PoPageChangePasswordComponent extends PoPageChangePasswordBaseCompo
 
   readonly literals: { backButton: string, confirmPassword: string, createNewPassword: string, createNewPasswordPhrase: string,
     currentPassword: string, enterSystemButton: string, forgotPassword: string, newPassword: string, passwordSuccessfullyCreated: string,
-    passwordSuccessfullyUpdated: string, safetyTips: string, safetyTipsPhrase: string, safetyTipsFirst: string, safetyTipsSecond: string,
-    safetyTipsThird: string, saveButton: string } =
+    passwordSuccessfullyUpdated: string, requirements: string, safetyTips: string, safetyTipsPhrase: string, safetyTipsFirst: string,
+    safetyTipsSecond: string, safetyTipsThird: string, saveButton: string } =
     {
       ...poPageChangePasswordLiterals[poLocaleDefault],
       ...poPageChangePasswordLiterals[browserLanguage()],

--- a/projects/templates/src/lib/components/po-page-dynamic-edit/po-page-dynamic-edit.component.ts
+++ b/projects/templates/src/lib/components/po-page-dynamic-edit/po-page-dynamic-edit.component.ts
@@ -299,6 +299,10 @@ export class PoPageDynamicEditComponent implements OnInit {
     return this._detailFields;
   }
 
+  detailActionNew() {
+    this.gridDetail.insertRow();
+  }
+
   private cancel(path) {
     if (this.dynamicForm && this.dynamicForm.form.dirty) {
       this.poDialogService.confirm({
@@ -367,10 +371,6 @@ export class PoPageDynamicEditComponent implements OnInit {
     } else {
       window.history.back();
     }
-  }
-
-  private detailActionNew() {
-    this.gridDetail.insertRow();
   }
 
   private resolveUrl(item: any, path: string) {

--- a/projects/templates/src/lib/components/po-page-login/interfaces/po-page-login-literals.interface.ts
+++ b/projects/templates/src/lib/components/po-page-login/interfaces/po-page-login-literals.interface.ts
@@ -7,6 +7,12 @@
  */
 export interface PoPageLoginLiterals {
 
+  /** Mensagem de erro apresentada quando o campo customizado está inválido */
+  customFieldErrorPattern?: string;
+
+  /** Placeholder para o campo customizado. */
+  customFieldPlaceholder?: string;
+
   /** Título exibido no topo da página. */
   title?: string;
 

--- a/projects/templates/src/lib/components/po-page-login/po-page-login-base.component.ts
+++ b/projects/templates/src/lib/components/po-page-login/po-page-login-base.component.ts
@@ -169,6 +169,7 @@ export abstract class PoPageLoginBaseComponent implements OnDestroy {
   customizedDefaultLiterals: PoPageLoginLiterals = {};
   loginSubscription: Subscription;
   password: string;
+  rememberUser: boolean = false;
   selectedLanguage: string;
   showExceededAttemptsWarning = false;
 
@@ -190,7 +191,6 @@ export abstract class PoPageLoginBaseComponent implements OnDestroy {
   private _registerUrl: string;
   private _urlRecovery: string;
 
-  protected rememberUser: boolean = false;
 
   /**
    * @optional

--- a/projects/templates/src/lib/components/po-page-login/po-page-login.component.ts
+++ b/projects/templates/src/lib/components/po-page-login/po-page-login.component.ts
@@ -96,6 +96,23 @@ export class PoPageLoginComponent extends PoPageLoginBaseComponent implements Af
     }
   }
 
+  openUrl(recovery: any): void {
+    switch (typeof recovery) {
+      case 'string': {
+        this.setUrlRedirect(recovery);
+        break;
+      }
+      case 'function': {
+        recovery();
+        break;
+      }
+      case 'object': {
+        this.createModalPasswordRecoveryComponent(recovery);
+        break;
+      }
+    }
+  }
+
   private checkingForMetadataProperty(object, property) {
     if (Object.prototype.hasOwnProperty.call(object, property)) {
       return object[property];
@@ -185,23 +202,6 @@ export class PoPageLoginComponent extends PoPageLoginBaseComponent implements Af
         this.changeDetector.detectChanges();
       }
     });
-  }
-
-  protected openUrl(recovery: any): void {
-    switch (typeof recovery) {
-      case 'string': {
-        this.setUrlRedirect(recovery);
-        break;
-      }
-      case 'function': {
-        recovery();
-        break;
-      }
-      case 'object': {
-        this.createModalPasswordRecoveryComponent(recovery);
-        break;
-      }
-    }
   }
 
   protected setLoginErrors(errors: Array<string>) {

--- a/projects/templates/tsconfig.lib.json
+++ b/projects/templates/tsconfig.lib.json
@@ -15,7 +15,7 @@
     "annotateForClosureCompiler": true,
     "skipTemplateCodegen": true,
     "strictMetadataEmit": true,
-    "fullTemplateTypeCheck": false,
+    "fullTemplateTypeCheck": true,
     "strictInjectionParameters": true,
     "enableResourceInlining": true
   },

--- a/projects/ui/src/lib/components/po-calendar/po-calendar-base.component.ts
+++ b/projects/ui/src/lib/components/po-calendar/po-calendar-base.component.ts
@@ -44,11 +44,13 @@ export class PoCalendarBaseComponent {
   private _maxDate: Date;
   private _minDate: Date;
 
+  currentYear: number;
   dayVisible: boolean = false;
   displayDays: Array<number>;
   displayDecade: Array<number>;
   displayFinalDecade: number;
   displayMonth: any;
+  displayMonthNumber: number;
   displayMonths: Array<any> = Array();
   displayStartDecade: number;
   displayWeekDays: Array<any> = Array();
@@ -57,10 +59,8 @@ export class PoCalendarBaseComponent {
   yearVisible: boolean = false;
 
   protected currentMonthNumber: number;
-  protected currentYear: number;
   protected date: Date;
   protected dateIso: string;
-  protected displayMonthNumber: number;
   protected lastDisplay: string;
   protected onTouched: any = null;
   protected propagateChange: any = null;

--- a/projects/ui/src/lib/components/po-calendar/po-calendar.component.spec.ts
+++ b/projects/ui/src/lib/components/po-calendar/po-calendar.component.spec.ts
@@ -98,7 +98,7 @@ describe('PoCalendarComponent:', () => {
       is less then 11`, () => {
 
       component.displayYear = 1997;
-      component['displayMonthNumber'] = 10;
+      component.displayMonthNumber = 10;
 
       spyOn(component, <any>'updateDisplay');
       component.onNextMonth();
@@ -110,7 +110,7 @@ describe('PoCalendarComponent:', () => {
       then 11`, () => {
 
       component.displayYear = 1997;
-      component['displayMonthNumber'] = 11;
+      component.displayMonthNumber = 11;
 
       spyOn(component, <any>'updateDisplay');
       component.onNextMonth();
@@ -122,7 +122,7 @@ describe('PoCalendarComponent:', () => {
       greater then 0`, () => {
 
         component.displayYear = 1997;
-        component['displayMonthNumber'] = 10;
+        component.displayMonthNumber = 10;
 
         spyOn(component, <any>'updateDisplay');
         component.onPreviousMonth();
@@ -132,7 +132,7 @@ describe('PoCalendarComponent:', () => {
 
     it(`onPreviousMonth: should call 'updateDisplay' with 'displayYear -1' and 11 if displayMonthNumber is equal or less then 0`, () => {
       component.displayYear = 1997;
-      component['displayMonthNumber'] = 0;
+      component.displayMonthNumber = 0;
 
       spyOn(component, <any>'updateDisplay');
       component.onPreviousMonth();
@@ -222,7 +222,7 @@ describe('PoCalendarComponent:', () => {
 
       component.onSelectYear(yearParam, 10);
 
-      expect(component['currentYear']).toBe(yearParam);
+      expect(component.currentYear).toBe(yearParam);
     });
 
     it('registerOnChange: should set `propagateChange` with value of the `fnParam`', () => {
@@ -281,7 +281,7 @@ describe('PoCalendarComponent:', () => {
 
     it(`updateYear: should call 'updateDisplay' with '2007' and '11'`, () => {
       component.displayYear = 1997;
-      component['displayMonthNumber'] = 11;
+      component.displayMonthNumber = 11;
       const value = 10;
       const yearExpected = 2007;
 
@@ -293,7 +293,7 @@ describe('PoCalendarComponent:', () => {
 
     it(`updateYear: should call 'updateDisplay' with '1987' and '11'`, () => {
       component.displayYear = 1997;
-      component['displayMonthNumber'] = 11;
+      component.displayMonthNumber = 11;
 
       spyOn(component, <any>'updateDisplay');
       component.updateYear(-10);
@@ -659,8 +659,8 @@ describe('PoCalendarComponent:', () => {
       component['updateDate'](date);
 
       expect(component['currentMonthNumber']).toBe(date.getMonth());
-      expect(component['currentYear']).toBe(date.getFullYear());
-      expect(component['updateDisplay']).toHaveBeenCalledWith(component['currentYear'], component['currentMonthNumber']);
+      expect(component.currentYear).toBe(date.getFullYear());
+      expect(component['updateDisplay']).toHaveBeenCalledWith(component.currentYear, component['currentMonthNumber']);
     });
 
     it(`updateDate: shouldn't call 'updateDisplay' if not have date`, () => {
@@ -708,7 +708,7 @@ describe('PoCalendarComponent:', () => {
 
       component['updateDisplay'](year, month);
 
-      expect(component['displayMonthNumber']).toEqual(month);
+      expect(component.displayMonthNumber).toEqual(month);
       expect(component['displayMonth']).toEqual(component['displayMonths'][month]);
       expect(component['displayYear']).toEqual(year);
       expect(component['getDecadeArray']).toHaveBeenCalledWith(year);

--- a/projects/ui/src/lib/components/po-chart/po-chart.component.ts
+++ b/projects/ui/src/lib/components/po-chart/po-chart.component.ts
@@ -54,7 +54,7 @@ export class PoChartComponent extends PoChartBaseComponent implements AfterViewI
   @ViewChild('chartLegend', { static: true }) chartLegend: ElementRef;
   @ViewChild('chartWrapper', { static: true }) chartWrapper: ElementRef;
 
-  @HostListener('window:resize', ['$event'])
+  @HostListener('window:resize')
   onResize = () => this.windowResizeListener.next()
 
   constructor(

--- a/projects/ui/src/lib/components/po-field/po-datepicker-range/po-datepicker-range.component.html
+++ b/projects/ui/src/lib/components/po-field/po-datepicker-range/po-datepicker-range.component.html
@@ -41,7 +41,7 @@
     </div>
 
     <div class="po-datepicker-range-icon">
-      <po-clean *ngIf="enableCleaner" (p-change-event)="clear($event)"></po-clean>
+      <po-clean *ngIf="enableCleaner" (p-change-event)="clear()"></po-clean>
     </div>
 
     <div class="po-datepicker-range-icon">

--- a/projects/ui/src/lib/components/po-field/po-datepicker/po-calendar/po-calendar.component.spec.ts
+++ b/projects/ui/src/lib/components/po-field/po-datepicker/po-calendar/po-calendar.component.spec.ts
@@ -338,7 +338,7 @@ describe('PoCalendarComponent:', () => {
     it(`onPrevMonth: should call 'updateDisplay' with 'displayYear' and 'displayMonthNumber -1'
       when displayMonthNumber is greater then 0`, () => {
         component.displayYear = 1997;
-        component['displayMonthNumber'] = 10;
+        component.displayMonthNumber = 10;
 
         spyOn(component, <any>'updateDisplay');
         component.onPrevMonth();
@@ -348,7 +348,7 @@ describe('PoCalendarComponent:', () => {
 
     it(`onPrevMonth: should call 'updateDisplay' with 'displayYear -1' and 11 when displayMonthNumber is equal or less then 0`, () => {
       component.displayYear = 1997;
-      component['displayMonthNumber'] = 0;
+      component.displayMonthNumber = 0;
 
       spyOn(component, <any>'updateDisplay');
       component.onPrevMonth();
@@ -359,7 +359,7 @@ describe('PoCalendarComponent:', () => {
     it(`onNextMonth: should call 'updateDisplay' with 'displayYear' and 'displayMonthNumber +1' when displayMonthNumber is less then 11`,
     () => {
       component.displayYear = 1997;
-      component['displayMonthNumber'] = 10;
+      component.displayMonthNumber = 10;
 
       spyOn(component, <any>'updateDisplay');
       component.onNextMonth();
@@ -369,7 +369,7 @@ describe('PoCalendarComponent:', () => {
 
     it(`onNextMonth: should call 'updateDisplay' with 'displayYear +1' and 0 when displayMonthNumber is greater or equal then 11`, () => {
       component.displayYear = 1997;
-      component['displayMonthNumber'] = 11;
+      component.displayMonthNumber = 11;
 
       spyOn(component, <any>'updateDisplay');
       component.onNextMonth();
@@ -440,7 +440,7 @@ describe('PoCalendarComponent:', () => {
 
     it(`updateYear: should call 'updateDisplay' and update 'displayYear' with positive number`, () => {
       component.displayYear = 1997;
-      component['displayMonthNumber'] = 11;
+      component.displayMonthNumber = 11;
 
       spyOn(component, <any>'updateDisplay');
       component.updateYear(10);
@@ -450,7 +450,7 @@ describe('PoCalendarComponent:', () => {
 
     it(`updateYear: should call 'updateDisplay' and update 'displayYear' with negative number`, () => {
       component.displayYear = 1997;
-      component['displayMonthNumber'] = 11;
+      component.displayMonthNumber = 11;
 
       spyOn(component, <any>'updateDisplay');
       component.updateYear(-10);
@@ -477,7 +477,7 @@ describe('PoCalendarComponent:', () => {
 
     it(`updateDate: should call 'updateDisplay' with year and month updated`, () => {
       component['currentMonthNumber'] = 2;
-      component['currentYear'] = 2000;
+      component.currentYear = 2000;
 
       spyOn(component, <any>'updateDisplay');
       component['updateDate'](new Date(2018, 5, 5));
@@ -499,7 +499,7 @@ describe('PoCalendarComponent:', () => {
       spyOn(component, 'getArrayDecade');
       component['updateDisplay'](2000, 5);
 
-      expect(component['displayMonthNumber']).toBe(5);
+      expect(component.displayMonthNumber).toBe(5);
       expect(component.getArrayDecade).toHaveBeenCalledWith(2000);
     });
 

--- a/projects/ui/src/lib/components/po-field/po-datepicker/po-calendar/po-calendar.component.ts
+++ b/projects/ui/src/lib/components/po-field/po-datepicker/po-calendar/po-calendar.component.ts
@@ -26,11 +26,13 @@ export class PoCalendarComponent {
   private _locale: string;
   private _selectedDate?: Date;
 
+  currentYear: number;
   dayVisible: boolean = false;
   displayDays: Array<number>;
   displayDecade: Array<number>;
   displayFinalDecade: number;
   displayMonth: any;
+  displayMonthNumber: number;
   displayMonths: Array<any> = Array();
   displayStartDecade: number;
   displayWeedDays: Array<any> = Array();
@@ -41,8 +43,6 @@ export class PoCalendarComponent {
   yearVisible: boolean = false;
 
   private currentMonthNumber: number;
-  private currentYear: number;
-  private displayMonthNumber: number;
   private isMobile: any = isMobile;
   private lastDisplay: string;
   private today: Date = new Date();

--- a/projects/ui/src/lib/components/po-field/po-radio-group/po-radio-group.component.html
+++ b/projects/ui/src/lib/components/po-field/po-radio-group/po-radio-group.component.html
@@ -14,7 +14,6 @@
         [checked]="value === option.value"
         [class.po-radio-group-input-checked]="value === option.value"
         [disabled]="option.disabled === true || disabled"
-        [readonly]="readonly"
         [required]="required"
         [value]="option.value"
         (keyup)="onKeyUp($event, option.value)">

--- a/projects/ui/src/lib/components/po-field/po-upload/po-upload.component.spec.ts
+++ b/projects/ui/src/lib/components/po-field/po-upload/po-upload.component.spec.ts
@@ -65,7 +65,7 @@ describe('PoUploadComponent:', () => {
 
   it('status should be equal file status', () => {
     file.status = PoUploadStatus.None;
-    const isStatusEquals = component['isStatusFile']('None', file);
+    const isStatusEquals = component.isStatusFile('None', file);
 
     expect(isStatusEquals).toBeTruthy();
   });
@@ -417,36 +417,36 @@ describe('PoUploadComponent:', () => {
     });
 
     it('getFileSize: should be get the text of size in KBytes', () => {
-      let kbSize = component['getFileSize'](3000);
+      let kbSize = component.getFileSize(3000);
 
       expect(kbSize).toEqual('3 KB');
 
-      kbSize = component['getFileSize'](0);
+      kbSize = component.getFileSize(0);
 
       expect(kbSize).toEqual('0 KB');
     });
 
     it('getPoIcon: should get po icon by file status', () => {
-      let poIcon = component['getPoIcon'](file);
+      let poIcon = component.getPoIcon(file);
       expect(poIcon).toEqual('po-icon-info');
 
       file.status = PoUploadStatus.Error;
-      poIcon = component['getPoIcon'](file);
+      poIcon = component.getPoIcon(file);
       expect(poIcon).toEqual('po-icon-close');
 
       file.status = PoUploadStatus.Uploaded;
-      poIcon = component['getPoIcon'](file);
+      poIcon = component.getPoIcon(file);
       expect(poIcon).toEqual('po-icon-ok');
 
       file.status = PoUploadStatus.Uploading;
-      poIcon = component['getPoIcon'](file);
+      poIcon = component.getPoIcon(file);
       expect(poIcon).toEqual('');
     });
 
     it('hasAnyFileUploading: should be check has any file uploading', () => {
       file.status = PoUploadStatus.Uploading;
 
-      const hasFileUploading = component['hasAnyFileUploading']([file]);
+      const hasFileUploading = component.hasAnyFileUploading([file]);
       expect(hasFileUploading).toBeTruthy();
     });
 
@@ -464,7 +464,7 @@ describe('PoUploadComponent:', () => {
 
       spyOn(fakeThis, 'removeFile');
 
-      component['stopUpload'].call(fakeThis, file, 0);
+      component.stopUpload.call(fakeThis, file, 0);
 
       expect(fakeThis.removeFile).toHaveBeenCalled();
     });
@@ -483,7 +483,7 @@ describe('PoUploadComponent:', () => {
 
       spyOn(fakeThis, 'stopUploadHandler');
 
-      component['stopUpload'].call(fakeThis, file, 0);
+      component.stopUpload.call(fakeThis, file, 0);
 
       expect(fakeThis.stopUploadHandler).toHaveBeenCalled();
     });
@@ -505,7 +505,7 @@ describe('PoUploadComponent:', () => {
 
         // Mock da função que é criada ao utilizar ngmodel para atualizar o mesmo.
         component.onModelChange = param => { };
-        component['uploadFiles'] = param => { };
+        component.uploadFiles = param => { };
         component.autoUpload = true;
 
         const event = {
@@ -533,7 +533,7 @@ describe('PoUploadComponent:', () => {
         };
         spyOn(fakeThis, 'uploadingHandler');
 
-        component['uploadFiles'].call(fakeThis, [file]);
+        component.uploadFiles.call(fakeThis, [file]);
 
         expect(fakeThis.uploadingHandler).toHaveBeenCalled();
       });
@@ -551,7 +551,7 @@ describe('PoUploadComponent:', () => {
         };
         spyOn(fakeThis, 'successHandler');
 
-        component['uploadFiles'].call(fakeThis, [file]);
+        component.uploadFiles.call(fakeThis, [file]);
 
         expect(fakeThis.successHandler).toHaveBeenCalled();
       });
@@ -568,7 +568,7 @@ describe('PoUploadComponent:', () => {
         };
         spyOn(fakeThis, 'errorHandler');
 
-        component['uploadFiles'].call(fakeThis, [file]);
+        component.uploadFiles.call(fakeThis, [file]);
 
         expect(fakeThis.errorHandler).toHaveBeenCalled();
       });

--- a/projects/ui/src/lib/components/po-field/po-upload/po-upload.component.ts
+++ b/projects/ui/src/lib/components/po-field/po-upload/po-upload.component.ts
@@ -98,6 +98,49 @@ export class PoUploadComponent extends PoUploadBaseComponent {
     this.cleanInputValue();
   }
 
+  // Retorna o tamanho do arquivo em KBytes.
+  getFileSize(size: number): string {
+    let kbSize = 0;
+
+    if (size) {
+        kbSize = Math.ceil(size / 1024);
+    }
+
+    return `${kbSize} KB`;
+  }
+
+  // Retorna o po-icon de acordo com o status do arquivo.
+  getPoIcon(file: PoUploadFile): string {
+    switch (file.status) {
+      case PoUploadStatus.Uploaded:
+        return 'po-icon-ok';
+
+      case PoUploadStatus.Error:
+        return 'po-icon-close';
+
+      case PoUploadStatus.None:
+        return 'po-icon-info';
+
+      case PoUploadStatus.Uploading:
+      default:
+        return '';
+    }
+  }
+
+  // Verifica se existe algum arquivo sendo enviado ao serviço.
+  hasAnyFileUploading(files: Array<PoUploadFile>) {
+    if (files && files.length) {
+      return files.some(file => file.status === PoUploadStatus.Uploading);
+    }
+
+    return false;
+  }
+
+  // Valida se o status passado por parâmetro é igual ao status do arquivo.
+  isStatusFile(status: string, file: PoUploadFile) {
+    return file.status === PoUploadStatus[status];
+  }
+
   // Função disparada ao selecionar algum arquivo.
   onFileChange(event): void {
 
@@ -139,51 +182,8 @@ export class PoUploadComponent extends PoUploadBaseComponent {
     }
   }
 
-  // Retorna o tamanho do arquivo em KBytes.
-  protected getFileSize(size: number): string {
-    let kbSize = 0;
-
-    if (size) {
-        kbSize = Math.ceil(size / 1024);
-    }
-
-    return `${kbSize} KB`;
-  }
-
-  // Retorna o po-icon de acordo com o status do arquivo.
-  protected getPoIcon(file: PoUploadFile): string {
-    switch (file.status) {
-      case PoUploadStatus.Uploaded:
-        return 'po-icon-ok';
-
-      case PoUploadStatus.Error:
-        return 'po-icon-close';
-
-      case PoUploadStatus.None:
-        return 'po-icon-info';
-
-      case PoUploadStatus.Uploading:
-      default:
-        return '';
-    }
-  }
-
-  // Verifica se existe algum arquivo sendo enviado ao serviço.
-  protected hasAnyFileUploading(files: Array<PoUploadFile>) {
-    if (files && files.length) {
-      return files.some(file => file.status === PoUploadStatus.Uploading);
-    }
-
-    return false;
-  }
-
-  // Valida se o status passado por parâmetro é igual ao status do arquivo.
-  protected isStatusFile(status: string, file: PoUploadFile) {
-    return file.status === PoUploadStatus[status];
-  }
-
   // Caso o componente estiver no modo AutoUpload, o arquivo também será removido da lista.
-  protected stopUpload(file: PoUploadFile) {
+  stopUpload(file: PoUploadFile) {
     this.uploadService.stopRequestByFile(file, () => {
       if (this.autoUpload) {
         this.removeFile(file);
@@ -194,7 +194,7 @@ export class PoUploadComponent extends PoUploadBaseComponent {
   }
 
   // Envia os arquivos passados por parâmetro, exceto os que já foram enviados ao serviço.
-  protected uploadFiles(files: Array<PoUploadFile>) {
+  uploadFiles(files: Array<PoUploadFile>) {
     const filesFiltered = files.filter(file => {
       return file.status !== PoUploadStatus.Uploaded;
     });

--- a/projects/ui/src/lib/components/po-navbar/po-navbar-items/po-navbar-item/po-navbar-item.component.ts
+++ b/projects/ui/src/lib/components/po-navbar/po-navbar-items/po-navbar-item/po-navbar-item.component.ts
@@ -24,7 +24,7 @@ export class PoNavbarItemComponent {
     return isExternalLink(this.link) ? 'externalLink' : 'internalLink';
   }
 
-  itemClick(label: string, link: string) {
+  itemClick(label?: string, link?: string) {
 
     if (this.action) {
       this.action({ label, link });

--- a/projects/ui/src/lib/components/po-page/po-page-edit/po-page-edit.component.spec.ts
+++ b/projects/ui/src/lib/components/po-page/po-page-edit/po-page-edit.component.spec.ts
@@ -141,7 +141,7 @@ describe('PoPageEditComponent', () => {
     });
 
     it('hasPageHeader: should return true if has breadcrumb', () => {
-      component['parentContext'] = <any> {};
+      component.parentContext = <any> {};
       component.title = undefined;
       component.breadcrumb = { items: [{ label: 'Breadcrumb' }]};
 
@@ -152,7 +152,7 @@ describe('PoPageEditComponent', () => {
       component.breadcrumb = undefined;
       component.title = undefined;
 
-      component['parentContext'] = <any> {
+      component.parentContext = <any> {
         cancel: function() {},
         saveNew: function() {},
         save: function() {}
@@ -162,7 +162,7 @@ describe('PoPageEditComponent', () => {
     });
 
     it('hasPageHeader: should return true if has title', () => {
-      component['parentContext'] = <any> {};
+      component.parentContext = <any> {};
       component.breadcrumb = undefined;
       component.title = 'Title';
 
@@ -170,7 +170,7 @@ describe('PoPageEditComponent', () => {
     });
 
     it('hasPageHeader: should return false if doesn`t have actions, breadcrumb and title', () => {
-      component['parentContext'] = <any> {};
+      component.parentContext = <any> {};
       component.breadcrumb = undefined;
       component.title = undefined;
 
@@ -178,7 +178,7 @@ describe('PoPageEditComponent', () => {
     });
 
     it('isPrimaryAction: should return true if action is "saveNew" and save function is undefined', () => {
-      component['parentContext'] = <any> {
+      component.parentContext = <any> {
         cancel: () => {},
         saveNew: () => {},
       };
@@ -187,7 +187,7 @@ describe('PoPageEditComponent', () => {
     });
 
     it('isPrimaryAction: should return false if action is "saveNew" and save funtion is defined', () => {
-      component['parentContext'] = <any> {
+      component.parentContext = <any> {
         cancel: () => {},
         saveNew: () => {},
         save: () => {}
@@ -197,7 +197,7 @@ describe('PoPageEditComponent', () => {
     });
 
     it('isPrimaryAction: should return true if action is "cancel", saveNew and save function are undefined', () => {
-      component['parentContext'] = <any> {
+      component.parentContext = <any> {
         cancel: () => {},
       };
 
@@ -205,7 +205,7 @@ describe('PoPageEditComponent', () => {
     });
 
     it('isPrimaryAction: should return false if action is "cancel" and saveNew funtion is defined', () => {
-      component['parentContext'] = <any> {
+      component.parentContext = <any> {
         cancel: () => {},
         saveNew: () => {},
       };
@@ -214,7 +214,7 @@ describe('PoPageEditComponent', () => {
     });
 
     it('isPrimaryAction: should return false if action is "cancel" and save funtion is defined', () => {
-      component['parentContext'] = <any> {
+      component.parentContext = <any> {
         cancel: () => {},
         save: () => {},
       };
@@ -223,7 +223,7 @@ describe('PoPageEditComponent', () => {
     });
 
     it('isPrimaryAction: should return false if action isn`t "cancel" or "saveNew"', () => {
-      component['parentContext'] = <any> {
+      component.parentContext = <any> {
         cancel: () => {},
         save: () => {},
       };
@@ -240,7 +240,7 @@ describe('PoPageEditComponent', () => {
 
       component.literals = poPageEditLiteralsDefault[poLocaleDefault];
 
-      component['parentContext'] = <any> {
+      component.parentContext = <any> {
         cancel: function() {},
         saveNew: function() {},
         save: function() {}
@@ -261,7 +261,7 @@ describe('PoPageEditComponent', () => {
 
       component.literals = poPageEditLiteralsDefault[poLocaleDefault];
 
-      component['parentContext'] = <any> {
+      component.parentContext = <any> {
         cancel: function() {},
         saveNew: function() {}
       };
@@ -281,7 +281,7 @@ describe('PoPageEditComponent', () => {
 
       component.literals = poPageEditLiteralsDefault[poLocaleDefault];
 
-      component['parentContext'] = <any> {
+      component.parentContext = <any> {
         cancel: function() {}
       };
 
@@ -308,7 +308,7 @@ describe('PoPageEditComponent', () => {
     });
 
     it('should only contain icon in "save" primary action if "save" function is defined.', () => {
-      component['parentContext'] = <any> {
+      component.parentContext = <any> {
         save: () => {},
         cancel: () => {},
         saveNew: () => {}
@@ -324,7 +324,7 @@ describe('PoPageEditComponent', () => {
     });
 
     it('should only contain icon in "saveNew" primary action if "save" function is undefined.', () => {
-      component['parentContext'] = <any> {
+      component.parentContext = <any> {
         cancel: () => {},
         saveNew: () => {}
       };
@@ -339,7 +339,7 @@ describe('PoPageEditComponent', () => {
     });
 
     it('should only contain icon in "cancel" primary action if "saveNew" and "save" function is undefined.', () => {
-      component['parentContext'] = <any> {
+      component.parentContext = <any> {
         cancel: () => {}
       };
 

--- a/projects/ui/src/lib/components/po-page/po-page-edit/po-page-edit.component.ts
+++ b/projects/ui/src/lib/components/po-page/po-page-edit/po-page-edit.component.ts
@@ -30,8 +30,7 @@ import { callAction, hasAction } from '../po-page-util/po-page-util';
 export class PoPageEditComponent extends PoPageEditBaseComponent {
   hasAction: Function = hasAction;
   callAction: Function = callAction;
-
-  private parentContext: ViewContainerRef;
+  parentContext: ViewContainerRef;
 
   constructor(viewRef: ViewContainerRef) {
     super();

--- a/projects/ui/src/lib/components/po-page/po-page-list/po-page-list.component.ts
+++ b/projects/ui/src/lib/components/po-page/po-page-list/po-page-list.component.ts
@@ -40,10 +40,10 @@ export class PoPageListComponent extends PoPageListBaseComponent implements Afte
   dropdownActions: Array<PoPageAction>;
   isMobile: boolean;
   limitPrimaryActions: number = 3;
+  parentRef: ViewContainerRef;
 
   private isRecalculate = true;
   private maxWidthMobile: number = 480;
-  private parentRef: ViewContainerRef;
 
   callFunction = callFunction;
 

--- a/projects/ui/src/lib/components/po-slide/po-slide-item/po-slide-item.component.html
+++ b/projects/ui/src/lib/components/po-slide/po-slide-item/po-slide-item.component.html
@@ -37,7 +37,7 @@
 
 </div>
 
-<ng-template #slideItemTemplate let-item='item'>
+<ng-template #slideItemTemplate let-item='item'; let-index='index'>
   <div
     *ngIf="template"
     class="po-slide-item-content">

--- a/projects/ui/src/lib/components/po-table/po-table.component.spec.ts
+++ b/projects/ui/src/lib/components/po-table/po-table.component.spec.ts
@@ -275,7 +275,7 @@ describe('PoTableComponent:', () => {
 
     spyOn(tableAction, <any> 'disabled');
 
-    component['validateTableAction'](tableRow, tableAction);
+    component.validateTableAction(tableRow, tableAction);
     expect(tableAction.disabled).toHaveBeenCalled();
   });
 
@@ -284,7 +284,7 @@ describe('PoTableComponent:', () => {
     const tableAction = component.actions[2];
     const tableRow = component.items[0];
 
-    const result = component['validateTableAction'](tableRow, tableAction);
+    const result = component.validateTableAction(tableRow, tableAction);
     expect(result).toBe(true);
   });
 

--- a/projects/ui/src/lib/components/po-table/po-table.component.ts
+++ b/projects/ui/src/lib/components/po-table/po-table.component.ts
@@ -312,6 +312,14 @@ export class PoTableComponent extends PoTableBaseComponent implements AfterViewI
     this.poPopupComponent.toggle(row);
   }
 
+  validateTableAction(row: any, tableAction: any) {
+    if (typeof tableAction.disabled === 'function') {
+      return tableAction.disabled.call(this.parentRef, row);
+    } else {
+      return tableAction.disabled;
+    }
+  }
+
   protected showContainer(container: string) {
 
     const containerClassList = this.tableContainerElement.nativeElement.firstChild.classList;
@@ -364,14 +372,6 @@ export class PoTableComponent extends PoTableBaseComponent implements AfterViewI
     });
 
     return icons;
-  }
-
-  private validateTableAction(row: any, tableAction: any) {
-    if (typeof tableAction.disabled === 'function') {
-      return tableAction.disabled.call(this.parentRef, row);
-    } else {
-      return tableAction.disabled;
-    }
   }
 
   private debounceResize() {

--- a/projects/ui/src/lib/components/po-toolbar/po-toolbar.component.html
+++ b/projects/ui/src/lib/components/po-toolbar/po-toolbar.component.html
@@ -13,8 +13,8 @@
     </po-toolbar-notification>
 
     <po-toolbar-profile *ngIf="isShowProfile"
-      [p-profile]="profile || { avatar: userSrc, title: userName }"
-      [p-profile-actions]="profileActions || userActions">
+      [p-profile]="profile"
+      [p-profile-actions]="profileActions">
     </po-toolbar-profile>
   </div>
 </div>

--- a/projects/ui/tsconfig.lib.json
+++ b/projects/ui/tsconfig.lib.json
@@ -16,6 +16,7 @@
     "annotateForClosureCompiler": true,
     "skipTemplateCodegen": true,
     "strictMetadataEmit": true,
+    "fullTemplateTypeCheck": true,
     "strictInjectionParameters": true,
     "enableResourceInlining": true
   },


### PR DESCRIPTION
**BUILD**

 **DTHFUI-1427**
_____________________________________________________________________________

**PR Checklist**

- [x] Código
- [x] Testes unitários
- [ ] Documentação
- [ ] Samples

**Qual o comportamento atual?**
Ao compilar uma aplicação com AOT que contem o atributo fullTemplateTypeCheck no tsconfig ocorre erros de acesso no HTML.

**Qual o novo comportamento?**
Adicionada a propriedade fullTemplateTypeCheck no tsconfig.lib.json das bibliotecas **templates** e **ui** e corrigidos diversos erros de acesso no HTML. 
Desta forma, o usuário pode também adicionar esta mesma propriedade em seus projetos e executar --prod.

**Simulação**
Pode-se verificar o comportamento adicionando a propriedade mencionada acima na master e tentar roda `ng build ui` e `ng build templates`. Posteriormente, baixe a branch e execute o mesmo comando. Posteriormente, aplique as dists em uma aplicação qualquer e execute `ng build --prod`.
