### PR TITLE
feat(page-list): traduz "busca avançada" com a linguagem utilizada no I18n

### DIFF
--- a/projects/ui/src/lib/components/po-page/po-page-list/po-page-list-base.component.spec.ts
+++ b/projects/ui/src/lib/components/po-page/po-page-list/po-page-list-base.component.spec.ts
@@ -1,6 +1,7 @@
 import { expectPropertiesValues } from '../../../util-test/util-expect.spec';
 import { poLocaleDefault } from './../../../utils/util';
 import * as UtilFunctions from './../../../utils/util';
+import { PoLanguageService } from './../../../services/po-language/po-language.service';
 
 import { PoDisclaimer } from '../../po-disclaimer/po-disclaimer.interface';
 
@@ -13,64 +14,70 @@ class PoPageListComponent extends PoPageListBaseComponent {
 }
 
 describe('PoPageListBaseComponent:', () => {
-  const component = new PoPageListComponent();
+  const languageService = new PoLanguageService();
+  const component = new PoPageListComponent(languageService);
 
   it('should be created', () => {
     expect(component instanceof PoPageListBaseComponent).toBeTruthy();
   });
 
   describe('Properties:', () => {
-    it('p-literals: should be in portuguese if browser is setted with an unsupported language', () => {
-      spyOn(UtilFunctions, <any>'browserLanguage').and.returnValue('ru');
 
-      component.literals = {};
+    describe('p-literals:', () => {
 
-      expect(component.literals).toEqual(poPageListLiteralsDefault[poLocaleDefault]);
-    });
+      it('should be in portuguese if `getShortLanguage` return an unsupported language.', () => {
+        component['language'] = 'ru';
 
-    it('p-literals: should be in portuguese if browser is setted with `pt`', () => {
-      spyOn(UtilFunctions, <any>'browserLanguage').and.returnValue('pt');
+        component.literals = {};
 
-      component.literals = {};
+        expect(component.literals).toEqual(poPageListLiteralsDefault[poLocaleDefault]);
+      });
 
-      expect(component.literals).toEqual(poPageListLiteralsDefault.pt);
-    });
+      it('should be in portuguese if `getShortLanguage` return `pt`.', () => {
+        component['language'] = 'pt';
 
-    it('p-literals: should be in english if browser is setted with `en`', () => {
-      spyOn(UtilFunctions, <any>'browserLanguage').and.returnValue('en');
+        component.literals = {};
 
-      component.literals = {};
+        expect(component.literals).toEqual(poPageListLiteralsDefault.pt);
+      });
 
-      expect(component.literals).toEqual(poPageListLiteralsDefault.en);
-    });
+      it('should be in english if `getShortLanguage` return `en`.', () => {
+        component['language'] = 'en';
 
-    it('p-literals: should be in spanish if browser is setted with `es`', () => {
-      spyOn(UtilFunctions, <any>'browserLanguage').and.returnValue('es');
+        component.literals = {};
 
-      component.literals = {};
+        expect(component.literals).toEqual(poPageListLiteralsDefault.en);
+      });
 
-      expect(component.literals).toEqual(poPageListLiteralsDefault.es);
-    });
+      it('should be in spanish if `getShortLanguage` return `es`.', () => {
+        component['language'] = 'es';
 
-    it('p-literals: should accept custom literals', () => {
-      spyOn(UtilFunctions, <any>'browserLanguage').and.returnValue(poLocaleDefault);
+        component.literals = {};
 
-      const customLiterals = poPageListLiteralsDefault[poLocaleDefault];
+        expect(component.literals).toEqual(poPageListLiteralsDefault.es);
+      });
 
-      // Custom some literals
-      customLiterals.otherActions = 'Other actions';
+      it('should accept custom literals.', () => {
+        spyOn(UtilFunctions, <any>'browserLanguage').and.returnValue(poLocaleDefault);
 
-      component.literals = customLiterals;
+        const customLiterals = poPageListLiteralsDefault[poLocaleDefault];
 
-      expect(component.literals).toEqual(customLiterals);
-    });
+        // Custom some literals
+        customLiterals.otherActions = 'Other actions';
 
-    it('p-literals: should update property with default literals if is setted with invalid values', () => {
-      const invalidValues = [null, undefined, false, true, '', 'literals', 0, 10, [], [1, 2], () => {}];
+        component.literals = customLiterals;
 
-      spyOn(UtilFunctions, <any>'browserLanguage').and.returnValue(poLocaleDefault);
+        expect(component.literals).toEqual(customLiterals);
+      });
 
-      expectPropertiesValues(component, 'literals', invalidValues, poPageListLiteralsDefault[poLocaleDefault]);
+      it('should update property with default literals if is setted with invalid values.', () => {
+        const invalidValues = [null, undefined, false, true, '', 'literals', 0, 10, [], [1, 2], () => {}];
+
+        component['language'] = poLocaleDefault;
+
+        expectPropertiesValues(component, 'literals', invalidValues, poPageListLiteralsDefault[poLocaleDefault]);
+      });
+
     });
 
     it('should return object when set disclaimerGroup with undefined', () => {

--- a/projects/ui/src/lib/components/po-page/po-page-list/po-page-list-base.component.ts
+++ b/projects/ui/src/lib/components/po-page/po-page-list/po-page-list-base.component.ts
@@ -1,6 +1,7 @@
 import { Input } from '@angular/core';
 
-import { browserLanguage, poLocaleDefault } from './../../../utils/util';
+import { poLocaleDefault } from './../../../utils/util';
+import { PoLanguageService } from './../../../services/po-language/po-language.service';
 
 import { PoBreadcrumb } from '../../po-breadcrumb/po-breadcrumb.interface';
 import { PoDisclaimerGroup } from '../../po-disclaimer-group/po-disclaimer-group.interface';
@@ -37,6 +38,9 @@ export abstract class PoPageListBaseComponent extends PoPageDefaultBaseComponent
 
   private _disclaimerGroup?: PoDisclaimerGroup;
   private _literals: PoPageListLiterals;
+
+  protected language: string;
+  protected resizeListener: () => void;
 
   /**
    * @optional
@@ -104,23 +108,28 @@ export abstract class PoPageListBaseComponent extends PoPageDefaultBaseComponent
    * </po-page-list>
    * ```
    *
-   *  > O objeto padrão de literais será traduzido de acordo com o idioma do browser (pt, en, es).
+   * > O valor padrão será traduzido de acordo com o idioma configurado no [`PoI18nService`](/documentation/po-i18n) ou *browser*.
    */
   @Input('p-literals') set literals(value: PoPageListLiterals) {
     if (value instanceof Object && !(value instanceof Array)) {
       this._literals = {
         ...poPageListLiteralsDefault[poLocaleDefault],
-        ...poPageListLiteralsDefault[browserLanguage()],
+        ...poPageListLiteralsDefault[this.language],
         ...value
       };
     } else {
-      this._literals = poPageListLiteralsDefault[browserLanguage()];
+      this._literals = poPageListLiteralsDefault[this.language];
     }
   }
+
   get literals() {
-    return this._literals || poPageListLiteralsDefault[browserLanguage()];
+    return this._literals || poPageListLiteralsDefault[this.language];
   }
 
-  protected resizeListener: () => void;
+  constructor(languageService: PoLanguageService) {
+    super();
+
+    this.language = languageService.getShortLanguage();
+  }
 
 }

--- a/projects/ui/src/lib/components/po-page/po-page-list/po-page-list.component.spec.ts
+++ b/projects/ui/src/lib/components/po-page/po-page-list/po-page-list.component.spec.ts
@@ -4,7 +4,6 @@ import { FormsModule, ReactiveFormsModule } from '@angular/forms';
 import { Router } from '@angular/router';
 import { RouterTestingModule } from '@angular/router/testing';
 
-import * as UtilFunctions from './../../../utils/util';
 import { changeBrowserInnerWidth, configureTestSuite } from '../../../util-test/util-expect.spec';
 
 import { PoBreadcrumbModule } from '../../po-breadcrumb/po-breadcrumb.module';
@@ -531,20 +530,26 @@ describe('PoPageListComponent - Desktop:', () => {
       expect(component.hasPageHeader()).toBe(false);
     });
 
-    it('initFixedLiterals: should return the advanced filter label by browser language.', () => {
-      const browserLanguage = spyOn(UtilFunctions, <any>'browserLanguage');
+    describe('initializeFixedLiterals:', () => {
 
-      browserLanguage.and.returnValue('pt');
+      it('should return the advanced filter label by `pt` language.', () => {
+        component['language'] = 'pt';
 
-      expect(component['initFixedLiterals']()).toBe('Busca avançada');
+        expect(component['initializeFixedLiterals']()).toBe('Busca avançada');
+      });
 
-      browserLanguage.and.returnValue('en');
+      it('should return the advanced filter label by `en` language.', () => {
+        component['language'] = 'en';
 
-      expect(component['initFixedLiterals']()).toBe('Advanced search');
+        expect(component['initializeFixedLiterals']()).toBe('Advanced search');
+      });
 
-      browserLanguage.and.returnValue('es');
+      it('should return the advanced filter label by `es` language.', () => {
+        component['language'] = 'es';
 
-      expect(component['initFixedLiterals']()).toBe('Búsqueda avanzada');
+        expect(component['initializeFixedLiterals']()).toBe('Búsqueda avanzada');
+      });
+
     });
 
   });

--- a/projects/ui/src/lib/components/po-page/po-page-list/po-page-list.component.ts
+++ b/projects/ui/src/lib/components/po-page/po-page-list/po-page-list.component.ts
@@ -3,10 +3,12 @@ import {
 } from '@angular/core';
 import { Router } from '@angular/router';
 
-import { browserLanguage, callFunction, isTypeof } from '../../../utils/util';
-import { PoPageAction } from '../po-page-action.interface';
-import { PoPageContentComponent } from '../po-page-content/po-page-content.component';
+import { callFunction, isTypeof } from '../../../utils/util';
+import { PoLanguageService } from './../../../services/po-language/po-language.service';
 
+import { PoPageAction } from '../po-page-action.interface';
+
+import { PoPageContentComponent } from '../po-page-content/po-page-content.component';
 import { PoPageListBaseComponent } from './po-page-list-base.component';
 
 /**
@@ -51,16 +53,17 @@ export class PoPageListComponent extends PoPageListBaseComponent implements Afte
 
   constructor(
     viewRef: ViewContainerRef,
+    languageService: PoLanguageService,
     public renderer: Renderer2,
     private router: Router) {
 
-    super();
+    super(languageService);
     this.parentRef = viewRef['_view']['component'];
     this.initializeListeners();
   }
 
   ngOnInit(): void {
-    this.advancedSearch = this.initFixedLiterals();
+    this.advancedSearch = this.initializeFixedLiterals();
   }
 
   ngAfterContentInit(): void {
@@ -123,24 +126,6 @@ export class PoPageListComponent extends PoPageListBaseComponent implements Afte
     this.callFunction(this.filter[field], this.parentRef);
   }
 
-  initFixedLiterals() {
-    const locale = browserLanguage();
-
-    const literal = {
-      pt: {
-        advancedSearch: 'Busca avançada'
-      },
-      en: {
-        advancedSearch: 'Advanced search'
-      },
-      es: {
-        advancedSearch: 'Búsqueda avanzada'
-      }
-    };
-
-    return literal[locale].advancedSearch;
-  }
-
   onkeypress(key) {
     if (key === 13) {
       this.callActionFilter('action');
@@ -161,6 +146,22 @@ export class PoPageListComponent extends PoPageListBaseComponent implements Afte
     if (this.disclaimerGroup && this.disclaimerGroup.change) {
       this.disclaimerGroup.change(disclaimers);
     }
+  }
+
+  private initializeFixedLiterals() {
+    const literal = {
+      pt: {
+        advancedSearch: 'Busca avançada'
+      },
+      en: {
+        advancedSearch: 'Advanced search'
+      },
+      es: {
+        advancedSearch: 'Búsqueda avanzada'
+      }
+    };
+
+    return literal[this.language].advancedSearch;
   }
 
   private initializeListeners() {

--- a/projects/ui/src/lib/components/po-page/po-page.module.ts
+++ b/projects/ui/src/lib/components/po-page/po-page.module.ts
@@ -8,6 +8,7 @@ import { PoButtonModule } from '../po-button/po-button.module';
 import { PoDisclaimerGroupModule } from '../po-disclaimer-group/po-disclaimer-group.module';
 import { PoDropdownModule } from '../po-dropdown/po-dropdown.module';
 import { PoFieldModule } from '../po-field/po-field.module';
+import { PoLanguageModule } from './../../services/po-language/po-language.module';
 import { PoModalModule } from './../po-modal/po-modal.module';
 import { PoPageComponent } from './po-page.component';
 import { PoPageContentComponent } from './po-page-content/po-page-content.component';
@@ -31,6 +32,7 @@ import { PoPageListComponent } from './po-page-list/po-page-list.component';
     PoDisclaimerGroupModule,
     PoDropdownModule,
     PoFieldModule,
+    PoLanguageModule,
     PoModalModule
   ],
   declarations: [

--- a/projects/ui/src/lib/components/po-progress/samples/sample-po-progress-publication/sample-po-progress-publication.component.ts
+++ b/projects/ui/src/lib/components/po-progress/samples/sample-po-progress-publication/sample-po-progress-publication.component.ts
@@ -2,23 +2,21 @@ import { Component } from '@angular/core';
 
 @Component({
   selector: 'sample-po-progress-publication',
-  templateUrl: './sample-po-progress-publication.component.html',
+  templateUrl: './sample-po-progress-publication.component.html'
 })
 export class SamplePoProgressPublicationComponent {
 
   buttonDisabled: boolean;
   progressBarValue = 0;
-
-  get progressBarInfo() {
-    return `${this.progressBarValue}/100`;
-  }
-
-  get publication() {
-    return `Lorem ipsum dolor sit amet, consectetur adipiscing elit. Quisque sodales, metus quis gravida dignissim, justo eros interdum
+  publication: string =
+    `Lorem ipsum dolor sit amet, consectetur adipiscing elit. Quisque sodales, metus quis gravida dignissim, justo eros interdum
     metus, lacinia mollis lorem nunc vel nibh. Donec odio turpis, malesuada quis enim eu, varius vulputate magna. Donec efficitur, nibh et
     ultricies lacinia, nunc metus viverra nisl, ut ultricies augue nibh nec nisi. Nunc elit arcu, auctor ac diam vel, tempus vehicula
     Pellentesque dignissim eros urna, nec vehicula nulla sagittis et. Aliquam nec elit justo. Curabitur sed consequat augue. Etiam ultrices
     lectus a mauris fringilla, sit amet imperdiet purus vulputate.`;
+
+  get progressBarInfo() {
+    return `${this.progressBarValue}/100`;
   }
 
   finishEdition() {


### PR DESCRIPTION
**PO-PAGE-LIST**

**DTHFUI-1563**

***

**PR Checklist**

- [x] Código
- [x] Testes unitários
- [x] Documentação
- [ ] Samples

***

**Qual o comportamento atual?**
O componente não traduz as literais de acordo com a linguagem definida no serviço I18N.

**Qual o novo comportamento?**
Implementado no componente o serviço `I18N` que busca a linguagem definida na aplicação, que agora passa traduzir as literais de acordo com essa linguagem retornada por este serviço.

**Simulação**
*Buildar* o projeto com a branch e, incluir nas dependências do Portal, definindo uma nova `language` nas definições do serviço de linguagem do mesmo.
