### PR TITLE
feat(fields): implementa método que habilita foco nos componentes

### DIFF
--- a/projects/ui/src/lib/components/po-button/po-button.component.html
+++ b/projects/ui/src/lib/components/po-button/po-button.component.html
@@ -1,4 +1,5 @@
 <button
+  #button
   class="po-button po-text-ellipsis"
   type="button"
   [class.po-button-danger]="type === 'danger'"

--- a/projects/ui/src/lib/components/po-button/po-button.component.spec.ts
+++ b/projects/ui/src/lib/components/po-button/po-button.component.spec.ts
@@ -130,6 +130,24 @@ describe('PoButtonComponent: ', () => {
 
   });
 
+  describe('Methods:', () => {
+
+    it('focus: should call `focus` of button', () => {
+      component.buttonElement = {
+        nativeElement: {
+          focus: () => {}
+        }
+      };
+
+      spyOn(component.buttonElement.nativeElement, 'focus');
+
+      component.focus();
+
+      expect(component.buttonElement.nativeElement.focus).toHaveBeenCalled();
+    });
+
+  });
+
   describe('Templates: ', () => {
 
     describe('Loading: ', () => {

--- a/projects/ui/src/lib/components/po-button/po-button.component.spec.ts
+++ b/projects/ui/src/lib/components/po-button/po-button.component.spec.ts
@@ -146,6 +146,21 @@ describe('PoButtonComponent: ', () => {
       expect(component.buttonElement.nativeElement.focus).toHaveBeenCalled();
     });
 
+    it('focus: should`t call `focus` of button if `disabled`', () => {
+      component.buttonElement = {
+        nativeElement: {
+          focus: () => {}
+        }
+      };
+      component.disabled = true;
+
+      spyOn(component.buttonElement.nativeElement, 'focus');
+
+      component.focus();
+
+      expect(component.buttonElement.nativeElement.focus).not.toHaveBeenCalled();
+    });
+
   });
 
   describe('Templates: ', () => {

--- a/projects/ui/src/lib/components/po-button/po-button.component.ts
+++ b/projects/ui/src/lib/components/po-button/po-button.component.ts
@@ -31,9 +31,25 @@ export class PoButtonComponent extends PoButtonBaseComponent {
 
   /**
    * Função que atribui foco ao componente.
+   *
+   * Para utilizá-la é necessário ter a instância do componente no DOM, podendo ser utilizado o ViewChild da seguinte forma:
+   *
+   * ```
+   * import { PoButtonComponent } from '@portinari/portinari-ui';
+   *
+   * ...
+   *
+   * @ViewChild(PoButtonComponent, { static: true }) button: PoButtonComponent;
+   *
+   * focusButton() {
+   *   this.button.focus();
+   * }
+   * ```
    */
   focus(): void {
-    this.buttonElement.nativeElement.focus();
+    if (!this.disabled) {
+      this.buttonElement.nativeElement.focus();
+    }
   }
 
   onClick() {

--- a/projects/ui/src/lib/components/po-button/po-button.component.ts
+++ b/projects/ui/src/lib/components/po-button/po-button.component.ts
@@ -1,4 +1,4 @@
-import { Component } from '@angular/core';
+import { Component, ElementRef, ViewChild } from '@angular/core';
 
 import { PoButtonBaseComponent } from './po-button-base.component';
 
@@ -26,6 +26,15 @@ import { PoButtonBaseComponent } from './po-button-base.component';
   templateUrl: './po-button.component.html'
 })
 export class PoButtonComponent extends PoButtonBaseComponent {
+
+  @ViewChild('button', { static: true }) buttonElement: ElementRef;
+
+  /**
+   * Função que atribui foco ao componente.
+   */
+  focus(): void {
+    this.buttonElement.nativeElement.focus();
+  }
 
   onClick() {
     this.click.emit(null);

--- a/projects/ui/src/lib/components/po-field/po-checkbox-group/po-checkbox-group.component.spec.ts
+++ b/projects/ui/src/lib/components/po-field/po-checkbox-group/po-checkbox-group.component.spec.ts
@@ -105,6 +105,47 @@ describe('PoCheckboxGroupComponent:', () => {
 
   describe('Methods:', () => {
 
+    it('focus: should call `focus` of checkbox', () => {
+      component.options = [{ label: 'teste1', value: 'teste1' }, { label: 'teste2', value: 'teste2' }];
+
+      fixture.detectChanges();
+
+      spyOn(component.checkboxLabels.toArray()[0].nativeElement, 'focus');
+
+      component.focus();
+
+      expect(component.checkboxLabels.toArray()[0].nativeElement.focus).toHaveBeenCalled();
+    });
+
+    it('focus: should`t call `focus` of checkbox if option is `disabled`', () => {
+      component.options = [{ label: 'teste1', value: 'teste1', disabled: true }, { label: 'teste2', value: 'teste2' }];
+
+      fixture.detectChanges();
+
+      spyOn(component.checkboxLabels.toArray()[0].nativeElement, 'focus');
+      spyOn(component.checkboxLabels.toArray()[1].nativeElement, 'focus');
+
+      component.focus();
+
+      expect(component.checkboxLabels.toArray()[0].nativeElement.focus).not.toHaveBeenCalled();
+      expect(component.checkboxLabels.toArray()[1].nativeElement.focus).toHaveBeenCalled();
+    });
+
+    it('focus: should`t call `focus` of checkbox if `disabled`', () => {
+      component.options = [{ label: 'teste1', value: 'teste1', disabled: true }, { label: 'teste2', value: 'teste2' }];
+      component.disabled = true;
+
+      fixture.detectChanges();
+
+      spyOn(component.checkboxLabels.toArray()[0].nativeElement, 'focus');
+      spyOn(component.checkboxLabels.toArray()[1].nativeElement, 'focus');
+
+      component.focus();
+
+      expect(component.checkboxLabels.toArray()[0].nativeElement.focus).not.toHaveBeenCalled();
+      expect(component.checkboxLabels.toArray()[1].nativeElement.focus).not.toHaveBeenCalled();
+    });
+
     describe('onKeyDown:', () => {
       let option;
       let fakeEvent: any;

--- a/projects/ui/src/lib/components/po-field/po-checkbox-group/po-checkbox-group.component.ts
+++ b/projects/ui/src/lib/components/po-field/po-checkbox-group/po-checkbox-group.component.ts
@@ -1,4 +1,4 @@
-import { AfterViewChecked, ChangeDetectorRef, Component, forwardRef } from '@angular/core';
+import { AfterViewChecked, ChangeDetectorRef, Component, ElementRef, forwardRef, QueryList, ViewChildren } from '@angular/core';
 import { NG_VALIDATORS, NG_VALUE_ACCESSOR } from '@angular/forms';
 
 import { PoCheckboxGroupBaseComponent } from './po-checkbox-group-base.component';
@@ -42,12 +42,41 @@ import { PoCheckboxGroupOption } from './po-checkbox-group-option.interface';
 })
 export class PoCheckboxGroupComponent extends PoCheckboxGroupBaseComponent implements AfterViewChecked {
 
+  @ViewChildren('checkboxLabel') checkboxLabels: QueryList<ElementRef>;
+
   constructor(private changeDetector: ChangeDetectorRef) {
     super();
   }
 
   ngAfterViewChecked(): void {
     this.changeDetector.detectChanges();
+  }
+
+  /**
+   * Função que atribui foco ao componente.
+   *
+   * Para utilizá-la é necessário ter a instância do componente no DOM, podendo ser utilizado o ViewChild da seguinte forma:
+   *
+   * ```
+   * import { PoCheckboxGroupComponent } from '@portinari/portinari-ui';
+   *
+   * ...
+   *
+   * @ViewChild(PoCheckboxGroupComponent, { static: true }) checkbox: PoCheckboxGroupComponent;
+   *
+   * focusCheckbox() {
+   *   this.checkbox.focus();
+   * }
+   * ```
+   */
+  focus(): void {
+    if (this.checkboxLabels && !this.disabled) {
+      const checkboxLabel = this.checkboxLabels.find((_, index) => !this.options[index].disabled);
+
+      if (checkboxLabel) {
+        checkboxLabel.nativeElement.focus();
+      }
+    }
   }
 
   onKeyDown(event: KeyboardEvent, option: PoCheckboxGroupOption) {

--- a/projects/ui/src/lib/components/po-field/po-combo/po-combo.component.spec.ts
+++ b/projects/ui/src/lib/components/po-field/po-combo/po-combo.component.spec.ts
@@ -474,6 +474,35 @@ describe('PoComboComponent:', () => {
       stopPropagation: () => {}
     };
 
+    it('focus: should call `focus` of combo', () => {
+      component.inputElement = {
+        nativeElement: {
+          focus: () => {}
+        }
+      };
+
+      spyOn(component.inputElement.nativeElement, 'focus');
+
+      component.focus();
+
+      expect(component.inputElement.nativeElement.focus).toHaveBeenCalled();
+    });
+
+    it('focus: should`t call `focus` of combo if `disabled`', () => {
+      component.inputElement = {
+        nativeElement: {
+          focus: () => {}
+        }
+      };
+      component.disabled = true;
+
+      spyOn(component.inputElement.nativeElement, 'focus');
+
+      component.focus();
+
+      expect(component.inputElement.nativeElement.focus).not.toHaveBeenCalled();
+    });
+
     describe('onKeyUp:', () => {
 
       function fakeKeypressEvent(code: number, target: any = 1) {

--- a/projects/ui/src/lib/components/po-field/po-combo/po-combo.component.ts
+++ b/projects/ui/src/lib/components/po-field/po-combo/po-combo.component.ts
@@ -158,6 +158,29 @@ export class PoComboComponent extends PoComboBaseComponent implements DoCheck, O
     }
   }
 
+  /**
+   * Função que atribui foco ao componente.
+   *
+   * Para utilizá-la é necessário ter a instância do componente no DOM, podendo ser utilizado o ViewChild da seguinte forma:
+   *
+   * ```
+   * import { PoComboComponent } from '@portinari/portinari-ui';
+   *
+   * ...
+   *
+   * @ViewChild(PoComboComponent, { static: true }) combo: PoComboComponent;
+   *
+   * focusCombo() {
+   *   this.combo.focus();
+   * }
+   * ```
+   */
+  focus(): void {
+    if (!this.disabled) {
+      this.inputElement.nativeElement.focus();
+    }
+  }
+
   onKeyDown(event?: any) {
     const key = event.keyCode;
     const inputValue = event.target.value;

--- a/projects/ui/src/lib/components/po-field/po-combo/samples/sample-po-combo-hotels/sample-po-combo-hotels.component.html
+++ b/projects/ui/src/lib/components/po-field/po-combo/samples/sample-po-combo-hotels/sample-po-combo-hotels.component.html
@@ -6,6 +6,7 @@
 
   <div class="po-row">
     <po-datepicker
+      #datepicker
       class="po-md-4"
       name="checkin"
       [(ngModel)]="checkin"

--- a/projects/ui/src/lib/components/po-field/po-combo/samples/sample-po-combo-hotels/sample-po-combo-hotels.component.ts
+++ b/projects/ui/src/lib/components/po-field/po-combo/samples/sample-po-combo-hotels/sample-po-combo-hotels.component.ts
@@ -1,7 +1,7 @@
 import { Component, ViewChild } from '@angular/core';
 import { NgForm } from '@angular/forms';
 
-import { PoNotificationService, PoSelectOption } from '@portinari/portinari-ui';
+import { PoDatepickerComponent, PoNotificationService, PoSelectOption } from '@portinari/portinari-ui';
 
 import { SamplePoComboHotelsService } from './sample-po-combo-hotels.service';
 
@@ -40,6 +40,7 @@ export class SamplePoComboHotelsComponent {
   ];
 
   @ViewChild('bookingForm', { static: true }) form: NgForm;
+  @ViewChild('datepicker', { static: true }) datepickerComponent: PoDatepickerComponent;
 
   constructor(
     public comboService: SamplePoComboHotelsService,
@@ -49,6 +50,8 @@ export class SamplePoComboHotelsComponent {
     this.poNotification.success('Hotel booked successfully');
 
     this.formReset();
+
+    this.datepickerComponent.focus();
   }
 
   private formReset() {

--- a/projects/ui/src/lib/components/po-field/po-datepicker-range/po-datepicker-range.component.spec.ts
+++ b/projects/ui/src/lib/components/po-field/po-datepicker-range/po-datepicker-range.component.spec.ts
@@ -210,6 +210,35 @@ describe('PoDatepickerRangeComponent:', () => {
       expect(component.endDateInputValue).toBe('');
     });
 
+    it('focus: should call `focus` of datepicker-range', () => {
+      component.startDateInput = {
+        nativeElement: {
+          focus: () => {}
+        }
+      };
+
+      spyOn(component.startDateInput.nativeElement, 'focus');
+
+      component.focus();
+
+      expect(component.startDateInput.nativeElement.focus).toHaveBeenCalled();
+    });
+
+    it('focus: should`t call `focus` of datepicker-range if `disabled`', () => {
+      component.startDateInput = {
+        nativeElement: {
+          focus: () => {}
+        }
+      };
+      component.disabled = true;
+
+      spyOn(component.startDateInput.nativeElement, 'focus');
+
+      component.focus();
+
+      expect(component.startDateInput.nativeElement.focus).not.toHaveBeenCalled();
+    });
+
     it('onBlur: should call `removeFocusFromDatePickerRangeField`', () => {
       spyOn(component, <any>'removeFocusFromDatePickerRangeField');
 

--- a/projects/ui/src/lib/components/po-field/po-datepicker-range/po-datepicker-range.component.ts
+++ b/projects/ui/src/lib/components/po-field/po-datepicker-range/po-datepicker-range.component.ts
@@ -132,6 +132,29 @@ export class PoDatepickerRangeComponent extends PoDatepickerRangeBaseComponent i
     this.updateModel(this.dateRange);
   }
 
+  /**
+   * Função que atribui foco ao componente.
+   *
+   * Para utilizá-la é necessário ter a instância do componente no DOM, podendo ser utilizado o ViewChild da seguinte forma:
+   *
+   * ```
+   * import { PoDatepickerRangeComponent } from '@portinari/portinari-ui';
+   *
+   * ...
+   *
+   * @ViewChild(PoDatepickerRangeComponent, { static: true }) datepickerRange: PoDatepickerRangeComponent;
+   *
+   * focusDatepickerRange() {
+   *   this.datepickerRange.focus();
+   * }
+   * ```
+   */
+  focus(): void {
+    if (!this.disabled) {
+      this.startDateInput.nativeElement.focus();
+    }
+  }
+
   onBlur() {
     this.removeFocusFromDatePickerRangeField();
   }

--- a/projects/ui/src/lib/components/po-field/po-datepicker/po-datepicker-base.component.spec.ts
+++ b/projects/ui/src/lib/components/po-field/po-datepicker/po-datepicker-base.component.spec.ts
@@ -58,9 +58,9 @@ describe('PoDatepickerBaseComponent:', () => {
   });
 
   it('should update property p-focus', () => {
-    expectSettersMethod(component, 'setFocus', '', 'focus', true);
-    expectSettersMethod(component, 'setFocus', 'true', 'focus', true);
-    expectSettersMethod(component, 'setFocus', 'false', 'focus', false);
+    expectSettersMethod(component, 'autofocus', '', 'autofocus', true);
+    expectSettersMethod(component, 'autofocus', 'true', 'autofocus', true);
+    expectSettersMethod(component, 'autofocus', 'false', 'autofocus', false);
   });
 
   it('should update property p-clean', () => {

--- a/projects/ui/src/lib/components/po-field/po-datepicker/po-datepicker-base.component.ts
+++ b/projects/ui/src/lib/components/po-field/po-datepicker/po-datepicker-base.component.ts
@@ -51,6 +51,7 @@ const poDatepickerFormatDefault: string = 'dd/mm/yyyy';
  */
 export abstract class PoDatepickerBaseComponent implements ControlValueAccessor, OnInit, Validator {
 
+  private _autofocus?: boolean;
   private _format?: string = poDatepickerFormatDefault;
   private _maxDate: Date;
   private _minDate: Date;
@@ -138,10 +139,21 @@ export abstract class PoDatepickerBaseComponent implements ControlValueAccessor,
     this.validateModel(convertDateToISOExtended(this.date, this.hour));
   }
 
-  /** Aplica foco ao elemento ao ser iniciado. */
-  focus?: boolean = false;
-  @Input('p-focus') set setFocus(focus: string) {
-    this.focus = focus === '' ? true : convertToBoolean(focus);
+  /**
+   * @optional
+   *
+   * @description
+   *
+   * Aplica foco no elemento ao ser iniciado.
+   *
+   * @default `false`
+   */
+  @Input('p-focus') set autofocus(autofocus: boolean) {
+    this._autofocus = convertToBoolean(autofocus);
+  }
+
+  get autofocus() {
+    return this._autofocus;
   }
 
   /** Habilita ação para limpar o campo. */

--- a/projects/ui/src/lib/components/po-field/po-datepicker/po-datepicker.component.spec.ts
+++ b/projects/ui/src/lib/components/po-field/po-datepicker/po-datepicker.component.spec.ts
@@ -47,7 +47,7 @@ describe('PoDatepickerComponent:', () => {
     component.help = 'Help de teste';
     component.format = 'dd/mm/yyyy';
     component.locale = 'en';
-    component.focus = true;
+    component.autofocus = true;
     component.required = true;
     component.clean = true;
     component.date = new Date();
@@ -327,7 +327,7 @@ describe('PoDatepickerComponent:', () => {
     component.label = 'Label de teste';
     component.help = 'Help de teste';
     component.locale = 'pt';
-    component.focus = true;
+    component.autofocus = true;
     component.clean = true;
     component.minDate = new Date(2017, 1, 1);
     component.maxDate = new Date(2017, 11, 10);
@@ -550,7 +550,7 @@ describe('PoDatepickerComponent:', () => {
     it('ngAfterViewInit: should call `setDialogPickerStyleDisplay` and call `inputEl.nativeElement.focus` if focus is true.', () => {
       const setDialogPickerStyleDisplay = spyOn(component, <any>'setDialogPickerStyleDisplay');
       const inputElFocus = spyOn(component.inputEl.nativeElement, <any>'focus');
-      component.focus = true;
+      component.autofocus = true;
 
       component.ngAfterViewInit();
 
@@ -561,7 +561,7 @@ describe('PoDatepickerComponent:', () => {
     it('ngAfterViewInit: should call `setDialogPickerStyleDisplay` and not call `inputEl.nativeElement.focus` if focus is false.', () => {
       const setDialogPickerStyleDisplay = spyOn(component, <any>'setDialogPickerStyleDisplay');
       const inputElFocus = spyOn(component.inputEl.nativeElement, <any>'focus');
-      component.focus = false;
+      component.autofocus = false;
 
       component.ngAfterViewInit();
 
@@ -573,6 +573,35 @@ describe('PoDatepickerComponent:', () => {
       const removeListener = spyOn(component, <any>'removeListeners');
       component.ngOnDestroy();
       expect(removeListener).toHaveBeenCalled();
+    });
+
+    it('focus: should call `focus` of datepicker', () => {
+      component.inputEl = {
+        nativeElement: {
+          focus: () => {}
+        }
+      };
+
+      spyOn(component.inputEl.nativeElement, 'focus');
+
+      component.focus();
+
+      expect(component.inputEl.nativeElement.focus).toHaveBeenCalled();
+    });
+
+    it('focus: should`t call `focus` of datepicker if `disabled`', () => {
+      component.inputEl = {
+        nativeElement: {
+          focus: () => {}
+        }
+      };
+      component.disabled = true;
+
+      spyOn(component.inputEl.nativeElement, 'focus');
+
+      component.focus();
+
+      expect(component.inputEl.nativeElement.focus).not.toHaveBeenCalled();
     });
 
     it('addListener: should call wasClickedOnPicker when click in document', () => {

--- a/projects/ui/src/lib/components/po-field/po-datepicker/po-datepicker.component.ts
+++ b/projects/ui/src/lib/components/po-field/po-datepicker/po-datepicker.component.ts
@@ -99,13 +99,36 @@ export class PoDatepickerComponent extends PoDatepickerBaseComponent implements 
   ngAfterViewInit() {
     this.setDialogPickerStyleDisplay('none');
     // Põe o foco no Input, setado pelo p-focus
-    if (this.focus) {
+    if (this.autofocus) {
       this.inputEl.nativeElement.focus();
     }
   }
 
   ngOnDestroy() {
     this.removeListeners();
+  }
+
+  /**
+   * Função que atribui foco ao componente.
+   *
+   * Para utilizá-la é necessário ter a instância do componente no DOM, podendo ser utilizado o ViewChild da seguinte forma:
+   *
+   * ```
+   * import { PoDatepickerComponent } from '@portinari/portinari-ui';
+   *
+   * ...
+   *
+   * @ViewChild(PoDatepickerComponent, { static: true }) datepicker: PoDatepickerComponent;
+   *
+   * focusDatepicker() {
+   *   this.datepicker.focus();
+   * }
+   * ```
+   */
+  focus(): void {
+    if (!this.disabled) {
+      this.inputEl.nativeElement.focus();
+    }
   }
 
   togglePicker() {

--- a/projects/ui/src/lib/components/po-field/po-decimal/po-decimal.component.spec.ts
+++ b/projects/ui/src/lib/components/po-field/po-decimal/po-decimal.component.spec.ts
@@ -297,7 +297,7 @@ describe('PoDecimalComponent:', () => {
 
   it('should set focus', () => {
     const fakeThis = {
-      focus: true,
+      autofocus: true,
       inputEl: component.inputEl
     };
 
@@ -718,6 +718,35 @@ describe('PoDecimalComponent:', () => {
 
   // testes já utilizando boas práticas.
   describe('Methods:', () => {
+
+    it('focus: should call `focus` of decimal', () => {
+      component.inputEl = {
+        nativeElement: {
+          focus: () => {}
+        }
+      };
+
+      spyOn(component.inputEl.nativeElement, 'focus');
+
+      component.focus();
+
+      expect(component.inputEl.nativeElement.focus).toHaveBeenCalled();
+    });
+
+    it('focus: should`t call `focus` of decimal if `disabled`', () => {
+      component.inputEl = {
+        nativeElement: {
+          focus: () => {}
+        }
+      };
+      component.disabled = true;
+
+      spyOn(component.inputEl.nativeElement, 'focus');
+
+      component.focus();
+
+      expect(component.inputEl.nativeElement.focus).not.toHaveBeenCalled();
+    });
 
     it('setInitialSelectionRange: should set cursor position if selectionStart and selectionEnd is 1', () => {
       const fakeTarget = {

--- a/projects/ui/src/lib/components/po-field/po-decimal/po-decimal.component.ts
+++ b/projects/ui/src/lib/components/po-field/po-decimal/po-decimal.component.ts
@@ -140,6 +140,12 @@ export class PoDecimalComponent extends PoInputBaseComponent implements AfterVie
     return null;
   }
 
+  focus(): void {
+    if (!this.disabled) {
+      this.inputEl.nativeElement.focus();
+    }
+  }
+
   getScreenValue() {
     return (this.inputEl) ? this.inputEl.nativeElement.value : '';
   }
@@ -449,7 +455,7 @@ export class PoDecimalComponent extends PoInputBaseComponent implements AfterVie
   }
 
   private putFocus() {
-    if (this.focus) {
+    if (this.autofocus) {
       this.inputEl.nativeElement.focus();
     }
   }

--- a/projects/ui/src/lib/components/po-field/po-input-generic/po-input-generic.spec.ts
+++ b/projects/ui/src/lib/components/po-field/po-input-generic/po-input-generic.spec.ts
@@ -70,26 +70,6 @@ describe('PoInputGeneric:', () => {
     expect(component.setPaddingInput).toHaveBeenCalled();
   });
 
-  it('should set focus', () => {
-    const fakeThis = {
-      focus: true,
-      inputEl: component.inputEl
-    };
-    spyOn(fakeThis.inputEl.nativeElement, 'focus');
-    component.putFocus.call(fakeThis);
-    expect(fakeThis.inputEl.nativeElement.focus).toHaveBeenCalled();
-  });
-
-  it('should not set focus', () => {
-    const fakeThis = {
-      focus: false,
-      inputEl: component.inputEl
-    };
-    spyOn(fakeThis.inputEl.nativeElement, 'focus');
-    component.putFocus.call(fakeThis);
-    expect(fakeThis.inputEl.nativeElement.focus).not.toHaveBeenCalled();
-  });
-
   it('should calc icons position with clean', fakeAsync(() => {
     const fakeThis = {
       clean: true,
@@ -452,6 +432,35 @@ describe('PoInputGeneric:', () => {
       expect(component.setPaddingInput).not.toHaveBeenCalled();
     });
 
+    it('focus: should call `focus` of input', () => {
+      component.inputEl = {
+        nativeElement: {
+          focus: () => {}
+        }
+      };
+
+      spyOn(component.inputEl.nativeElement, 'focus');
+
+      component.focus();
+
+      expect(component.inputEl.nativeElement.focus).toHaveBeenCalled();
+    });
+
+    it('focus: should`t call `focus` of input if `disabled`', () => {
+      component.inputEl = {
+        nativeElement: {
+          focus: () => {}
+        }
+      };
+      component.disabled = true;
+
+      spyOn(component.inputEl.nativeElement, 'focus');
+
+      component.focus();
+
+      expect(component.inputEl.nativeElement.focus).not.toHaveBeenCalled();
+    });
+
     it('getScreenValue: should get input numeric value when call `getScreenValue` method.', () => {
       component.type = 'number';
       component.inputEl.nativeElement.value = '123.1';
@@ -493,6 +502,32 @@ describe('PoInputGeneric:', () => {
       spyOn(fakeThis.objMask, 'keyup');
       component.onKeyup.call(fakeThis, fakeEvent);
       expect(fakeThis.objMask.keyup).not.toHaveBeenCalled();
+    });
+
+    it('putFocus: should call `focus` if autofocus is true', () => {
+      const fakeThis = {
+        autofocus: true,
+        focus: () => {}
+      };
+
+      spyOn(fakeThis, 'focus');
+
+      component.putFocus.call(fakeThis);
+
+      expect(fakeThis.focus).toHaveBeenCalled();
+    });
+
+    it('putFocus: shouldn`t call `focus` if autofocus is false', () => {
+      const fakeThis = {
+        autofocus: false,
+        focus: () => {}
+      };
+
+      spyOn(fakeThis, 'focus');
+
+      component.putFocus.call(fakeThis);
+
+      expect(fakeThis.focus).not.toHaveBeenCalled();
     });
 
     it('eventOnBlur: should call `objMask.blur` when exists a `mask`.', () => {

--- a/projects/ui/src/lib/components/po-field/po-input-generic/po-input-generic.ts
+++ b/projects/ui/src/lib/components/po-field/po-input-generic/po-input-generic.ts
@@ -34,6 +34,12 @@ export abstract class PoInputGeneric extends PoInputBaseComponent implements Aft
     }
   }
 
+  focus() {
+    if (!this.disabled) {
+      this.inputEl.nativeElement.focus();
+    }
+  }
+
   setPaddingInput() {
     setTimeout(() => {
       const selectorIcons = '.po-field-icon-container:not(.po-field-icon-container-left) > .po-icon';
@@ -48,8 +54,8 @@ export abstract class PoInputGeneric extends PoInputBaseComponent implements Aft
   }
 
   putFocus() {
-    if (this.focus) {
-      this.inputEl.nativeElement.focus();
+    if (this.autofocus) {
+      this.focus();
     }
   }
 

--- a/projects/ui/src/lib/components/po-field/po-input/po-input-base.component.spec.ts
+++ b/projects/ui/src/lib/components/po-field/po-input/po-input-base.component.spec.ts
@@ -7,9 +7,13 @@ import { PoInputBaseComponent } from './po-input-base.component';
 import { PoMask } from './po-mask';
 
 class PoInput extends PoInputBaseComponent {
+
   extraValidation(c: AbstractControl): { [key: string]: any; } {
     return null;
   }
+
+  focus(): void { }
+
   getScreenValue(): string {
     return '';
   }
@@ -51,12 +55,6 @@ describe('PoInputBase:', () => {
     expectSettersMethod(component, 'setRequired', 'false', 'required', false);
 
     expect(component['validateModel']).toHaveBeenCalled();
-  });
-
-  it('should set focus', () => {
-    expectSettersMethod(component, 'setFocus', '', 'focus', true);
-    expectSettersMethod(component, 'setFocus', 'true', 'focus', true);
-    expectSettersMethod(component, 'setFocus', 'false', 'focus', false);
   });
 
   it('should set clean', () => {
@@ -179,6 +177,16 @@ describe('PoInputBase:', () => {
   });
 
   describe('Properties:', () => {
+
+    it('p-focus: should update property with `false` if invalid values.', () => {
+      const invalidValues = [undefined, null, 0, false, 'false', 'string'];
+      expectPropertiesValues(component, 'autofocus', invalidValues, false);
+    });
+
+    it('p-focus: should update property with valid values with valid values.', () => {
+      const validValues = [true, 'true', 1];
+      expectPropertiesValues(component, 'autofocus', validValues, true);
+    });
 
     it('p-placeholder: should update property p-placeholder with valid value.', () => {
       component.placeholder = 'teste';

--- a/projects/ui/src/lib/components/po-field/po-input/po-input-base.component.ts
+++ b/projects/ui/src/lib/components/po-field/po-input/po-input-base.component.ts
@@ -22,6 +22,7 @@ import { PoMask } from './po-mask';
  */
 export abstract class PoInputBaseComponent implements ControlValueAccessor, Validator {
 
+  private _autofocus?: boolean;
   private _maxlength?: number;
   private _minlength?: number;
   private _noAutocomplete?: boolean = false;
@@ -119,10 +120,21 @@ export abstract class PoInputBaseComponent implements ControlValueAccessor, Vali
     this.validateModel();
   }
 
-  /** Se verdadeiro, o campo iniciará com foco. */
-  focus?: boolean = false;
-  @Input('p-focus') set setFocus(focus: string) {
-    this.focus = focus === '' ? true : convertToBoolean(focus);
+  /**
+   * @optional
+   *
+   * @description
+   *
+   * Aplica foco no elemento ao ser iniciado.
+   *
+   * @default `false`
+   */
+  @Input('p-focus') set autofocus(focus: boolean) {
+    this._autofocus = convertToBoolean(focus);
+  }
+
+  get autofocus() {
+    return this._autofocus;
   }
 
   /** Se verdadeiro, o campo receberá um botão para ser limpo. */
@@ -287,6 +299,25 @@ export abstract class PoInputBaseComponent implements ControlValueAccessor, Vali
       this.modelLastUpdate = value;
     }
   }
+
+  /**
+   * Função que atribui foco ao componente.
+   *
+   * Para utilizá-la é necessário ter a instância do componente no DOM, podendo ser utilizado o ViewChild da seguinte forma:
+   *
+   * ```
+   * import { PoNomeDoComponenteComponent } from '@portinari/portinari-ui';
+   *
+   * ...
+   *
+   * @ViewChild(PoNomeDoComponenteComponent, { static: true }) nomeDoComponente: PoNomeDoComponenteComponent;
+   *
+   * focusComponent() {
+   *   this.nomeDoComponente.focus();
+   * }
+   * ```
+   */
+  abstract focus(): void;
 
   // Função implementada do ControlValueAccessor
   // Usada para interceptar as mudanças e não atualizar automaticamente o Model

--- a/projects/ui/src/lib/components/po-field/po-lookup/po-lookup-base.component.spec.ts
+++ b/projects/ui/src/lib/components/po-field/po-lookup/po-lookup-base.component.spec.ts
@@ -89,16 +89,16 @@ describe('PoLookupBaseComponent:', () => {
   });
 
   it('should set focus', () => {
-    expectSettersMethod(component, 'focus', '', '_focus', true);
-    expectSettersMethod(component, 'focus', 'true', '_focus', true);
-    expectSettersMethod(component, 'focus', true, '_focus', true);
-    expectSettersMethod(component, 'focus', 'false', '_focus', false);
-    expectSettersMethod(component, 'focus', false, '_focus', false);
-    expectSettersMethod(component, 'focus', 'null', 'focus', false);
-    expectSettersMethod(component, 'focus', null, 'focus', false);
-    expectSettersMethod(component, 'focus', NaN, 'focus', false);
-    expectSettersMethod(component, 'focus', 'undefined', 'focus', false);
-    expectSettersMethod(component, 'focus', undefined, 'focus', false);
+    expectSettersMethod(component, 'autofocus', '', '_autofocus', true);
+    expectSettersMethod(component, 'autofocus', 'true', '_autofocus', true);
+    expectSettersMethod(component, 'autofocus', true, '_autofocus', true);
+    expectSettersMethod(component, 'autofocus', 'false', '_autofocus', false);
+    expectSettersMethod(component, 'autofocus', false, '_autofocus', false);
+    expectSettersMethod(component, 'autofocus', 'null', 'autofocus', false);
+    expectSettersMethod(component, 'autofocus', null, 'autofocus', false);
+    expectSettersMethod(component, 'autofocus', NaN, 'autofocus', false);
+    expectSettersMethod(component, 'autofocus', 'undefined', 'autofocus', false);
+    expectSettersMethod(component, 'autofocus', undefined, 'autofocus', false);
   });
 
   it('should register function OnChangePropagate', () => {

--- a/projects/ui/src/lib/components/po-field/po-lookup/po-lookup-base.component.ts
+++ b/projects/ui/src/lib/components/po-field/po-lookup/po-lookup-base.component.ts
@@ -26,9 +26,9 @@ import { PoLookupLiterals } from './interfaces/po-lookup-literals.interface';
  */
 export abstract class PoLookupBaseComponent implements ControlValueAccessor, OnDestroy, OnInit, Validator {
 
+  private _autofocus?: boolean = false;
   private _disabled?: boolean = false;
   private _filterService: PoLookupFilter | string;
-  private _focus?: boolean = false;
   private _noAutocomplete: boolean;
   private _required?: boolean = false;
 
@@ -221,19 +221,20 @@ export abstract class PoLookupBaseComponent implements ControlValueAccessor, OnD
   }
 
   /**
+   * @optional
+   *
    * @description
    *
-   * Indica que o campo iniciará com foco.
+   * Aplica foco no elemento ao ser iniciado.
    *
-   * @default false
-   * @optional
+   * @default `false`
    */
-  @Input('p-focus') set focus(focus: boolean) {
-    this._focus = <any>focus === '' ? true : convertToBoolean(focus);
+  @Input('p-focus') set autofocus(focus: boolean) {
+    this._autofocus = convertToBoolean(focus);
   }
 
-  get focus(): boolean {
-    return this._focus;
+  get autofocus(): boolean {
+    return this._autofocus;
   }
 
   /**

--- a/projects/ui/src/lib/components/po-field/po-lookup/po-lookup.component.spec.ts
+++ b/projects/ui/src/lib/components/po-field/po-lookup/po-lookup.component.spec.ts
@@ -171,6 +171,35 @@ describe('PoLookupComponent: ', () => {
       expect(fakeSubscription.unsubscribe).not.toHaveBeenCalled();
     });
 
+    it('focus: should call `focus` of lookup', () => {
+      component.inputEl = {
+        nativeElement: {
+          focus: () => {}
+        }
+      };
+
+      spyOn(component.inputEl.nativeElement, 'focus');
+
+      component.focus();
+
+      expect(component.inputEl.nativeElement.focus).toHaveBeenCalled();
+    });
+
+    it('focus: should`t call `focus` of lookup if `disabled`', () => {
+      component.inputEl = {
+        nativeElement: {
+          focus: () => {}
+        }
+      };
+      component.disabled = true;
+
+      spyOn(component.inputEl.nativeElement, 'focus');
+
+      component.focus();
+
+      expect(component.inputEl.nativeElement.focus).not.toHaveBeenCalled();
+    });
+
     it('openLookup: should call `openModal` if `isAllowedOpenModal` return true',
       inject([LookupFilterService], ( lookupFilterService: LookupFilterService) => {
 

--- a/projects/ui/src/lib/components/po-field/po-lookup/po-lookup.component.ts
+++ b/projects/ui/src/lib/components/po-field/po-lookup/po-lookup.component.ts
@@ -99,6 +99,29 @@ export class PoLookupComponent extends PoLookupBaseComponent implements OnDestro
     super.ngOnInit();
   }
 
+  /**
+   * Função que atribui foco ao componente.
+   *
+   * Para utilizá-la é necessário ter a instância do componente no DOM, podendo ser utilizado o ViewChild da seguinte forma:
+   *
+   * ```
+   * import { PoLookupComponent } from '@portinari/portinari-ui';
+   *
+   * ...
+   *
+   * @ViewChild(PoLookupComponent, { static: true }) lookup: PoLookupComponent;
+   *
+   * focusLookup() {
+   *   this.lookup.focus();
+   * }
+   * ```
+   */
+  focus(): void {
+    if (!this.disabled) {
+      this.inputEl.nativeElement.focus();
+    }
+  }
+
   openLookup(): void {
     if (this.isAllowedOpenModal()) {
       const { service, columns, filterParams, literals } = this;

--- a/projects/ui/src/lib/components/po-field/po-multiselect/po-multiselect-base.component.spec.ts
+++ b/projects/ui/src/lib/components/po-field/po-multiselect/po-multiselect-base.component.spec.ts
@@ -60,13 +60,13 @@ describe('PoMultiselectBaseComponent:', () => {
   });
 
   it('should set focus', () => {
-    expectSettersMethod(component, 'focus', '', 'focus', true);
-    expectSettersMethod(component, 'focus', 'true', 'focus', true);
-    expectSettersMethod(component, 'focus', true, 'focus', true);
-    expectSettersMethod(component, 'focus', 'null', 'focus', false);
-    expectSettersMethod(component, 'focus', null, 'focus', false);
-    expectSettersMethod(component, 'focus', 'undefined', 'focus', false);
-    expectSettersMethod(component, 'focus', undefined, 'focus', false);
+    expectSettersMethod(component, 'autofocus', '', 'autofocus', true);
+    expectSettersMethod(component, 'autofocus', 'true', 'autofocus', true);
+    expectSettersMethod(component, 'autofocus', true, 'autofocus', true);
+    expectSettersMethod(component, 'autofocus', 'null', 'autofocus', false);
+    expectSettersMethod(component, 'autofocus', null, 'autofocus', false);
+    expectSettersMethod(component, 'autofocus', 'undefined', 'autofocus', false);
+    expectSettersMethod(component, 'autofocus', undefined, 'autofocus', false);
   });
 
   it('should set p-filter-mode', () => {

--- a/projects/ui/src/lib/components/po-field/po-multiselect/po-multiselect-base.component.ts
+++ b/projects/ui/src/lib/components/po-field/po-multiselect/po-multiselect-base.component.ts
@@ -38,9 +38,9 @@ export const poMultiselectLiteralsDefault = {
  */
 export abstract class PoMultiselectBaseComponent implements AfterContentChecked, ControlValueAccessor, OnInit, Validator {
 
+  private _autofocus?: boolean = false;
   private _disabled?: boolean = false;
   private _filterMode?: PoMultiselectFilterMode = PoMultiselectFilterMode.startsWith;
-  private _focus?: boolean = false;
   private _hideSearch?: boolean = false;
   private _literals: PoMultiselectLiterals;
   private _options: Array<PoMultiselectOption>;
@@ -240,16 +240,16 @@ export abstract class PoMultiselectBaseComponent implements AfterContentChecked,
    *
    * @description
    *
-   * Indica que o campo iniciará com foco.
+   * Aplica foco no elemento ao ser iniciado.
    *
    * @default `false`
    */
-  @Input('p-focus') set focus(focus: boolean) {
-    this._focus = <any>focus === '' ? true : convertToBoolean(focus);
+  @Input('p-focus') set autofocus(focus: boolean) {
+    this._autofocus = convertToBoolean(focus);
   }
 
-  get focus() {
-    return this._focus;
+  get autofocus() {
+    return this._autofocus;
   }
 
   /**

--- a/projects/ui/src/lib/components/po-field/po-multiselect/po-multiselect.component.spec.ts
+++ b/projects/ui/src/lib/components/po-field/po-multiselect/po-multiselect.component.spec.ts
@@ -89,7 +89,7 @@ describe('PoMultiselectComponent:', () => {
 
   it('should set focus on input', () => {
     component.initialized = false;
-    component.focus = true;
+    component.autofocus = true;
     component.ngAfterViewInit();
     expect(document.activeElement.tagName.toLowerCase()).toBe('input');
     expect(component.initialized).toBeTruthy();
@@ -97,7 +97,7 @@ describe('PoMultiselectComponent:', () => {
 
   it('shouldn`t set focus on input', () => {
     component.initialized = false;
-    component.focus = false;
+    component.autofocus = false;
     component.ngAfterViewInit();
     expect(document.activeElement.tagName.toLowerCase()).not.toBe('input');
     expect(component.initialized).toBeTruthy();
@@ -325,6 +325,35 @@ describe('PoMultiselectComponent:', () => {
       component.ngOnDestroy();
 
       expect(removeListenersSpy).toHaveBeenCalled();
+    });
+
+    it('focus: should call `focus` of multiselect', () => {
+      component.inputElement = {
+        nativeElement: {
+          focus: () => {}
+        }
+      };
+
+      spyOn(component.inputElement.nativeElement, 'focus');
+
+      component.focus();
+
+      expect(component.inputElement.nativeElement.focus).toHaveBeenCalled();
+    });
+
+    it('focus: should`t call `focus` of multiselect if `disabled`', () => {
+      component.inputElement = {
+        nativeElement: {
+          focus: () => {}
+        }
+      };
+      component.disabled = true;
+
+      spyOn(component.inputElement.nativeElement, 'focus');
+
+      component.focus();
+
+      expect(component.inputElement.nativeElement.focus).not.toHaveBeenCalled();
     });
 
     it(`calculateVisibleItems: should calc visible items and not set 'isCalculateVisibleItems' to false when

--- a/projects/ui/src/lib/components/po-field/po-multiselect/po-multiselect.component.ts
+++ b/projects/ui/src/lib/components/po-field/po-multiselect/po-multiselect.component.ts
@@ -81,7 +81,7 @@ export class PoMultiselectComponent extends PoMultiselectBaseComponent implement
   }
 
   ngAfterViewInit() {
-    if (this.focus) {
+    if (this.autofocus) {
       this.inputElement.nativeElement.focus();
     }
     this.initialized = true;
@@ -100,6 +100,29 @@ export class PoMultiselectComponent extends PoMultiselectBaseComponent implement
 
   ngOnDestroy() {
     this.removeListeners();
+  }
+
+  /**
+   * Função que atribui foco ao componente.
+   *
+   * Para utilizá-la é necessário ter a instância do componente no DOM, podendo ser utilizado o ViewChild da seguinte forma:
+   *
+   * ```
+   * import { PoMultiselectComponent } from '@portinari/portinari-ui';
+   *
+   * ...
+   *
+   * @ViewChild(PoMultiselectComponent, { static: true }) multiselect: PoMultiselectComponent;
+   *
+   * focusMultiselect() {
+   *   this.multiselect.focus();
+   * }
+   * ```
+   */
+  focus(): void {
+    if (!this.disabled) {
+      this.inputElement.nativeElement.focus();
+    }
   }
 
   getInputWidth() {

--- a/projects/ui/src/lib/components/po-field/po-number/po-number.component.ts
+++ b/projects/ui/src/lib/components/po-field/po-number/po-number.component.ts
@@ -1,7 +1,6 @@
 import { AbstractControl, NG_VALUE_ACCESSOR, NG_VALIDATORS } from '@angular/forms';
 import { Component, ElementRef, forwardRef, Input } from '@angular/core';
 
-import { convertToBoolean } from '../../../utils/util';
 import { minFailed, maxFailed } from '../validators';
 
 import { PoNumberBaseComponent } from './po-number-base.component';

--- a/projects/ui/src/lib/components/po-field/po-radio-group/po-radio-group.component.html
+++ b/projects/ui/src/lib/components/po-field/po-radio-group/po-radio-group.component.html
@@ -7,7 +7,7 @@
     <div *ngFor="let option of options"
       class="po-radio-group-item po-md-{{ mdColumns }} po-lg-{{ columns }}">
 
-      <input #input
+      <input #inputRadio
         class="po-radio-group-input"
         type="radio"
         [attr.name]="name"
@@ -19,7 +19,7 @@
         (keyup)="onKeyUp($event, option.value)">
         <label
           class="po-radio-group-label"
-          [class.po-clickable]="!input.disabled"
+          [class.po-clickable]="!inputRadio.disabled"
           [for]="name"
           (click)="eventClick(option.value, option.disabled === true || disabled)">
         {{ option.label }}

--- a/projects/ui/src/lib/components/po-field/po-radio-group/po-radio-group.component.spec.ts
+++ b/projects/ui/src/lib/components/po-field/po-radio-group/po-radio-group.component.spec.ts
@@ -93,6 +93,51 @@ describe('PoRadioGroupComponent: ', () => {
       which: 37
     };
 
+    it('focus: should call `focus` of radio', () => {
+      component.options = [{ label: 'Option 1', value: '1' }, { label: 'Option 2', value: '2' }];
+
+      fixture.detectChanges();
+
+      spyOn(component.radioLabels.toArray()[0].nativeElement, 'focus');
+
+      component.focus();
+
+      expect(component.radioLabels.toArray()[0].nativeElement.focus).toHaveBeenCalled();
+    });
+
+    it('focus: should`t call `focus` of radio if option is `disabled`', () => {
+      component.options = [
+        { label: 'Option 1', value: '1', disabled: true },
+        { label: 'Option 2', value: '2' },
+        { label: 'Option 3', value: '3' }
+      ];
+
+      fixture.detectChanges();
+
+      spyOn(component.radioLabels.toArray()[0].nativeElement, 'focus');
+      spyOn(component.radioLabels.toArray()[1].nativeElement, 'focus');
+
+      component.focus();
+
+      expect(component.radioLabels.toArray()[0].nativeElement.focus).not.toHaveBeenCalled();
+      expect(component.radioLabels.toArray()[1].nativeElement.focus).toHaveBeenCalled();
+    });
+
+    it('focus: should`t call `focus` of radio if `disabled`', () => {
+      component.options = [{ label: 'Option 1', value: '1', disabled: true }, { label: 'Option 2', value: '2' }];
+      component.disabled = true;
+
+      fixture.detectChanges();
+
+      spyOn(component.radioLabels.toArray()[0].nativeElement, 'focus');
+      spyOn(component.radioLabels.toArray()[1].nativeElement, 'focus');
+
+      component.focus();
+
+      expect(component.radioLabels.toArray()[0].nativeElement.focus).not.toHaveBeenCalled();
+      expect(component.radioLabels.toArray()[1].nativeElement.focus).not.toHaveBeenCalled();
+    });
+
     it('onKeyUp: should call `changeValue` when `isArrowKey` is true.', () => {
       spyOn(component, 'changeValue');
       component.onKeyUp(fakeEventArrowKey, 1);

--- a/projects/ui/src/lib/components/po-field/po-radio-group/po-radio-group.component.ts
+++ b/projects/ui/src/lib/components/po-field/po-radio-group/po-radio-group.component.ts
@@ -1,4 +1,4 @@
-import { Component, DoCheck, ElementRef, forwardRef, Input, IterableDiffers, ViewChild } from '@angular/core';
+import { Component, DoCheck, ElementRef, forwardRef, Input, IterableDiffers, QueryList, ViewChild, ViewChildren } from '@angular/core';
 import { NG_VALIDATORS, NG_VALUE_ACCESSOR } from '@angular/forms';
 
 import { removeDuplicatedOptions } from '../../../utils/util';
@@ -58,6 +58,7 @@ export class PoRadioGroupComponent extends PoRadioGroupBaseComponent implements 
   @Input('p-help') help?: string;
 
   @ViewChild('inp', {read: ElementRef, static: true }) inputEl: ElementRef;
+  @ViewChildren('inputRadio') radioLabels: QueryList<ElementRef>;
 
   differ: any;
 
@@ -76,6 +77,33 @@ export class PoRadioGroupComponent extends PoRadioGroupBaseComponent implements 
   eventClick(value: any, disabled: any) {
     if (!disabled) {
       this.changeValue(value);
+    }
+  }
+
+  /**
+   * Função que atribui foco ao componente.
+   *
+   * Para utilizá-la é necessário ter a instância do componente no DOM, podendo ser utilizado o ViewChild da seguinte forma:
+   *
+   * ```
+   * import { PoRadioGroupComponent } from '@portinari/portinari-ui';
+   *
+   * ...
+   *
+   * @ViewChild(PoRadioGroupComponent, { static: true }) radio: PoRadioGroupComponent;
+   *
+   * focusRadio() {
+   *   this.radio.focus();
+   * }
+   * ```
+   */
+  focus(): void {
+    if (this.radioLabels && !this.disabled) {
+      const radioLabel = this.radioLabels.find((_, index) => !this.options[index].disabled);
+
+      if (radioLabel) {
+        radioLabel.nativeElement.focus();
+      }
     }
   }
 

--- a/projects/ui/src/lib/components/po-field/po-rich-text/po-rich-text-body/po-rich-text-body.component.html
+++ b/projects/ui/src/lib/components/po-field/po-rich-text/po-rich-text-body/po-rich-text-body.component.html
@@ -1,5 +1,6 @@
 <div #bodyElement
   class="po-rich-text-body"
+  tabindex="0"
   [attr.contenteditable]="!readonly"
   [attr.data-placeholder]="placeholder"
   [style.height.px]="height"

--- a/projects/ui/src/lib/components/po-field/po-rich-text/po-rich-text-body/po-rich-text-body.component.spec.ts
+++ b/projects/ui/src/lib/components/po-field/po-rich-text/po-rich-text-body/po-rich-text-body.component.spec.ts
@@ -98,6 +98,15 @@ describe('PoRichTextBodyComponent:', () => {
 
     });
 
+    it('focus: should call `focus` of rich-text', () => {
+
+      spyOn(component.bodyElement.nativeElement, 'focus');
+
+      component.focus();
+
+      expect(component.bodyElement.nativeElement.focus).toHaveBeenCalled();
+    });
+
     it('onClick: should call `emitSelectionCommands`', () => {
       spyOn(component, <any>'emitSelectionCommands');
       component.onClick();

--- a/projects/ui/src/lib/components/po-field/po-rich-text/po-rich-text-body/po-rich-text-body.component.ts
+++ b/projects/ui/src/lib/components/po-field/po-rich-text/po-rich-text-body/po-rich-text-body.component.ts
@@ -58,6 +58,10 @@ export class PoRichTextBodyComponent implements OnInit {
     }
   }
 
+  focus(): void {
+    this.bodyElement.nativeElement.focus();
+  }
+
   onClick() {
     this.emitSelectionCommands();
   }

--- a/projects/ui/src/lib/components/po-field/po-rich-text/po-rich-text.component.spec.ts
+++ b/projects/ui/src/lib/components/po-field/po-rich-text/po-rich-text.component.spec.ts
@@ -126,6 +126,15 @@ describe('PoRichTextComponent:', () => {
       expect(nativeElement.removeEventListener).not.toHaveBeenCalled();
     });
 
+    it('focus: should call input `focus`', () => {
+
+      spyOn(component.bodyElement, 'focus');
+
+      component.focus();
+
+      expect(component.bodyElement.focus).toHaveBeenCalled();
+    });
+
     it('updateValue: should apply values to value, invalid and call updateModel', () => {
       spyOn(component, <any>'updateModel');
       spyOn(component, <any>'controlChangeModelEmitter');

--- a/projects/ui/src/lib/components/po-field/po-rich-text/po-rich-text.component.ts
+++ b/projects/ui/src/lib/components/po-field/po-rich-text/po-rich-text.component.ts
@@ -1,8 +1,9 @@
-import { AfterViewInit, Component, ElementRef, forwardRef, OnDestroy } from '@angular/core';
+import { AfterViewInit, Component, ElementRef, forwardRef, OnDestroy, ViewChild } from '@angular/core';
 
 import { NG_VALIDATORS, NG_VALUE_ACCESSOR } from '@angular/forms';
 
 import { PoRichTextBaseComponent } from './po-rich-text-base.component';
+import { PoRichTextBodyComponent } from './po-rich-text-body/po-rich-text-body.component';
 
 /**
  * @docsExtends PoRichTextBaseComponent
@@ -44,6 +45,8 @@ export class PoRichTextComponent extends PoRichTextBaseComponent implements Afte
   private listener = this.validateClassesForRequired.bind(this);
   private modelLastUpdate: any;
 
+  @ViewChild(PoRichTextBodyComponent, { static: true }) bodyElement: PoRichTextBodyComponent;
+
   get errorMsg() {
     return (this.errorMessage !== '' && !this.value && this.required && this.invalid) ? this.errorMessage : '';
   }
@@ -67,6 +70,27 @@ export class PoRichTextComponent extends PoRichTextBaseComponent implements Afte
       this.element.nativeElement.removeEventListener('cut', this.listener);
       this.element.nativeElement.removeEventListener('paste', this.listener);
     }
+  }
+
+  /**
+   * Função que atribui foco ao componente.
+   *
+   * Para utilizá-la é necessário ter a instância do componente no DOM, podendo ser utilizado o ViewChild da seguinte forma:
+   *
+   * ```
+   * import { PoRichTextComponent } from '@portinari/portinari-ui';
+   *
+   * ...
+   *
+   * @ViewChild(PoRichTextComponent, { static: true }) richText: PoRichTextComponent;
+   *
+   * focusRichText() {
+   *   this.richText.focus();
+   * }
+   * ```
+   */
+  focus(): void {
+    this.bodyElement.focus();
   }
 
   onChangeValue(value: any) {

--- a/projects/ui/src/lib/components/po-field/po-select/po-select.component.spec.ts
+++ b/projects/ui/src/lib/components/po-field/po-select/po-select.component.spec.ts
@@ -175,6 +175,35 @@ describe('PoSelectComponent:', () => {
 
   describe('Methods:', () => {
 
+    it('focus: should call `focus` of select', () => {
+      component.selectElement = {
+        nativeElement: {
+          focus: () => {}
+        }
+      };
+
+      spyOn(component.selectElement.nativeElement, 'focus');
+
+      component.focus();
+
+      expect(component.selectElement.nativeElement.focus).toHaveBeenCalled();
+    });
+
+    it('focus: should`t call `focus` of select if `disabled`', () => {
+      component.selectElement = {
+        nativeElement: {
+          focus: () => {}
+        }
+      };
+      component.disabled = true;
+
+      spyOn(component.selectElement.nativeElement, 'focus');
+
+      component.focus();
+
+      expect(component.selectElement.nativeElement.focus).not.toHaveBeenCalled();
+    });
+
     it('getSelectItemHeight: should return height of po-select-item class', () => {
       const selectItem: any = { clientHeight: 5 };
 

--- a/projects/ui/src/lib/components/po-field/po-select/po-select.component.ts
+++ b/projects/ui/src/lib/components/po-field/po-select/po-select.component.ts
@@ -131,6 +131,29 @@ export class PoSelectComponent extends PoSelectBaseComponent implements DoCheck 
     }
   }
 
+  /**
+   * Função que atribui foco ao componente.
+   *
+   * Para utilizá-la é necessário ter a instância do componente no DOM, podendo ser utilizado o ViewChild da seguinte forma:
+   *
+   * ```
+   * import { PoSelectComponent } from '@portinari/portinari-ui';
+   *
+   * ...
+   *
+   * @ViewChild(PoSelectComponent, { static: true }) select: PoSelectComponent;
+   *
+   * focusSelect() {
+   *   this.select.focus();
+   * }
+   * ```
+   */
+  focus(): void {
+    if (!this.disabled) {
+      this.selectElement.nativeElement.focus();
+    }
+  }
+
   hideDropDown() {
     this.selectIcon = 'po-icon-arrow-down';
     this.selector('.po-select-container').classList.remove('po-select-show');

--- a/projects/ui/src/lib/components/po-field/po-switch/po-switch.component.html
+++ b/projects/ui/src/lib/components/po-field/po-switch/po-switch.component.html
@@ -4,6 +4,7 @@
 
   <div class="po-field-container-content po-switch-content" [attr.name]="name">
     <div class="po-switch-container po-clickable"
+      #switchContainer
       [class.po-switch-container-disabled]="disabled"
       [class.po-switch-container-off]="switchValue === false && !disabled"
       [class.po-switch-container-on]="switchValue === true && !disabled"

--- a/projects/ui/src/lib/components/po-field/po-switch/po-switch.component.spec.ts
+++ b/projects/ui/src/lib/components/po-field/po-switch/po-switch.component.spec.ts
@@ -121,6 +121,35 @@ describe('PoRadioGroupComponent', () => {
 
   describe('Methods:', () => {
 
+    it('focus: should call `focus` of switch', () => {
+      component.switchContainer = {
+        nativeElement: {
+          focus: () => {}
+        }
+      };
+
+      spyOn(component.switchContainer.nativeElement, 'focus');
+
+      component.focus();
+
+      expect(component.switchContainer.nativeElement.focus).toHaveBeenCalled();
+    });
+
+    it('focus: should`t call `focus` of switch if `disabled`', () => {
+      component.switchContainer = {
+        nativeElement: {
+          focus: () => {}
+        }
+      };
+      component.disabled = true;
+
+      spyOn(component.switchContainer.nativeElement, 'focus');
+
+      component.focus();
+
+      expect(component.switchContainer.nativeElement.focus).not.toHaveBeenCalled();
+    });
+
     describe('onKeyDown:', () => {
 
       let fakeEvent;

--- a/projects/ui/src/lib/components/po-field/po-switch/po-switch.component.ts
+++ b/projects/ui/src/lib/components/po-field/po-switch/po-switch.component.ts
@@ -1,4 +1,4 @@
-import { AfterViewChecked, ChangeDetectorRef, Component, forwardRef } from '@angular/core';
+import { AfterViewChecked, ChangeDetectorRef, Component, ElementRef, forwardRef, ViewChild } from '@angular/core';
 import { NG_VALUE_ACCESSOR } from '@angular/forms';
 
 import { PoSwitchBaseComponent } from './po-switch-base.component';
@@ -44,12 +44,37 @@ import { PoSwitchLabelPosition } from './po-switch-label-position.enum';
 })
 export class PoSwitchComponent extends PoSwitchBaseComponent implements AfterViewChecked {
 
+  @ViewChild('switchContainer', { static: true }) switchContainer: ElementRef;
+
   constructor(private changeDetector: ChangeDetectorRef) {
     super();
   }
 
   ngAfterViewChecked(): void {
     this.changeDetector.detectChanges();
+  }
+
+  /**
+   * Função que atribui foco ao componente.
+   *
+   * Para utilizá-la é necessário ter a instância do componente no DOM, podendo ser utilizado o ViewChild da seguinte forma:
+   *
+   * ```
+   * import { PoSwitchComponent } from '@portinari/portinari-ui';
+   *
+   * ...
+   *
+   * @ViewChild(PoSwitchComponent, { static: true }) switch: PoSwitchComponent;
+   *
+   * focusSwitch() {
+   *   this.switch.focus();
+   * }
+   * ```
+   */
+  focus() {
+    if (!this.disabled) {
+      this.switchContainer.nativeElement.focus();
+    }
   }
 
   getLabelPosition() {

--- a/projects/ui/src/lib/components/po-field/po-textarea/po-textarea-base.component.spec.ts
+++ b/projects/ui/src/lib/components/po-field/po-textarea/po-textarea-base.component.spec.ts
@@ -42,13 +42,6 @@ describe('PoTextareaBase:', () => {
     expectSettersMethod(component, 'required', null, 'required', false);
   });
 
-  it('should set focus', () => {
-    expectSettersMethod(component, 'focus', '', '_focus', true);
-    expectSettersMethod(component, 'focus', 'false', '_focus', false);
-    expectSettersMethod(component, 'focus', 'true', '_focus', true);
-    expectSettersMethod(component, 'focus', null, 'focus', false);
-  });
-
   it('should update property `p-rows` with valid values', () => {
     const validValues = [3, 5, '3', '5'];
     const expectValidValues = [3, 5, 3, 5];
@@ -103,6 +96,16 @@ describe('PoTextareaBase:', () => {
   });
 
   describe('Properties:', () => {
+
+    it('p-focus: should update property with valid values with valid values.', () => {
+      const invalidValues = [undefined, null, 0, false, 'false', 'string'];
+      expectPropertiesValues(component, 'autofocus', invalidValues, false);
+    });
+
+    it('p-focus: should update property with valid values with valid values.', () => {
+      const validValues = [true, 'true', 1];
+      expectPropertiesValues(component, 'autofocus', validValues, true);
+    });
 
     it('p-maxlength: should update property p-maxlength with valid values.', () => {
       const validValues = [105, 1, 7, 0, -5];

--- a/projects/ui/src/lib/components/po-field/po-textarea/po-textarea-base.component.ts
+++ b/projects/ui/src/lib/components/po-field/po-textarea/po-textarea-base.component.ts
@@ -24,8 +24,8 @@ import { maxlengpoailed, minlengpoailed, requiredFailed } from '../validators';
  */
 export abstract class PoTextareaBaseComponent implements ControlValueAccessor, Validator {
 
+  private _autofocus: boolean = false;
   private _disabled: boolean = false;
-  private _focus: boolean = false;
   private _maxlength: number;
   private _minlength: number;
   private _readonly: boolean = false;
@@ -125,16 +125,16 @@ export abstract class PoTextareaBaseComponent implements ControlValueAccessor, V
    *
    * @description
    *
-   * Indica que o campo iniciará com foco.
+   * Aplica foco no elemento ao ser iniciado.
    *
    * @default `false`
    */
-  @Input('p-focus') set focus(focus: boolean) {
-    this._focus = convertToBoolean(focus);
+  @Input('p-focus') set autofocus(focus: boolean) {
+    this._autofocus = convertToBoolean(focus);
   }
 
-  get focus(): boolean {
-    return this._focus;
+  get autofocus(): boolean {
+    return this._autofocus;
   }
 
   /**

--- a/projects/ui/src/lib/components/po-field/po-textarea/po-textarea.component.spec.ts
+++ b/projects/ui/src/lib/components/po-field/po-textarea/po-textarea.component.spec.ts
@@ -131,6 +131,35 @@ describe('PoTextareaComponent:', () => {
       expect(fakeThis.change.emit).toHaveBeenCalledWith(fakeThis.inputEl.nativeElement.value);
     });
 
+    it('focus: should call `focus` of textarea', () => {
+      component.inputEl = {
+        nativeElement: {
+          focus: () => {}
+        }
+      };
+
+      spyOn(component.inputEl.nativeElement, 'focus');
+
+      component.focus();
+
+      expect(component.inputEl.nativeElement.focus).toHaveBeenCalled();
+    });
+
+    it('focus: should`t call `focus` of textarea if `disabled`', () => {
+      component.inputEl = {
+        nativeElement: {
+          focus: () => {}
+        }
+      };
+      component.disabled = true;
+
+      spyOn(component.inputEl.nativeElement, 'focus');
+
+      component.focus();
+
+      expect(component.inputEl.nativeElement.focus).not.toHaveBeenCalled();
+    });
+
     it('writeValueModel: should call change if value exists', () => {
       const value = 'value';
       const fakeThis = {

--- a/projects/ui/src/lib/components/po-field/po-textarea/po-textarea.component.ts
+++ b/projects/ui/src/lib/components/po-field/po-textarea/po-textarea.component.ts
@@ -56,6 +56,29 @@ export class PoTextareaComponent extends PoTextareaBaseComponent {
     super();
   }
 
+  /**
+   * Função que atribui foco ao componente.
+   *
+   * Para utilizá-la é necessário ter a instância do componente no DOM, podendo ser utilizado o ViewChild da seguinte forma:
+   *
+   * ```
+   * import { PoTextareaComponent } from '@portinari/portinari-ui';
+   *
+   * ...
+   *
+   * @ViewChild(PoTextareaComponent, { static: true }) textarea: PoTextareaComponent;
+   *
+   * focusTextarea() {
+   *   this.textarea.focus();
+   * }
+   * ```
+   */
+  focus(): void {
+    if (!this.disabled) {
+      this.inputEl.nativeElement.focus();
+    }
+  }
+
   writeValueModel(value: any): void {
     if (this.inputEl) {
       if (!value) {

--- a/projects/ui/src/lib/components/po-field/po-upload/po-upload-drag-drop/po-upload-drag-drop-area/po-upload-drag-drop-area.component.html
+++ b/projects/ui/src/lib/components/po-field/po-upload/po-upload-drag-drop/po-upload-drag-drop-area/po-upload-drag-drop-area.component.html
@@ -23,9 +23,11 @@
     {{ literals?.dragFilesHere }}
   </div>
 
-  <div class="po-upload-drag-drop-area-select-files"
-  [ngClass]="{'po-clickable': !disabled}"
-  (click)="selectFiles.emit()">
+  <button #selectFilesLink
+    class="po-upload-drag-drop-area-select-files"
+    [disabled]="disabled"
+    [ngClass]="{'po-clickable': !disabled}"
+    (click)="selectFiles.emit()">
     {{ literals?.selectFilesOnComputer }}
-  </div>
+  </button>
 </ng-template>

--- a/projects/ui/src/lib/components/po-field/po-upload/po-upload-drag-drop/po-upload-drag-drop-area/po-upload-drag-drop-area.component.spec.ts
+++ b/projects/ui/src/lib/components/po-field/po-upload/po-upload-drag-drop/po-upload-drag-drop-area/po-upload-drag-drop-area.component.spec.ts
@@ -29,6 +29,24 @@ describe('PoUploadDragDropAreaComponent:', () => {
     expect(component instanceof PoUploadDragDropAreaComponent).toBeTruthy();
   });
 
+  describe('Methods:', () => {
+
+    it('focus: should call `focus` of `selectFilesLinkElement`', () => {
+      component.selectFilesLinkElement = {
+        nativeElement: {
+          focus: () => {}
+        }
+      };
+
+      spyOn(component.selectFilesLinkElement.nativeElement, 'focus');
+
+      component.focus();
+
+      expect(component.selectFilesLinkElement.nativeElement.focus).toHaveBeenCalled();
+    });
+
+  });
+
   describe('Templates:', () => {
 
     it(`should contain 'po-upload-drag-drop-area' and 'po-upload-drag-drop-area-container' classes.`, () => {
@@ -42,6 +60,22 @@ describe('PoUploadDragDropAreaComponent:', () => {
       changeDetector.detectChanges();
 
       expect(nativeElement.querySelector('.po-upload-drag-drop-area-disabled')).toBeTruthy();
+    });
+
+    it(`should contain 'disabled' property in button if disabled is true`, () => {
+      component.disabled = true;
+
+      changeDetector.detectChanges();
+
+      expect(nativeElement.querySelector('button').hasAttribute('disabled')).toBe(true);
+    });
+
+    it(`shouldn't contain 'disabled' property in button if disabled is false`, () => {
+      component.disabled = false;
+
+      changeDetector.detectChanges();
+
+      expect(nativeElement.querySelector('button').hasAttribute('disabled')).toBe(false);
     });
 
     it(`should contain 'po-upload-drag-drop-area-overlay-icon' and 'po-upload-drag-drop-area-overlay-label' if disabled is false

--- a/projects/ui/src/lib/components/po-field/po-upload/po-upload-drag-drop/po-upload-drag-drop-area/po-upload-drag-drop-area.component.ts
+++ b/projects/ui/src/lib/components/po-field/po-upload/po-upload-drag-drop/po-upload-drag-drop-area/po-upload-drag-drop-area.component.ts
@@ -1,4 +1,4 @@
-import { ChangeDetectionStrategy, Component, EventEmitter, Input, Output } from '@angular/core';
+import { ChangeDetectionStrategy, Component, ElementRef, EventEmitter, Input, Output, ViewChild } from '@angular/core';
 
 import { PoUploadLiterals } from '../../interfaces/po-upload-literals.interface';
 
@@ -18,5 +18,13 @@ export class PoUploadDragDropAreaComponent {
   @Input('p-overlay') overlay: boolean;
 
   @Output('p-select-files') selectFiles: EventEmitter<any> = new EventEmitter<any>();
+
+  @ViewChild('selectFilesLink', { static: false }) selectFilesLinkElement: ElementRef;
+
+  constructor(public elementRef: ElementRef) {}
+
+  focus() {
+    this.selectFilesLinkElement.nativeElement.focus();
+  }
 
 }

--- a/projects/ui/src/lib/components/po-field/po-upload/po-upload-drag-drop/po-upload-drag-drop.component.html
+++ b/projects/ui/src/lib/components/po-field/po-upload/po-upload-drag-drop/po-upload-drag-drop.component.html
@@ -1,11 +1,11 @@
 <po-upload-drag-drop-area-overlay #dragDropOverlay *ngIf="isDragOver"
   [p-disabled]="disabled"
   [p-literals]="literals"
-  [p-target]="DragDropAreaElement"
+  [p-target]="dragDropAreaComponent.elementRef"
   (p-area-element)="onAreaElement($event)">
 </po-upload-drag-drop-area-overlay>
 
-<po-upload-drag-drop-area #DragDropArea
+<po-upload-drag-drop-area
   p-upload-drag-drop
   [p-area-element]="areaElement"
   [p-disabled]="disabled"

--- a/projects/ui/src/lib/components/po-field/po-upload/po-upload-drag-drop/po-upload-drag-drop.component.spec.ts
+++ b/projects/ui/src/lib/components/po-field/po-upload/po-upload-drag-drop/po-upload-drag-drop.component.spec.ts
@@ -61,6 +61,14 @@ describe('PoUploadDragDropAreaComponent:', () => {
 
   describe('Methods:', () => {
 
+    it('focus: should call `dragDropAreaComponent.focus`', () => {
+      spyOn(component.dragDropAreaComponent, 'focus');
+
+      component.focus();
+
+      expect(component.dragDropAreaComponent.focus).toHaveBeenCalled();
+    });
+
     it('onDragLeave: should set `isDragOver` to `false`', () => {
       component.isDragOver = true;
 

--- a/projects/ui/src/lib/components/po-field/po-upload/po-upload-drag-drop/po-upload-drag-drop.component.ts
+++ b/projects/ui/src/lib/components/po-field/po-upload/po-upload-drag-drop/po-upload-drag-drop.component.ts
@@ -2,6 +2,7 @@ import { ChangeDetectionStrategy, ChangeDetectorRef, Component, ElementRef, Even
 
 import { convertToInt } from '../../../../utils/util';
 
+import { PoUploadDragDropAreaComponent } from './po-upload-drag-drop-area/po-upload-drag-drop-area.component';
 import { PoUploadLiterals } from '../interfaces/po-upload-literals.interface';
 
 const PoUploadDragDropHeightDefault = 320;
@@ -20,8 +21,7 @@ export class PoUploadDragDropComponent {
   isDragOver: boolean = false;
 
   @ViewChild('dragDropOverlay', { read: ElementRef, static: false }) dragDropOverlayElement: ElementRef;
-
-  @ViewChild('DragDropArea', { read: ElementRef, static: true }) DragDropAreaElement: ElementRef;
+  @ViewChild(PoUploadDragDropAreaComponent, { static: true }) dragDropAreaComponent: PoUploadDragDropAreaComponent;
 
   @Input('p-disabled') disabled: boolean;
 
@@ -42,6 +42,10 @@ export class PoUploadDragDropComponent {
   @Output('p-select-files') selectFiles: EventEmitter<any> = new EventEmitter<any>();
 
   constructor(private changeDetector: ChangeDetectorRef) { }
+
+  focus() {
+    this.dragDropAreaComponent.focus();
+  }
 
   onAreaElement(element: HTMLElement) {
     this.areaElement = element;

--- a/projects/ui/src/lib/components/po-field/po-upload/po-upload-drag-drop/po-upload-drag-drop.directive.ts
+++ b/projects/ui/src/lib/components/po-field/po-upload/po-upload-drag-drop/po-upload-drag-drop.directive.ts
@@ -2,7 +2,6 @@ import { Directive, EventEmitter, HostListener, Input, Output } from '@angular/c
 
 import { PoNotificationService } from '../../../../services/po-notification/po-notification.service';
 import { PoUploadLiterals } from '../interfaces/po-upload-literals.interface';
-import { PoUploadFileRestrictions } from '../interfaces/po-upload-file-restriction.interface';
 
 @Directive({
   selector: '[p-upload-drag-drop]'

--- a/projects/ui/src/lib/components/po-field/po-upload/po-upload.component.html
+++ b/projects/ui/src/lib/components/po-field/po-upload/po-upload.component.html
@@ -24,6 +24,7 @@
     </po-upload-drag-drop>
 
     <po-button *ngIf="!hideSelectButton && !displayDragDrop"
+      #uploadButton
       class="po-upload-button"
       for="file"
       [p-disabled]="isDisabled"

--- a/projects/ui/src/lib/components/po-field/po-upload/po-upload.component.spec.ts
+++ b/projects/ui/src/lib/components/po-field/po-upload/po-upload.component.spec.ts
@@ -306,6 +306,58 @@ describe('PoUploadComponent:', () => {
       expect(component['cleanInputValue']).toHaveBeenCalled();
     });
 
+    it('focus: should call `uploadButton.focus` if `uploadButton` is defined', () => {
+      component.hideSelectButton = false;
+      spyOnProperty(component, 'displayDragDrop').and.returnValue(false);
+
+      fixture.detectChanges();
+
+      spyOn(component['uploadButton'], 'focus');
+
+      component.focus();
+
+      expect(component['uploadButton'].focus).toHaveBeenCalled();
+    });
+
+    it('focus: should`t call `uploadButton.focus` if `disabled`', () => {
+      component.hideSelectButton = false;
+      component.disabled = true;
+      spyOnProperty(component, 'displayDragDrop').and.returnValue(false);
+
+      fixture.detectChanges();
+
+      spyOn(component['uploadButton'], 'focus');
+
+      component.focus();
+
+      expect(component['uploadButton'].focus).not.toHaveBeenCalled();
+    });
+
+    it('focus: should call `poUploadDragDropComponent.focus` if `displayDragDrop` is defined', () => {
+      spyOnProperty(component, 'displayDragDrop').and.returnValue(true);
+
+      fixture.detectChanges();
+
+      spyOn(component['poUploadDragDropComponent'], 'focus');
+
+      component.focus();
+
+      expect(component['poUploadDragDropComponent'].focus).toHaveBeenCalled();
+    });
+
+    it('focus: should`t call `poUploadDragDropComponent.focus` if `disabled`', () => {
+      component.disabled = true;
+      spyOnProperty(component, 'displayDragDrop').and.returnValue(true);
+
+      fixture.detectChanges();
+
+      spyOn(component['poUploadDragDropComponent'], 'focus');
+
+      component.focus();
+
+      expect(component['poUploadDragDropComponent'].focus).not.toHaveBeenCalled();
+    });
+
     it('onFileChangeDragDrop: should call `updateFiles` with files.', () => {
       const files = 'teste';
 

--- a/projects/ui/src/lib/components/po-field/po-upload/po-upload.component.ts
+++ b/projects/ui/src/lib/components/po-field/po-upload/po-upload.component.ts
@@ -2,11 +2,13 @@ import { Component, ElementRef, forwardRef, ViewChild } from '@angular/core';
 import { NG_VALIDATORS, NG_VALUE_ACCESSOR } from '@angular/forms';
 
 import { formatBytes, isMobile } from '../../../utils/util';
+import { PoButtonComponent } from './../../po-button/po-button.component';
 import { PoI18nPipe } from '../../../services/po-i18n/po-i18n.pipe';
 import { PoNotificationService } from '../../../services/po-notification/po-notification.service';
 import { PoProgressStatus } from '../../po-progress/enums/po-progress-status.enum';
 
 import { PoUploadBaseComponent } from './po-upload-base.component';
+import { PoUploadDragDropComponent } from './po-upload-drag-drop/po-upload-drag-drop.component';
 import { PoUploadFile } from './po-upload-file';
 import { PoUploadService } from './po-upload.service';
 import { PoUploadStatus } from './po-upload-status.enum';
@@ -82,6 +84,8 @@ export class PoUploadComponent extends PoUploadBaseComponent {
   private calledByCleanInputValue: boolean = false;
 
   @ViewChild('inputFile', {read: ElementRef, static: true }) private inputFile: ElementRef;
+  @ViewChild(PoUploadDragDropComponent, { static: false }) private poUploadDragDropComponent: PoUploadDragDropComponent;
+  @ViewChild('uploadButton', { static: false }) private uploadButton: PoButtonComponent;
 
   constructor(
     private i18nPipe: PoI18nPipe,
@@ -133,6 +137,36 @@ export class PoUploadComponent extends PoUploadBaseComponent {
     this.currentFiles = undefined;
     this.updateModel([]);
     this.cleanInputValue();
+  }
+
+  /**
+   * Função que atribui foco ao componente.
+   *
+   * Para utilizá-la é necessário ter a instância do componente no DOM, podendo ser utilizado o ViewChild da seguinte forma:
+   *
+   * ```
+   * import { PoUploadComponent } from '@portinari/portinari-ui';
+   *
+   * ...
+   *
+   * @ViewChild(PoUploadComponent, { static: true }) upload: PoUploadComponent;
+   *
+   * focusUpload() {
+   *   this.upload.focus();
+   * }
+   * ```
+   */
+  focus() {
+    if (!this.disabled) {
+      if (this.uploadButton) {
+        this.uploadButton.focus();
+        return;
+      }
+
+      if (this.displayDragDrop) {
+        this.poUploadDragDropComponent.focus();
+      }
+    }
   }
 
   // Verifica se existe algum arquivo sendo enviado ao serviço.


### PR DESCRIPTION
**FIELDS**

**DTHFUI-1720**
_____________________________________________________________________________

**PR Checklist**

- [x] Código
- [x] Testes unitários
- [x] Documentação
- [x] Samples

**Qual o comportamento atual?**
Não é possível  atribuir foco aos inputs via método.

**Qual o novo comportamento?**
Criado método para dar foco aos componentes.

**Simulação**
Chamar o método focus() conforme documentação.
Exemplo da funcionalidade no Sample do Portinari Combo -Booking Hotel
Testar seguintes componentes e validar pois não pode chamar se estiver disabled:
- Checkbox-group
- Combo
- Datepicker
- Datepicker-range
- Decimal
- Email
- Input
- Login
- Lookup
- Multiselect
- Number
- Password
- Radio-group
- Rich-text (não tem propriedade disabled)
- Select
- Switch
- Textarea
- Upload (normal e drag drop)
- Url
- Button (foi feita inclusão da funcionalidade no button por conta do upload)


**OBS:** 
- (datepicker, decimal, input, lookup, multiselect, textarea) foi alterado o nome da propriedade existente `focus` para  `autofocus` já que a propriedade nativa do html é `autofocus` e também pois estava gerando conflito com o nome do método.
- Foi criada uma PR no portinari-style e no portinari-theme, pois o link do drag drop não tinha foco e ação por teclado.