### PR TITLE
fix(multiselect): corrige comportamento do componente no IE

### DIFF
--- a/projects/ui/src/lib/components/po-field/po-multiselect/po-multiselect-dropdown/po-multiselect-dropdown.component.html
+++ b/projects/ui/src/lib/components/po-field/po-multiselect/po-multiselect-dropdown/po-multiselect-dropdown.component.html
@@ -13,7 +13,7 @@
     </div>
 
     <po-multiselect-item *ngFor="let option of options"
-      [p-option]="option"
+      [p-label]="option.label"
       [p-selected]="isSelectedItem(option)"
       (p-change)="clickItem($event, option)">
     </po-multiselect-item>

--- a/projects/ui/src/lib/components/po-field/po-multiselect/po-multiselect-item/po-multiselect-item.component.html
+++ b/projects/ui/src/lib/components/po-field/po-multiselect/po-multiselect-item/po-multiselect-item.component.html
@@ -1,6 +1,4 @@
-<li [value]="option?.value"
-  (click)="itemClicked()"
-  [class.po-multiselect-item-selected]="selected">
+<li [class.po-multiselect-item-selected]="selected" (click)="itemClicked()">
 
   <a class="po-multiselect-item">
     <input
@@ -10,7 +8,7 @@
       type="checkbox">
 
     <label class="po-multiselect-checkbox-label po-clickable">
-      {{ option?.label }}
+      {{ label }}
     </label>
   </a>
 </li>

--- a/projects/ui/src/lib/components/po-field/po-multiselect/po-multiselect-item/po-multiselect-item.component.spec.ts
+++ b/projects/ui/src/lib/components/po-field/po-multiselect/po-multiselect-item/po-multiselect-item.component.spec.ts
@@ -17,8 +17,6 @@ describe('PoMultiselectItemComponent', () => {
   beforeEach(() => {
     fixture = TestBed.createComponent(PoMultiselectItemComponent);
     component = fixture.componentInstance;
-
-    fixture.detectChanges();
   });
 
   it('should be created', () => {

--- a/projects/ui/src/lib/components/po-field/po-multiselect/po-multiselect-item/po-multiselect-item.component.ts
+++ b/projects/ui/src/lib/components/po-field/po-multiselect/po-multiselect-item/po-multiselect-item.component.ts
@@ -1,6 +1,4 @@
-import { Component, EventEmitter, Input, Output } from '@angular/core';
-
-import { PoMultiselectOption } from './../po-multiselect-option.interface';
+import { ChangeDetectionStrategy, Component, EventEmitter, Input, Output } from '@angular/core';
 
 /**
  * @docsPrivate
@@ -11,12 +9,13 @@ import { PoMultiselectOption } from './../po-multiselect-option.interface';
  */
 @Component({
   selector: 'po-multiselect-item',
-  templateUrl: './po-multiselect-item.component.html'
+  templateUrl: './po-multiselect-item.component.html',
+  changeDetection: ChangeDetectionStrategy.OnPush
 })
 export class PoMultiselectItemComponent {
 
-  /** Opção que irá gerar o item, implementando a interface PoMultiselectOption. */
-  @Input('p-option') option: PoMultiselectOption = null;
+  /** Rótulo do item. */
+  @Input('p-label') label: string;
 
   /** Esta propriedade indica se o campo está selecionado ou não. */
   @Input('p-selected') selected?: boolean = false;


### PR DESCRIPTION
**PO MULTISELECT**

**DTHFUI-1857**
_____________________________________________________________________________

**PR Checklist**

- [x] Código
- [ ] Testes unitários
- [ ] Documentação
- [ ] Samples

**Qual o comportamento atual?**
Ao informar `p-options` com valores numéricos muito grandes,
não era possível abrir o mesmo no Internet Explorer.

**Qual o novo comportamento?**
A propriedade value da tag li não deveria ser utilizada
quando a mesma estiver abaixo da tag ul, isso acabava causando problemas no IE.
Portanto foi removido a propriedade value da tag li no componente PoMultiSelectItem

**Simulação**
- Utilizar PoMultiselect com valores númericos grandes.

``` 
app.component.html

<po-multiselect
  class="po-md-4"
  p-label="Conta transitória"
  name="multiselect"
  [(ngModel)]="multiselect"
  [p-options]="multiselectOptions">
</po-multiselect>

<div class="po-row">
  <pre>{{ multiselectOptions | json }}</pre>
</div>
```

```
import { Component, AfterViewInit } from '@angular/core';

@Component({
  selector: 'app-root',
  templateUrl: './app.component.html'
})
export class AppComponent implements AfterViewInit {

  multiselect = [];

  multiselectOptions = [];

  ngAfterViewInit() {
    this.multiselectOptions = this.factoryOptions();
  }

  private factoryOptions() {
    const labels = [];

    for (let i = 0; i < 30; i++) {
      const value = (Math.random() * 10000000000000).toFixed();
      const label = `${value} - Portinari UI`;

      labels.push({ label,  value });
    }

    return labels;
  }
}
```