### PR TITLE
feat(upload): exibir informações referente as restrições dos arquivos

### DIFF
--- a/projects/ui/src/lib/components/po-field/po-field.module.ts
+++ b/projects/ui/src/lib/components/po-field/po-field.module.ts
@@ -36,6 +36,7 @@ import { PoPasswordComponent } from './po-password/po-password.component';
 import { PoRadioGroupComponent } from './po-radio-group/po-radio-group.component';
 import { PoSelectComponent } from './po-select/po-select.component';
 import { PoSelectOptionTemplateDirective } from './po-select/po-select-option-template/po-select-option-template.directive';
+import { PoServicesModule } from '../../services/services.module';
 import { PoSwitchComponent } from './po-switch/po-switch.component';
 import { PoTextareaComponent } from './po-textarea/po-textarea.component';
 import { PoUploadComponent } from './po-upload/po-upload.component';
@@ -45,6 +46,7 @@ import {
   PoUploadDragDropAreaOverlayComponent
 } from './po-upload/po-upload-drag-drop/po-upload-drag-drop-area-overlay/po-upload-drag-drop-area-overlay.component';
 import { PoUploadDragDropAreaComponent } from './po-upload/po-upload-drag-drop/po-upload-drag-drop-area/po-upload-drag-drop-area.component';
+import { PoUploadFileRestrictionsComponent } from './po-upload/po-upload-file-restrictions/po-upload-file-restrictions.component';
 import { PoUrlComponent } from './po-url/po-url.component';
 
 /**
@@ -58,12 +60,13 @@ import { PoUrlComponent } from './po-url/po-url.component';
     CommonModule,
     FormsModule,
     HttpClientModule,
+    PoButtonGroupModule,
     PoButtonModule,
     PoDisclaimerModule,
     PoLoadingModule,
     PoModalModule,
+    PoServicesModule,
     PoTableModule,
-    PoButtonGroupModule
   ],
   exports: [
     PoCheckboxGroupComponent,
@@ -123,6 +126,7 @@ import { PoUrlComponent } from './po-url/po-url.component';
     PoUploadDragDropDirective,
     PoUploadDragDropAreaOverlayComponent,
     PoUploadDragDropAreaComponent,
+    PoUploadFileRestrictionsComponent,
     PoUrlComponent
   ],
   providers: [],

--- a/projects/ui/src/lib/components/po-field/po-upload/interfaces/po-upload-file-restriction.interface.ts
+++ b/projects/ui/src/lib/components/po-field/po-upload/interfaces/po-upload-file-restriction.interface.ts
@@ -3,34 +3,40 @@
  *
  * @description
  *
- * Os arquivos a serem selecionados podem ser restritos com base em regras pré definidas
- * para o seu tamanho e / ou extensão.
+ * Interface que define as restrições dos arquivos a serem selecionados com base em regras predefinidas
+ * para o seu tamanho, extensão e quantidade.
  */
 export interface PoUploadFileRestrictions {
 
   /**
-   * Tamanho minimo do arquivo a ser enviado ao servidor. Deve ser informado o valor em bytes.
-   * Por padrão o valor é 0.
+   * Extensões permitidas de arquivos que serão enviados ao servidor, devendo ser informada uma coleção de extensões, por exemplo:
+   * ```
+   *  allowedExtensions = ['.png', '.jpg', '.pdf'];
+   * ```
    */
-  minFileSize?: number;
+  allowedExtensions?: Array<string>;
 
   /**
    * Quantidade máxima de arquivos para o *upload*.
-   * Este valor deve ser maior que zero, caso contrário será desconsiderado e a funcionalidade não será habilitada.
    *
-   * > Esta propriedade somente será válida se a propriedade `p-multiple` estiver habilitada.
+   * > Esta propriedade será válida somente se a propriedade `p-multiple` estiver habilitada e seu valor for maior do que zero.
    */
   maxFiles?: number;
 
   /**
-   * Tamanho máximo do arquivo a ser enviado ao servidor. Deve ser informado o valor em bytes,
-   * Por exemplo: 31457280 (30MB).
+   * Tamanho máximo do arquivo a ser enviado ao servidor.
+   *
+   * Deve ser informado um valor em *bytes*, por exemplo: `31457280` (30MB).
+   *
+   * > Por padrão o valor é `30 MB`.
    */
   maxFileSize?: number;
 
   /**
-   * Extensões permitidas a serem enviadas ao servidor, deve ser informado uma coleção de extensões.
-   * Exemplo de valores válidos: ['.png', '.jpg', '.pdf'].
+   * Tamanho mínimo em *bytes* do arquivo que será enviado ao servidor.
+   *
+   * > Por padrão o valor é `0`.
    */
-  allowedExtensions?: Array<string>;
+  minFileSize?: number;
+
 }

