### PR TITLE
fix(combo): corrige comportamento dos exemplos heroes

### DIFF
--- a/projects/ui/src/lib/components/po-field/po-combo/samples/sample-po-combo-heroes-reactive-form/sample-po-combo-heroes-reactive-form.component.html
+++ b/projects/ui/src/lib/components/po-field/po-combo/samples/sample-po-combo-heroes-reactive-form/sample-po-combo-heroes-reactive-form.component.html
@@ -1,7 +1,7 @@
 <div class="po-row">
   <po-widget
     class="po-lg-6"
-    p-primary-label="Know more"
+    [p-primary-label]="knowMoreLabel"
     (p-primary-action)="knowMore()">
 
     <div [formGroup]="form">
@@ -33,7 +33,7 @@
         </po-info>
       </div>
 
-      <hr>
+      <po-divider></po-divider>
 
       <div class="po-row">
         <po-info

--- a/projects/ui/src/lib/components/po-field/po-combo/samples/sample-po-combo-heroes-reactive-form/sample-po-combo-heroes-reactive-form.component.ts
+++ b/projects/ui/src/lib/components/po-field/po-combo/samples/sample-po-combo-heroes-reactive-form/sample-po-combo-heroes-reactive-form.component.ts
@@ -21,6 +21,10 @@ export class SamplePoComboHeroesReactiveFormComponent implements OnInit {
     });
   }
 
+  get knowMoreLabel() {
+    return this.form.valid ? 'Know more' : undefined;
+  }
+
   knowMore() {
     const heroName = this.form.get('hero').value;
 

--- a/projects/ui/src/lib/components/po-field/po-combo/samples/sample-po-combo-heroes/sample-po-combo-heroes.component.html
+++ b/projects/ui/src/lib/components/po-field/po-combo/samples/sample-po-combo-heroes/sample-po-combo-heroes.component.html
@@ -1,7 +1,7 @@
 <div class="po-row">
   <po-widget
     class="po-lg-6"
-    p-primary-label="Know more"
+    [p-primary-label]="knowMoreLabel"
     (p-primary-action)="knowMore(heroName)">
 
     <po-combo
@@ -30,7 +30,7 @@
         </po-info>
       </div>
 
-      <hr>
+      <po-divider></po-divider>
 
       <div class="po-row">
         <po-info

--- a/projects/ui/src/lib/components/po-field/po-combo/samples/sample-po-combo-heroes/sample-po-combo-heroes.component.ts
+++ b/projects/ui/src/lib/components/po-field/po-combo/samples/sample-po-combo-heroes/sample-po-combo-heroes.component.ts
@@ -14,6 +14,10 @@ export class SamplePoComboHeroesComponent {
 
   constructor(private http: HttpClient) { }
 
+  get knowMoreLabel() {
+    return this.heroName ? 'Know more' : undefined;
+  }
+
   knowMore(heroName: string) {
     window.open(`http://google.com/search?q=${heroName}`, '_blank');
   }


### PR DESCRIPTION
**PO-COMBO**

**Fixes DTHFUI-865**
***

**PR Checklist**

- [x] Código
- [ ] Testes unitários
- [ ] Documentação
- [ ] Samples
***

**Qual o comportamento atual?**
Nos samples Heroes, se não houver opção selecionada no THF_Combo e clicar em 'Saiba Mais', o link redireciona para busca do Google para os termos null e undefined. O método knowMore() espera um herói como parâmetro para concatenar com a URL porém está recebendo undefined / null.

**Qual o novo comportamento?**
Exibirá o link para click apenas se houver alguma opção selecionada no `po-combo`.

**Simulação**
Executar os *samples* no portal ou localmente.