### PR TITLE
fix(datepicker): corrige foco no campo após selecionar data no mobile

### DIFF
--- a/projects/ui/src/lib/components/po-field/po-datepicker/po-datepicker.component.spec.ts
+++ b/projects/ui/src/lib/components/po-field/po-datepicker/po-datepicker.component.spec.ts
@@ -712,25 +712,46 @@ describe('PoDatepickerComponent:', () => {
       expect(component.formatToDate).not.toHaveBeenCalled();
     });
 
-    it('dateSelected: should set `calendar.visible` to false', () => {
-      component.calendar.visible = true;
+    describe('dateSelected:', () => {
 
-      spyOn(component, <any>'closeCalendar');
+      it('should set `calendar.visible` to false', () => {
+        component.calendar.visible = true;
 
-      component.dateSelected();
+        spyOn(component, <any>'closeCalendar');
 
-      expect(component['closeCalendar']).toHaveBeenCalled();
-    });
+        component.dateSelected();
 
-    it('dateSelected: should call `controlModel` and `controlChangeEmitter`', () => {
+        expect(component['closeCalendar']).toHaveBeenCalled();
+      });
 
-      spyOn(component, 'controlModel');
-      spyOn(component, <any>'controlChangeEmitter');
+      it('should call `controlModel` and `controlChangeEmitter`', () => {
+        spyOn(component, 'controlModel');
+        spyOn(component, <any>'controlChangeEmitter');
 
-      component.dateSelected();
+        component.dateSelected();
 
-      expect(component.controlModel).toHaveBeenCalled();
-      expect(component['controlChangeEmitter']).toHaveBeenCalled();
+        expect(component.controlModel).toHaveBeenCalled();
+        expect(component['controlChangeEmitter']).toHaveBeenCalled();
+      });
+
+      it('should call ´focus´ if ´verifyMobile´ returns ´false´.', () => {
+        spyOn(component, 'verifyMobile').and.returnValue(<any> false);
+        const spyInputFocus = spyOn(component.inputEl.nativeElement, 'focus');
+
+        component.dateSelected();
+
+        expect(spyInputFocus).toHaveBeenCalled();
+      });
+
+      it('shouldn´t call ´focus´ if ´verifyMobile´ returns ´true´.', () => {
+        spyOn(component, 'verifyMobile').and.returnValue(<any> true);
+        const spyInputFocus = spyOn(component.inputEl.nativeElement, 'focus');
+
+        component.dateSelected();
+
+        expect(spyInputFocus).not.toHaveBeenCalled();
+      });
+
     });
 
     it('formatToDate: should call `formatYear` with date year', () => {

--- a/projects/ui/src/lib/components/po-field/po-datepicker/po-datepicker.component.ts
+++ b/projects/ui/src/lib/components/po-field/po-datepicker/po-datepicker.component.ts
@@ -121,7 +121,10 @@ export class PoDatepickerComponent extends PoDatepickerBaseComponent implements 
   }
 
   dateSelected() {
-    this.inputEl.nativeElement.focus();
+    if (!this.verifyMobile()) {
+      this.inputEl.nativeElement.focus();
+    }
+
     this.inputEl.nativeElement.value = this.formatToDate(this.date);
     this.controlModel(this.date);
     this.controlChangeEmitter();


### PR DESCRIPTION
**PO-DATEPICKER**

**Fixes DTHFUI-1495**

***

**PR Checklist**

- [x] Código
- [x] Testes unitários
- [ ] Documentação
- [ ] Samples

***

**Qual o comportamento atual?**
Ao selecionar uma data no `po-datepicker` em modo mobile, o mesmo retorna o foco para o campo, abrindo caixa de texto do dispositivo móvel, fazendo com que o usuário sempre tenha que realizar o *blur* para fechar a caixa de texto.

**Qual o novo comportamento?**
Agora ao selecionar uma data no componente `po-datepicker` em modo mobile, o *overlay* do calendário é fechado e não abre a caixa de texto, possibilitando que o usuário tenha uma experiencia mais amigável.

**Simulação**
Utilizar os *samples*.