--- a/projects/ui/src/lib/components/po-field/po-upload/po-upload-drag-drop/po-upload-drag-drop.directive.ts
+++ b/projects/ui/src/lib/components/po-field/po-upload/po-upload-drag-drop/po-upload-drag-drop.directive.ts
@@ -2,6 +2,7 @@ import { Directive, EventEmitter, HostListener, Input, Output } from '@angular/c
 
 import { PoNotificationService } from '../../../../services/po-notification/po-notification.service';
 import { PoUploadLiterals } from '../interfaces/po-upload-literals.interface';
+import { PoUploadFileRestrictions } from '../interfaces/po-upload-file-restriction.interface';
 
 @Directive({
   selector: '[p-upload-drag-drop]'

--- a/projects/ui/src/lib/components/po-field/po-upload/po-upload-file-restrictions/po-upload-file-restrictions.component.html
+++ b/projects/ui/src/lib/components/po-field/po-upload/po-upload-file-restrictions/po-upload-file-restrictions.component.html
@@ -1,0 +1,23 @@
+<p class="po-font-text-small" *ngIf="maxFiles > 1">
+  {{ literals?.numberOfFilesAllowed | poI18n:maxFiles }}
+</p>
+
+<p class="po-font-text-small" *ngIf="allowedExtensions">
+  {{ literals?.allowedFormats | poI18n:allowedExtensions }}
+</p>
+
+<p class="po-font-text-small" *ngIf="minFileSize || maxFileSize">
+  <span>{{ literals?.allowedSizes }}</span>
+
+  <span *ngIf="minFileSize && maxFileSize">
+    {{ literals?.allowedFileSizeRange | poI18n:[minFileSize, maxFileSize] }}
+  </span>
+
+  <span *ngIf="minFileSize && !maxFileSize">
+    {{ literals?.minFileSizeAllowed | poI18n:minFileSize }}
+  </span>
+
+  <span *ngIf="maxFileSize && !minFileSize">
+    {{ literals?.maxFileSizeAllowed | poI18n:maxFileSize }}
+  </span>
+</p>

--- a/projects/ui/src/lib/components/po-field/po-upload/po-upload-file-restrictions/po-upload-file-restrictions.component.spec.ts
+++ b/projects/ui/src/lib/components/po-field/po-upload/po-upload-file-restrictions/po-upload-file-restrictions.component.spec.ts
@@ -1,0 +1,246 @@
+import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import { ChangeDetectorRef } from '@angular/core';
+
+import * as UtilsFunctions from './../../../../utils/util';
+import { expectSettersMethod } from './../../../../util-test/util-expect.spec';
+import { poLocaleDefault } from './../../../../utils/util';
+import { PoServicesModule } from './../../../../services/services.module';
+
+import { PoUploadFileRestrictionsComponent } from './po-upload-file-restrictions.component';
+import { poUploadLiteralsDefault } from '../po-upload-base.component';
+
+describe('PoUploadFileRestrictionsComponent:', () => {
+  let changeDetector: any;
+  let component: PoUploadFileRestrictionsComponent;
+  let fixture: ComponentFixture<PoUploadFileRestrictionsComponent>;
+  let nativeElement: any;
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      declarations: [ PoUploadFileRestrictionsComponent ],
+      imports: [ PoServicesModule ]
+    })
+    .compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(PoUploadFileRestrictionsComponent);
+    component = fixture.componentInstance;
+
+    nativeElement = fixture.debugElement.nativeElement;
+    changeDetector = fixture.componentRef.injector.get(ChangeDetectorRef);
+
+    spyOn(UtilsFunctions, 'browserLanguage').and.returnValue('en');
+  });
+
+  it('should be created', () => {
+    expect(component).toBeTruthy();
+  });
+
+  describe('Properties:', () => {
+
+    it('allowedExtensions: should set `allowedExtensions` with `png and jpg`', () => {
+      const extensions = ['png', 'jpg'];
+      const expected = 'PNG and JPG';
+
+      expectSettersMethod(component, 'allowedExtensions', extensions, 'allowedExtensions', expected);
+    });
+
+    it('maxFileSize: should set `maxFileSize` with `30 MB`', () => {
+      expectSettersMethod(component, 'maxFileSize', 31457280, 'maxFileSize', '30 MB');
+    });
+
+    it('minFileSize: should set `minFileSize` with `30 MB`', () => {
+      expectSettersMethod(component, 'minFileSize', 31457280, 'minFileSize', '30 MB');
+    });
+
+  });
+
+  describe('Methods:', () => {
+
+    it('ngOnInit: should call `setLiterals`', () => {
+      spyOn(component, <any>'setLiterals');
+
+      component.ngOnInit();
+
+      expect(component['setLiterals']).toHaveBeenCalled();
+    });
+
+    it('formatAllowedExtensions: should return undefined if `allowedExtensions` is undefined', () => {
+      const allowedExtensions = undefined;
+
+      expect(component['formatAllowedExtensions'](allowedExtensions)).toBeUndefined();
+    });
+
+    it('formatAllowedExtensions: should return `PNG, JPG and SVG` if allowedExtensions is `png,jpg and svg`', () => {
+      const allowedExtensions = [ 'png', 'jpg', 'svg' ];
+
+      spyOnProperty(component, 'language').and.returnValue('en');
+
+      expect(component['formatAllowedExtensions'](allowedExtensions)).toBe('PNG, JPG and SVG');
+    });
+
+    it('formatAllowedExtensions: should return `PNG and JPG` if allowedExtensions is `png and jpg`', () => {
+      const allowedExtensions = [ 'png', 'jpg' ];
+
+      spyOnProperty(component, 'language').and.returnValue('en');
+
+      expect(component['formatAllowedExtensions'](allowedExtensions)).toBe('PNG and JPG');
+    });
+
+    it('formatAllowedExtensions: should return `PNG e JPG` if allowedExtensions is `png and jpg` and `language` is `pt`', () => {
+      const allowedExtensions = [ 'png', 'jpg' ];
+
+      spyOnProperty(component, 'language').and.returnValue('pt');
+
+      expect(component['formatAllowedExtensions'](allowedExtensions)).toBe('PNG e JPG');
+    });
+
+    it('formatAllowedExtensions: should return `PNG y JPG` if allowedExtensions is `png and jpg` and `language` is `es`', () => {
+      const allowedExtensions = [ 'png', 'jpg' ];
+
+      spyOnProperty(component, 'language').and.returnValue('es');
+
+      expect(component['formatAllowedExtensions'](allowedExtensions)).toBe('PNG y JPG');
+    });
+
+    it('formatAllowedExtensions: should return `PNG` if allowedExtensions is `png`', () => {
+      const allowedExtensions = [ 'png' ];
+
+      expect(component['formatAllowedExtensions'](allowedExtensions)).toBe('PNG');
+    });
+
+    it('formatAllowedExtensions: should return empty string if allowedExtensions is empty array', () => {
+      const allowedExtensions = [];
+
+      expect(component['formatAllowedExtensions'](allowedExtensions)).toBe('');
+    });
+
+    it('setLiterals: should set `literals` with `poUploadLiteralsDefault`', () => {
+      component.literals = undefined;
+
+      spyOnProperty(component, 'language').and.returnValue('en');
+
+      component['setLiterals']();
+
+      expect(component.literals).toEqual(poUploadLiteralsDefault['en']);
+    });
+
+    it('setLiterals: should set `literals` with `poUploadLiteralsDefault` and `poLocaleDefault`', () => {
+      component.literals = undefined;
+
+      spyOnProperty(component, 'language').and.returnValue('');
+
+      component['setLiterals']();
+
+      expect(component.literals).toEqual(poUploadLiteralsDefault[poLocaleDefault]);
+    });
+
+    it('setLiterals: should call `detectChanges`', () => {
+      spyOn(component['changeDetector'], 'detectChanges');
+
+      component['setLiterals']();
+
+      expect(component['changeDetector'].detectChanges).toHaveBeenCalled();
+    });
+
+  });
+
+  describe('Templates:', () => {
+
+    it('should contain `numberOfFilesAllowed` if `maxFiles` is greater than 1', () => {
+      component.maxFiles = 2;
+      const numberOfFilesAllowed = '2 file(s) allowed';
+
+      component['setLiterals']();
+
+      changeDetector.detectChanges();
+
+      const text = nativeElement.querySelector('.po-font-text-small').textContent;
+
+      expect(text).toContain(numberOfFilesAllowed);
+    });
+
+    it('shouldn`t contain a text if `maxFiles` is 1', () => {
+      component.maxFiles = 1;
+
+      component['setLiterals']();
+
+      changeDetector.detectChanges();
+
+      const text = nativeElement.querySelector('.po-font-text-small');
+
+      expect(text).toBeFalsy();
+    });
+
+    it('should contain `allowedFormats` if `allowedExtensions` is defined', () => {
+      spyOnProperty(component, 'language').and.returnValue('en');
+      component.allowedExtensions = <any> ['png', 'jpg'];
+      const allowedExtensions = 'Accepted file formats: PNG and JPG.';
+
+      component['setLiterals']();
+
+      changeDetector.detectChanges();
+
+      const text = nativeElement.querySelector('.po-font-text-small').textContent;
+
+      expect(text).toContain(allowedExtensions);
+    });
+
+    it('shouldn`t contain text if allowedExtensions is undefined', () => {
+      component.allowedExtensions = undefined;
+
+      component['setLiterals']();
+
+      changeDetector.detectChanges();
+
+      const text = nativeElement.querySelector('.po-font-text-small');
+
+      expect(text).toBeFalsy();
+    });
+
+    it('should contain `allowedFileSizeRange` if `minFileSize` and `maxFileSize` are defined', () => {
+      component.minFileSize = <any>1048576;
+      component.maxFileSize = <any>20971520;
+      const allowedFileSizeRange = 'Size limit per file: from 1 MB to 20 MB';
+
+      component['setLiterals']();
+
+      changeDetector.detectChanges();
+
+      const text = nativeElement.querySelector('.po-font-text-small').textContent;
+
+      expect(text).toContain(allowedFileSizeRange);
+    });
+
+    it('should contain `minFileSizeAllowed` if `minFileSize` is defined and `maxFileSize` is undefined', () => {
+      component.minFileSize = <any>1048576;
+      const minFileSizeAllowed = 'Size limit per file: 1 MB minimum';
+      spyOnProperty(component, 'language').and.returnValue('en');
+
+      component['setLiterals']();
+
+      changeDetector.detectChanges();
+
+      const text = nativeElement.querySelector('.po-font-text-small').textContent;
+
+      expect(text).toContain(minFileSizeAllowed);
+    });
+
+    it('should contain `maxFileSizeAllowed` if `minFileSize` is undefined and `maxFileSize` is defined', () => {
+      component.maxFileSize = <any>1048576;
+      const maxFileSizeAllowed = 'Size limit per file: 1 MB maximum';
+      spyOnProperty(component, 'language').and.returnValue('en');
+
+      component['setLiterals']();
+
+      changeDetector.detectChanges();
+
+      const text = nativeElement.querySelector('.po-font-text-small').textContent;
+
+      expect(text).toContain(maxFileSizeAllowed);
+    });
+
+  });
+
+});

