### PR TITLE
fix(decimal): corrige aceitação de valores inválidos

### DIFF
--- a/projects/ui/src/lib/components/po-field/po-decimal/po-decimal.component.spec.ts
+++ b/projects/ui/src/lib/components/po-field/po-decimal/po-decimal.component.spec.ts
@@ -105,14 +105,6 @@ describe('PoDecimalComponent:', () => {
     expect(component.hasInvalidClass.call(fakeThis)).toBeTruthy();
   });
 
-  it('should return true in hasLetters', () => {
-    expect(component.hasLetters('AAAAAA')).toBeTruthy();
-  });
-
-  it('should return true in hasLetters with undefined param', () => {
-    expect(component.hasLetters(undefined)).toBeFalsy();
-  });
-
   it('blur event must be called', () => {
     const fakeEvent = {
       target: {
@@ -1199,6 +1191,23 @@ describe('PoDecimalComponent:', () => {
       expect(component['setViewValue']).not.toHaveBeenCalled();
       expect(component['setCursorInput']).not.toHaveBeenCalled();
     });
+
+    it('hasLetters: should return true with numbers.', () => {
+      expect(component.hasLetters('333')).toBeFalsy();
+    });
+
+    it('hasLetters: should return true wird letters.', () => {
+      expect(component.hasLetters('AAAAAA')).toBeTruthy();
+    });
+
+    it('hasLetters: should return true with special characteres.', () => {
+      expect(component.hasLetters('!@#$%&')).toBeTruthy();
+    });
+
+    it('hasLetters: should return true with undefined value.', () => {
+      expect(component.hasLetters(undefined)).toBeFalsy();
+    });
+
   });
 
   describe('Templates:', () => {

--- a/projects/ui/src/lib/components/po-field/po-decimal/po-decimal.component.ts
+++ b/projects/ui/src/lib/components/po-field/po-decimal/po-decimal.component.ts
@@ -149,7 +149,7 @@ export class PoDecimalComponent extends PoInputBaseComponent implements AfterVie
   }
 
   hasLetters(value: string = '') {
-    return value.match(/[a-zA-Z:;+=_´^~"'@#$%¨&*()/\\|]+/);
+    return value.match(/[a-zA-Z:;+=_´`^~"'?!@#$%¨&*()><{}çÇ\[\]/\\|]+/);
   }
 
   isValidNumber(event: any): boolean {


### PR DESCRIPTION
**PO-DECIMAL**

**DTHFUI-914**
_____________________________________________________________________________

**PR Checklist**

- [x] Código
- [x] Testes unitários
- [ ] Documentação
- [ ] Samples

**Qual o comportamento atual?**
O componente po-decimal aceita os caracteres "ç, [, ], {, }, !, ? e `".

**Qual o novo comportamento?**
O componente não aceita mais os valores citados acima.

**Simulação**
Utilizar qualquer um dos samples com o componente.