### PR TITLE
fix(datepicker): corrige disparo do p-change

### DIFF
--- a/projects/ui/src/lib/components/po-field/po-datepicker/po-datepicker.component.html
+++ b/projects/ui/src/lib/components/po-field/po-datepicker/po-datepicker.component.html
@@ -15,7 +15,6 @@
       [readonly]="readonly"
       [required]="required"
       (blur)="eventOnBlur($event)"
-      (change)="eventOnChange($event)"
       (click)="eventOnClick($event)">
 
     <div class="po-field-icon-container-right">

--- a/projects/ui/src/lib/components/po-field/po-datepicker/po-datepicker.component.spec.ts
+++ b/projects/ui/src/lib/components/po-field/po-datepicker/po-datepicker.component.spec.ts
@@ -412,17 +412,6 @@ describe('PoDatepickerComponent:', () => {
     expect(component.callOnChange).toHaveBeenCalled();
   });
 
-  it('should emit onchange when it is not mobile', () => {
-    const input = fixture.debugElement.nativeElement.querySelector('input');
-    input.value = '01/01/2000';
-
-    spyOn(component.onchange, 'emit');
-
-    component.eventOnChange({});
-
-    expect(component.onchange.emit).toHaveBeenCalled();
-  });
-
   it('simulate click out behavior the datepicker field read-only', () => {
     component.dialogPicker = undefined;
     fixture.detectChanges();
@@ -435,18 +424,6 @@ describe('PoDatepickerComponent:', () => {
   });
 
   // Testes de mobile
-
-  it('should emit onchange when it is mobile', () => {
-    spyOn(component, 'verifyMobile').and.returnValue(['Android']);
-
-    spyOn(component, 'callOnChange');
-    spyOn(component, 'controlModel');
-
-    component.eventOnChange({});
-
-    expect(component.callOnChange).toHaveBeenCalled();
-    expect(component.controlModel).toHaveBeenCalled();
-  });
 
   it('should call eventOnClick when have mobile', () => {
     spyOn(component, 'verifyMobile').and.returnValue(['Android']);
@@ -745,13 +722,15 @@ describe('PoDatepickerComponent:', () => {
       expect(component['closeCalendar']).toHaveBeenCalled();
     });
 
-    it('dateSelected: should call `controlModel`', () => {
+    it('dateSelected: should call `controlModel` and `controlChangeEmitter`', () => {
 
       spyOn(component, 'controlModel');
+      spyOn(component, <any>'controlChangeEmitter');
 
       component.dateSelected();
 
       expect(component.controlModel).toHaveBeenCalled();
+      expect(component['controlChangeEmitter']).toHaveBeenCalled();
     });
 
     it('formatToDate: should call `formatYear` with date year', () => {
@@ -968,24 +947,6 @@ describe('PoDatepickerComponent:', () => {
       component['controlChangeEmitter'].call(fakeThis);
 
       expect(fakeThis.onchange.emit).not.toHaveBeenCalled();
-    });
-
-    it('eventOnChange: should emit value', () => {
-      const value = '30/08/2018' ;
-      const fakeThis = {
-        verifyMobile: () => false,
-        inputEl: {
-          nativeElement: {
-            value: value
-          }
-        },
-        onchange: { emit: () => {} }
-      };
-
-      spyOn(fakeThis.onchange, 'emit');
-      component['eventOnChange'].call(fakeThis);
-
-      expect(fakeThis.onchange.emit).toHaveBeenCalledWith(value);
     });
 
     it('isValidDateIso: should return `true` if value format is `yyyy-mm-dd`.', () => {

--- a/projects/ui/src/lib/components/po-field/po-datepicker/po-datepicker.component.ts
+++ b/projects/ui/src/lib/components/po-field/po-datepicker/po-datepicker.component.ts
@@ -124,6 +124,7 @@ export class PoDatepickerComponent extends PoDatepickerBaseComponent implements 
     this.inputEl.nativeElement.focus();
     this.inputEl.nativeElement.value = this.formatToDate(this.date);
     this.controlModel(this.date);
+    this.controlChangeEmitter();
     this.closeCalendar();
   }
 
@@ -210,15 +211,6 @@ export class PoDatepickerComponent extends PoDatepickerBaseComponent implements 
 
     this.controlChangeEmitter();
 
-  }
-
-  eventOnChange($event) {
-    const elementValue = this.inputEl.nativeElement.value;
-    if (this.verifyMobile()) {
-      this.controlModel(elementValue);
-      this.callOnChange(elementValue);
-    }
-    this.onchange.emit(elementValue);
   }
 
   eventOnClick($event) {


### PR DESCRIPTION
**PO-DATEPICKER**

**DTHFUI-904**
_____________________________________________________________________________

**PR Checklist**

- [x] Código
- [x] Testes unitários
- [ ] Documentação
- [ ] Samples

**Qual o comportamento atual?**
Evento p-change só é chamado ao selecionar o valor e sair do campo

**Qual o novo comportamento?**
- O evento p-change passa agora a ser disparado assim que selecionar um novo valor. 
- Para alterações de valor diretamente no input o disparo ainda prevalece ao sair do campo (blur).
- Foi removido o evento (p-change) do template assim como o método `eventOnChange` pois nunca era chamado. Quem já faz a mesma função que o método removido é o método `controlChangeEmitter`. 

**Simulação**
Basta definir um evento p-change e checar o disparo na seleção de datas