--- a/projects/ui/src/lib/components/po-field/po-upload/po-upload-file-restrictions/po-upload-file-restrictions.component.ts
+++ b/projects/ui/src/lib/components/po-field/po-upload/po-upload-file-restrictions/po-upload-file-restrictions.component.ts
@@ -1,0 +1,74 @@
+import { ChangeDetectionStrategy, ChangeDetectorRef, Component, Input, OnInit } from '@angular/core';
+
+import { browserLanguage, formatBytes, poLocaleDefault } from '../../../../utils/util';
+
+import { poUploadLiteralsDefault } from '../po-upload-base.component';
+
+@Component({
+  selector: 'po-upload-file-restrictions',
+  templateUrl: './po-upload-file-restrictions.component.html',
+  changeDetection: ChangeDetectionStrategy.OnPush
+})
+export class PoUploadFileRestrictionsComponent implements OnInit {
+
+  private _allowedExtensions: string;
+  private _maxFileSize: string;
+  private  _minFileSize: string;
+
+  literals: any;
+
+  @Input('p-allowed-extensions') set allowedExtensions(value) {
+    this._allowedExtensions = this.formatAllowedExtensions(<any>value);
+  }
+
+  get allowedExtensions(): string {
+    return this._allowedExtensions;
+  }
+
+  @Input('p-max-files') maxFiles: number;
+
+  @Input('p-max-file-size') set maxFileSize(value) {
+    this._maxFileSize = formatBytes(<any>value);
+  }
+
+  get maxFileSize(): string {
+    return this._maxFileSize;
+  }
+
+  @Input('p-min-file-size') set minFileSize(value) {
+    this._minFileSize = formatBytes(<any>value);
+  }
+
+  get minFileSize(): string {
+    return this._minFileSize;
+  }
+
+  get language(): string {
+    return browserLanguage();
+  }
+
+  constructor(private changeDetector: ChangeDetectorRef) { }
+
+  ngOnInit() {
+    this.setLiterals();
+  }
+
+  private formatAllowedExtensions(allowedExtensions: Array<string>): string {
+    const conjunction = { 'pt': 'e', 'en': 'and', 'es': 'y' };
+
+    return allowedExtensions ? allowedExtensions
+      .join(', ')
+      .toUpperCase()
+      .replace(/,(?=[^,]*$)/, ` ${conjunction[this.language]}`) : undefined;
+  }
+
+  private setLiterals() {
+    this.literals = {
+      ...poUploadLiteralsDefault[poLocaleDefault],
+      ...poUploadLiteralsDefault[this.language],
+    };
+
+    this.changeDetector.detectChanges();
+  }
+
+}

--- a/projects/ui/src/lib/components/po-field/po-upload/po-upload.component.html
+++ b/projects/ui/src/lib/components/po-field/po-upload/po-upload.component.html
@@ -31,6 +31,15 @@
       (p-click)="selectFiles()">
     </po-button>
 
+    <po-upload-file-restrictions *ngIf="fileRestrictions && !hideRestrictionsInfo"
+      class="po-upload-file-restrictions"
+      [ngClass]="{'po-upload-file-restrictions-drag-drop' : displayDragDrop}"
+      [p-allowed-extensions]="fileRestrictions?.allowedExtensions"
+      [p-max-files]="maxFiles"
+      [p-max-file-size]="fileRestrictions?.maxFileSize"
+      [p-min-file-size]="fileRestrictions?.minFileSize">
+    </po-upload-file-restrictions>
+
     <div class="po-upload-progress" *ngFor="let file of currentFiles" [id]="file.uid">
       <div class="po-upload-progress-status"></div>
       <div class="po-upload-filename-foreground">

--- a/projects/ui/src/lib/components/po-field/po-upload/samples/sample-po-upload-labs/sample-po-upload-labs.component.html
+++ b/projects/ui/src/lib/components/po-field/po-upload/samples/sample-po-upload-labs/sample-po-upload-labs.component.html
@@ -8,6 +8,7 @@
   [p-form-field]="formField"
   [p-help]="help"
   [p-hide-select-button]="properties.includes('selectButton')"
+  [p-hide-restrictions-info]="properties.includes('restrictionsInfo')"
   [p-hide-send-button]="properties.includes('sendButton')"
   [p-label]="label"
   [p-literals]="customLiterals"
@@ -141,7 +142,7 @@
       class="po-md-12"
       name="literals"
       [(ngModel)]="literals"
-      p-help='Ex.: {"selectFile": "Select file", "deleteFile": "Delete file", "cancel": "Cancel sending "}'
+      p-help='Ex.: {"selectFile": "Select file", "deleteFile": "Delete file", "cancel": "Cancel sending"}'
       p-label="Literals"
       (p-change)="changeLiterals()">
     </po-input>

--- a/projects/ui/src/lib/components/po-field/po-upload/samples/sample-po-upload-labs/sample-po-upload-labs.component.ts
+++ b/projects/ui/src/lib/components/po-field/po-upload/samples/sample-po-upload-labs/sample-po-upload-labs.component.ts
@@ -31,6 +31,7 @@ export class SamplePoUploadLabsComponent implements OnInit {
     { value: 'multiple', label: 'Multiple upload' },
     { value: 'optional', label: 'Optional' },
     { value: 'required', label: 'Required' },
+    { value: 'restrictionsInfo', label: 'Hide Restrictions Info' },
     { value: 'selectButton', label: 'Hide Select Files Button' },
     { value: 'sendButton', label: 'Hide Send Files Button' }
   ];

--- a/projects/ui/src/lib/components/po-field/po-upload/samples/sample-po-upload-resume-drag-drop/sample-po-upload-resume-drag-drop.component.html
+++ b/projects/ui/src/lib/components/po-field/po-upload/samples/sample-po-upload-resume-drag-drop/sample-po-upload-resume-drag-drop.component.html
@@ -37,11 +37,10 @@
       [(ngModel)]="resume"
       p-drag-drop
       p-drag-drop-height="160"
-      p-help="Maximum file size limit: 200kb"
       p-label="Resume"
       p-required
-      p-restrictions="{maxSize: 200}"
       p-url="https://thf.totvs.com.br/sample/api/uploads/addFile"
+      p-restrictions="{maxFileSize: '204800'}"
       (p-error)="resumeUploadError()"
       (p-success)="resumeUploadSuccess()">
     </po-upload>

--- a/projects/ui/src/lib/components/po-field/po-upload/samples/sample-po-upload-resume/sample-po-upload-resume.component.html
+++ b/projects/ui/src/lib/components/po-field/po-upload/samples/sample-po-upload-resume/sample-po-upload-resume.component.html
@@ -35,11 +35,10 @@
       class="po-md-12"
       name="resume"
       [(ngModel)]="resume"
-      p-help="Maximum file size limit: 200kb"
       p-label="Resume"
       p-required
-      p-restrictions="{maxSize: 200}"
       p-url="https://thf.totvs.com.br/sample/api/uploads/addFile"
+      [p-restrictions]="{maxFileSize: '204800'}"
       (p-error)="resumeUploadError()"
       (p-success)="resumeUploadSuccess()">
     </po-upload>

--- a/projects/ui/src/lib/utils/util.spec.ts
+++ b/projects/ui/src/lib/utils/util.spec.ts
@@ -51,6 +51,77 @@ describe('Function browserLanguage:', () => {
   });
 });
 
+describe('Function formatBytes:', () => {
+  it('formatBytes: should return undefined if bytes is undefined', () => {
+    const bytes = undefined;
+
+    expect(UtilFunctions.formatBytes(bytes)).toBeUndefined();
+  });
+
+  it('formatBytes: should return `2 Bytes` if bytes is 2', () => {
+    const bytes = 2;
+
+    expect(UtilFunctions.formatBytes(bytes)).toBe('2 Bytes');
+  });
+
+  it('formatBytes: should return `12.567 Bytes` if bytes is 12.5666666 and decimals is 3', () => {
+    const bytes = 12.5666666;
+    const decimals = 3;
+
+    expect(UtilFunctions.formatBytes(bytes, decimals)).toBe('12.567 Bytes');
+  });
+
+  it('formatBytes: should return `12.57 Bytes` if bytes is 12.5666666 and decimals is undefined', () => {
+    const bytes = 12.5666666;
+
+    expect(UtilFunctions.formatBytes(bytes)).toBe('12.57 Bytes');
+  });
+
+  it('formatBytes: should return `13 Bytes` if bytes is 12.5666666 and decimals is -1', () => {
+    const bytes = 12.5666666;
+    const decimals = -1;
+
+    expect(UtilFunctions.formatBytes(bytes, decimals)).toBe('13 Bytes');
+  });
+
+  it('formatBytes: should return `30 MB` if bytes is 31457280', () => {
+    const bytes = 31457280;
+
+    expect(UtilFunctions.formatBytes(bytes)).toBe('30 MB');
+  });
+
+  it('formatBytes: should return `20 GB` if bytes is 21474836480', () => {
+    const bytes = 21474836480;
+
+    expect(UtilFunctions.formatBytes(bytes)).toBe('20 GB');
+  });
+
+  it('formatBytes: should return `10 KB` if bytes is 10240', () => {
+    const bytes = 10240;
+
+    expect(UtilFunctions.formatBytes(bytes)).toBe('10 KB');
+  });
+
+  it('formatBytes: should return `23 TB` if bytes is 25288767438848', () => {
+    const bytes = 25288767438848;
+
+    expect(UtilFunctions.formatBytes(bytes)).toBe('23 TB');
+  });
+
+  it('formatBytes: should return `15 PB` if bytes is 16888498602639360', () => {
+    const bytes = 16888498602639360;
+
+    expect(UtilFunctions.formatBytes(bytes)).toBe('15 PB');
+  });
+
+  it('formatBytes: should return `2 EB` if bytes is 2305843009213694000', () => {
+    const bytes = 2305843009213694000;
+
+    expect(UtilFunctions.formatBytes(bytes)).toBe('2 EB');
+  });
+
+});
+
 describe('Function getBrowserLanguage:', () => {
 
   it('should return the value of `navigator.language` if it`s defined', () => {

--- a/projects/ui/src/lib/utils/util.ts
+++ b/projects/ui/src/lib/utils/util.ts
@@ -15,6 +15,31 @@ export function browserLanguage() {
 }
 
 /**
+ * Converte e formata os bytes em formato mais legível para o usuário.
+ *
+ * Por exemplo:
+ * - 31457280 em 30 MB.
+ * - 21474836480 em 20 GB.
+ * - 12.5666666 em 12.57 Bytes (duas casas decimais).
+ *
+ * @param bytes {number} Valor em bytes
+ * @param decimals {number} Quantidade de casas decimais que terá após a conversão.
+ */
+export function formatBytes(bytes: number, decimals = 2): string {
+
+  if (!bytes) {
+    return undefined;
+  }
+
+  const multiplier = 1024;
+  const sizes = ['Bytes', 'KB', 'MB', 'GB', 'TB', 'PB', 'EB', 'ZB', 'YB'];
+  const result = Math.floor(Math.log(bytes) / Math.log(multiplier));
+  decimals = decimals < 0 ? 0 : decimals;
+
+  return `${parseFloat((bytes / Math.pow(multiplier, result)).toFixed(decimals))} ${sizes[result]}`;
+}
+
+/**
  * Retorna o idioma atual do navegador
  */
 export function getBrowserLanguage(): string {


### PR DESCRIPTION
**PO UPLOAD**

**DTHFUI-788**
_____________________________________________________________________________

**PR Checklist**

- [x] Código
- [x] Testes unitários
- [x] Documentação
- [x] Samples

**Qual o comportamento atual?**
Não são exibidas as informações referente às restrições dos arquivos e nem notificação caso o arquivo esteja inválido por formato, tamanho ou quantidade.

**Qual o novo comportamento?**
São exibidas as restrições via texto fixo, abaixo da area de drag drop e o botão de selecionar arquivo.
São exibidas notificações informando as restrições ao selecionar arquivos inválidos por formato, tamanho ou quantidade.

**Simulação**
Buildar o projeto com esta _branch_ e executar no portal.