### PR TITLE
feat(storage): adiciona po-loki-driver no storage

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
     "custom-idle-queue": "2.1.2",
     "http-status-codes": "^1.3.0",
     "localforage": "1.4.0",
+    "lokijs": "1.5.7",
     "monaco-editor": "0.15.6",
     "rxjs": "~6.4.0",
     "rxjs-compat": "~6.4.0",

--- a/projects/storage/ng-package.json
+++ b/projects/storage/ng-package.json
@@ -6,6 +6,7 @@
   },
   "whitelistedNonPeerDependencies": [
     "custom-idle-queue",
-    "localforage"
+    "localforage",
+    "lokijs"
   ]
 }

--- a/projects/storage/package.json
+++ b/projects/storage/package.json
@@ -12,12 +12,14 @@
   },
   "dependencies": {
     "custom-idle-queue": "2.1.2",
-    "localforage": "1.4.0"
+    "localforage": "1.4.0",
+    "lokijs": "1.5.7"
   },
   "peerDependencies": {
     "@angular/core": "~8.0.0",
     "custom-idle-queue": "2.1.2",
     "localforage": "1.4.0",
+    "lokijs": "1.5.7",
     "rxjs": "~6.4.0",
     "zone.js": "~0.9.1"
   }

--- a/projects/storage/src/lib/drivers/lokijs/po-loki-driver.spec.ts
+++ b/projects/storage/src/lib/drivers/lokijs/po-loki-driver.spec.ts
@@ -1,0 +1,723 @@
+import { PoLokiDriver } from './po-loki-driver';
+
+import * as LocalForage from 'localforage';
+import { handleThrowError } from '../../util-test/util';
+
+describe('PoLokiDriver', () => {
+
+  const items = [
+    { id: 'item1', value: 'value1' },
+    { id: 'item2', value: 'value2' },
+    { id: 'item3', value: 'value3' },
+    { id: 'item4', value: 'value4' },
+    { id: 'item5', value: 'value5' }
+  ];
+
+  describe('Iteration methods:', () => {
+
+    const poLokiDriver = new PoLokiDriver();
+
+    it('should be created', () => {
+      expect(poLokiDriver instanceof PoLokiDriver).toBeTruthy();
+    });
+
+    describe('constructor:', () => {
+
+      it('should call initStorage', () => {
+        spyOn(poLokiDriver, <any> 'initStorage');
+
+        poLokiDriver['driver']._initStorage(null);
+
+        expect(poLokiDriver['initStorage']).toHaveBeenCalled();
+      });
+
+      it('should call clear', () => {
+        spyOn(poLokiDriver, <any> 'clear');
+
+        poLokiDriver['driver'].clear(null);
+
+        expect(poLokiDriver['clear']).toHaveBeenCalled();
+      });
+
+      it('should call getItem', () => {
+        spyOn(poLokiDriver, <any> 'getItem');
+
+        poLokiDriver['driver'].getItem(null);
+
+        expect(poLokiDriver['getItem']).toHaveBeenCalled();
+      });
+
+      it('should call iterate', () => {
+        spyOn(poLokiDriver, <any> 'iterate');
+
+        poLokiDriver['driver'].iterate(null);
+
+        expect(poLokiDriver['iterate']).toHaveBeenCalled();
+      });
+
+      it('should call key', () => {
+        spyOn(poLokiDriver, <any> 'key');
+
+        poLokiDriver['driver'].key(null);
+
+        expect(poLokiDriver['key']).toHaveBeenCalled();
+      });
+
+      it('should call keys', () => {
+        spyOn(poLokiDriver, <any> 'keys');
+
+        poLokiDriver['driver'].keys(null);
+
+        expect(poLokiDriver['keys']).toHaveBeenCalled();
+      });
+
+      it('should call length', () => {
+        spyOn(poLokiDriver, <any> 'length');
+
+        poLokiDriver['driver'].length(null);
+
+        expect(poLokiDriver['length']).toHaveBeenCalled();
+      });
+
+      it('should call removeItem', () => {
+        spyOn(poLokiDriver, <any> 'removeItem');
+
+        poLokiDriver['driver'].removeItem(null);
+
+        expect(poLokiDriver['removeItem']).toHaveBeenCalled();
+      });
+
+      it('should call setItem', () => {
+        spyOn(poLokiDriver, <any> 'setItem');
+
+        poLokiDriver['driver'].setItem(null);
+
+        expect(poLokiDriver['setItem']).toHaveBeenCalled();
+      });
+
+    });
+
+    it(`clear: should call 'clearCollection' if 'hasCollectionAndDataInCollection' return 'true'`, async () => {
+      const localForage = createLocalForageInstance();
+
+      spyOn(poLokiDriver, <any>'hasCollectionAndDataInCollection').and.returnValue(true);
+      spyOn(poLokiDriver, <any>'clearCollection');
+
+      await poLokiDriver['clear'](localForage);
+
+      expect(poLokiDriver['clearCollection']).toHaveBeenCalled();
+    });
+
+    it(`clear: shouldn't call 'clearCollection' if 'hasCollectionAndDataInCollection' return 'false'`, async () => {
+      const localForage = createLocalForageInstance();
+
+      spyOn(poLokiDriver, <any>'hasCollectionAndDataInCollection').and.returnValue(false);
+      spyOn(poLokiDriver, <any>'clearCollection');
+
+      await poLokiDriver['clear'](localForage);
+
+      expect(poLokiDriver['clearCollection']).not.toHaveBeenCalled();
+    });
+
+    it(`getItem: should call 'getItemInCollectionBy' if 'hasCollectionAndDataInCollection' return 'true'`, async () => {
+      const localForage = createLocalForageInstance();
+      const key = 'key1';
+
+      spyOn(poLokiDriver, <any>'hasCollectionAndDataInCollection').and.returnValue(true);
+      spyOn(poLokiDriver, <any>'getItemInCollectionBy');
+
+      await poLokiDriver['getItem'](localForage, key);
+
+      expect(poLokiDriver['getItemInCollectionBy']).toHaveBeenCalled();
+    });
+
+    it(`getItem: shouldn't call 'getItemInCollectionBy' if 'hasCollectionAndDataInCollection' return 'false'`, async () => {
+      const localForage = createLocalForageInstance();
+      const key = 'key1';
+
+      spyOn(poLokiDriver, <any>'hasCollectionAndDataInCollection').and.returnValue(false);
+      spyOn(poLokiDriver, <any>'getItemInCollectionBy');
+
+      await poLokiDriver['getItem'](localForage, key);
+
+      expect(poLokiDriver['getItemInCollectionBy']).not.toHaveBeenCalled();
+    });
+
+    it(`getItem: should return item value if item is found`, async () => {
+      const localForage = createLocalForageInstance();
+      const key = 'key1';
+
+      spyOn(poLokiDriver, <any>'hasCollectionAndDataInCollection').and.returnValue(true);
+      spyOn(poLokiDriver, <any>'getItemInCollectionBy').and.returnValue({value: 'value1'});
+
+      expect(await poLokiDriver['getItem'](localForage, key)).toBe('value1');
+    });
+
+    it(`getItem: should return null if item is not found`, async () => {
+      const localForage = createLocalForageInstance();
+      const key = 'key1';
+
+      spyOn(poLokiDriver, <any>'hasCollectionAndDataInCollection').and.returnValue(true);
+      spyOn(poLokiDriver, <any>'getItemInCollectionBy').and.returnValue(undefined);
+
+      expect(await poLokiDriver['getItem'](localForage, key)).toBeNull();
+    });
+
+    it(`getItem: should return null if hasCollectionAndDataInCollection return false`, async () => {
+      const localForage = createLocalForageInstance();
+      const key = 'key1';
+
+      spyOn(poLokiDriver, <any>'hasCollectionAndDataInCollection').and.returnValue(false);
+
+      expect(await poLokiDriver['getItem'](localForage, key)).toBeNull();
+    });
+
+    it('initStorage: should call `configureLokiStorage` and `databaseInitialize.bind`', () => {
+      spyOn(poLokiDriver, <any>'configureLokiStorage');
+      spyOn(poLokiDriver['databaseInitialize'], <never>'bind');
+
+      poLokiDriver['initStorage'](getConfigMock());
+
+      expect(poLokiDriver['configureLokiStorage']).toHaveBeenCalled();
+      expect(poLokiDriver['databaseInitialize'].bind).toHaveBeenCalled();
+    });
+
+    it('initStorage: should return a error if configureLokiStorage return an error', async () => {
+      spyOn(poLokiDriver, <any>'configureLokiStorage').and.throwError('');
+
+      expect(await handleThrowError(poLokiDriver['initStorage'](getConfigMock())))
+      .toThrowError(`Cannot configure Loki Storage`);
+    });
+
+    it(`iterate: should call 'iterateWithDataItem' with 'iteratorcallback' if 'hasCollectionAndDataInCollection'
+    return true`, async () => {
+      const localForage = createLocalForageInstance();
+      const iteratorCallbackMock = () => {};
+
+      spyOn(poLokiDriver, <any>'hasCollectionAndDataInCollection').and.returnValue(true);
+      spyOn(poLokiDriver, <any>'iterateWithDataItem');
+
+      await poLokiDriver['iterate'](localForage, iteratorCallbackMock);
+
+      expect(poLokiDriver['iterateWithDataItem']).toHaveBeenCalledWith(iteratorCallbackMock);
+    });
+
+    it(`iterate: shouldn't call 'iterateWithDataItem' if 'hasCollectionAndDataInCollection' return false`, async () => {
+      const localForage = createLocalForageInstance();
+      const iteratorCallbackMock = () => {};
+
+      spyOn(poLokiDriver, <any>'hasCollectionAndDataInCollection').and.returnValue(false);
+      spyOn(poLokiDriver, <any>'iterateWithDataItem');
+
+      await poLokiDriver['iterate'](localForage, iteratorCallbackMock);
+
+      expect(poLokiDriver['iterateWithDataItem']).not.toHaveBeenCalled();
+    });
+
+    it(`key: should call 'getLokiMap' and return item value passed by parameter if 'hasCollection' return true`, async () => {
+      const localForage = createLocalForageInstance();
+      const nMock = 1;
+      const getLokiMapItems = items;
+
+      spyOn(poLokiDriver, <any>'hasCollection').and.returnValue(true);
+      spyOn(poLokiDriver, <any>'getLokiMap').and.returnValue(getLokiMapItems);
+
+      expect(await poLokiDriver['key'](localForage, nMock)).toEqual({ id: 'item2', value: 'value2' });
+      expect(poLokiDriver['getLokiMap']).toHaveBeenCalled();
+    });
+
+    it(`key: shouldn't call 'getLokiMap' and return null if 'hasCollection' return false`, async () => {
+      const localForage = createLocalForageInstance();
+      const nMock = 1;
+      const getLokiMapItems = items;
+
+      spyOn(poLokiDriver, <any>'hasCollection').and.returnValue(false);
+      spyOn(poLokiDriver, <any>'getLokiMap').and.returnValue(getLokiMapItems);
+
+      expect(await poLokiDriver['key'](localForage, nMock)).toBeNull();
+      expect(poLokiDriver['getLokiMap']).not.toHaveBeenCalled();
+    });
+
+    it(`keys: should call 'getLokiMap' and return an array of keys if 'hasCollection' return true`, async () => {
+      const localForage = createLocalForageInstance();
+      const getAllLokiMapItems = {1: 'key1', 2: 'key2', key: 'key3'};
+      const result = ['key1', 'key2', 'key3'];
+
+      spyOn(poLokiDriver, <any>'hasCollection').and.returnValue(true);
+      spyOn(poLokiDriver, <any>'getLokiMap').and.returnValue(getAllLokiMapItems);
+
+      expect(await poLokiDriver['keys'](localForage)).toEqual(result);
+      expect(poLokiDriver['getLokiMap']).toHaveBeenCalled();
+    });
+
+    it(`keys: shouldn't call 'getLokiMap' and return null if 'hasCollection' return false`, async () => {
+      const localForage = createLocalForageInstance();
+
+      spyOn(poLokiDriver, <any>'hasCollection').and.returnValue(false);
+      spyOn(poLokiDriver, <any>'getLokiMap');
+
+      expect(await poLokiDriver['keys'](localForage)).toBeNull();
+      expect(poLokiDriver['getLokiMap']).not.toHaveBeenCalled();
+    });
+
+    it(`length: should call 'getNumberItensInCollection' and return a number of items in collection`, async () => {
+      const localForage = createLocalForageInstance();
+      const numberOfItemsInCollection = 12;
+
+      spyOn(poLokiDriver, <any>'hasCollection').and.returnValue(true);
+      spyOn(poLokiDriver, <any>'getNumberItensInCollection').and.returnValue(numberOfItemsInCollection);
+
+      expect(await poLokiDriver['length'](localForage)).toEqual(numberOfItemsInCollection);
+      expect(poLokiDriver['getNumberItensInCollection']).toHaveBeenCalled();
+    });
+
+    it(`length: shouldn't call 'getNumberItensInCollection' and return zero if hasCollection return false`, async () => {
+      const localForage = createLocalForageInstance();
+
+      spyOn(poLokiDriver, <any>'hasCollection').and.returnValue(false);
+      spyOn(poLokiDriver, <any>'getNumberItensInCollection');
+
+      expect(await poLokiDriver['length'](localForage)).toBe(0);
+      expect(poLokiDriver['getNumberItensInCollection']).not.toHaveBeenCalled();
+    });
+
+    it(`removeItem: should call 'findAndRemoveItem' with key parameter if hasCollection return true`, async () => {
+      const localForage = createLocalForageInstance();
+      const keyParameter = 'value1';
+
+      spyOn(poLokiDriver, <any>'hasCollection').and.returnValue(true);
+      spyOn(poLokiDriver, <any>'findAndRemoveItem');
+
+      await poLokiDriver['removeItem'](localForage, keyParameter);
+
+      expect(poLokiDriver['findAndRemoveItem']).toHaveBeenCalledWith(keyParameter);
+    });
+
+    it(`removeItem: shouldn't call 'findAndRemoveItem' if hasCollection return false`, async () => {
+      const localForage = createLocalForageInstance();
+      const keyParameter = 'value1';
+
+      spyOn(poLokiDriver, <any>'hasCollection').and.returnValue(false);
+      spyOn(poLokiDriver, <any>'findAndRemoveItem');
+
+      await poLokiDriver['removeItem'](localForage, keyParameter);
+
+      expect(poLokiDriver['findAndRemoveItem']).not.toHaveBeenCalled();
+    });
+
+    it(`setItem: should call 'hasDataInCollection' and 'insertOrUpdate' if 'hasCollection' return true`, async () => {
+      const localForage = createLocalForageInstance();
+      const keyParameter = 'key1';
+      const valueParameter = 'value1';
+
+      spyOn(poLokiDriver, <any>'hasCollection').and.returnValue(true);
+      spyOn(poLokiDriver, <any>'hasDataInCollection');
+      spyOn(poLokiDriver, <any>'insertOrUpdate');
+
+      await poLokiDriver['setItem'](localForage, keyParameter, valueParameter);
+
+      expect(poLokiDriver['hasDataInCollection']).toHaveBeenCalled();
+      expect(poLokiDriver['insertOrUpdate']).toHaveBeenCalled();
+    });
+
+    it(`setItem: should call 'getItemInCollectionBy' if 'hasCollection' and 'hasDataInCollection' return true`, async () => {
+      const localForage = createLocalForageInstance();
+      const keyParameter = 'key1';
+      const valueParameter = 'value1';
+
+      spyOn(poLokiDriver, <any>'hasCollection').and.returnValue(true);
+      spyOn(poLokiDriver, <any>'hasDataInCollection').and.returnValue(true);
+      spyOn(poLokiDriver, <any>'getItemInCollectionBy');
+      spyOn(poLokiDriver, <any>'insertOrUpdate');
+
+      await poLokiDriver['setItem'](localForage, keyParameter, valueParameter);
+
+      expect(poLokiDriver['getItemInCollectionBy']).toHaveBeenCalled();
+    });
+
+    it(`setItem: should call 'insertOrUpdate' with 'getItemInCollectionBy' return, keyParameter and valueParameter`, async () => {
+      const localForage = createLocalForageInstance();
+      const keyParameter = 'key1';
+      const valueParameter = 'value1';
+      const getItemInCollectionByReturn = {id: 'value'};
+
+      spyOn(poLokiDriver, <any>'hasCollection').and.returnValue(true);
+      spyOn(poLokiDriver, <any>'hasDataInCollection').and.returnValue(true);
+      spyOn(poLokiDriver, <any>'getItemInCollectionBy').and.returnValue(getItemInCollectionByReturn);
+      spyOn(poLokiDriver, <any>'insertOrUpdate');
+
+      await poLokiDriver['setItem'](localForage, keyParameter, valueParameter);
+
+      expect(poLokiDriver['insertOrUpdate']).toHaveBeenCalledWith(getItemInCollectionByReturn, valueParameter, keyParameter);
+    });
+
+    it(`setItem: should resolve with valueParameter value`, async () => {
+      const localForage = createLocalForageInstance();
+      const keyParameter = 'key1';
+      const valueParameter = 'value1';
+
+      spyOn(poLokiDriver, <any>'hasCollection').and.returnValue(true);
+      spyOn(poLokiDriver, <any>'hasDataInCollection');
+      spyOn(poLokiDriver, <any>'insertOrUpdate');
+
+      expect(await poLokiDriver['setItem'](localForage, keyParameter, valueParameter)).toBe(valueParameter);
+    });
+
+    it(`setItem: shouldn't call 'hasDataInCollection', 'getItemInCollectionBy' and 'insertOrUpdate' if 'hasCollection'
+    return false `, async () => {
+      const localForage = createLocalForageInstance();
+      const keyParameter = 'key1';
+      const valueParameter = 'value1';
+
+      spyOn(poLokiDriver, <any>'hasCollection').and.returnValue(false);
+      spyOn(poLokiDriver, <any>'hasDataInCollection');
+      spyOn(poLokiDriver, <any>'getItemInCollectionBy');
+      spyOn(poLokiDriver, <any>'insertOrUpdate');
+
+      await poLokiDriver['setItem'](localForage, keyParameter, valueParameter);
+
+      expect(poLokiDriver['hasDataInCollection']).not.toHaveBeenCalled();
+      expect(poLokiDriver['getItemInCollectionBy']).not.toHaveBeenCalled();
+      expect(poLokiDriver['insertOrUpdate']).not.toHaveBeenCalled();
+    });
+
+    it(`setItem: shouldn't call 'getItemInCollectionBy' if 'hasCollection' return true and 'hasDataInCollection'
+    return false `, async () => {
+      const localForage = createLocalForageInstance();
+      const keyParameter = 'key1';
+      const valueParameter = 'value1';
+
+      spyOn(poLokiDriver, <any>'hasCollection').and.returnValue(true);
+      spyOn(poLokiDriver, <any>'hasDataInCollection').and.returnValue(false);
+      spyOn(poLokiDriver, <any>'getItemInCollectionBy');
+      spyOn(poLokiDriver, <any>'insertOrUpdate');
+
+      await poLokiDriver['setItem'](localForage, keyParameter, valueParameter);
+
+      expect(poLokiDriver['getItemInCollectionBy']).not.toHaveBeenCalled();
+    });
+
+  });
+
+  describe('Access storage methods :', () => {
+
+    const poLokiDriver = new PoLokiDriver();
+
+    it(`getDriver: should return driver`, () => {
+      const driver = 'lokijs';
+
+      poLokiDriver['driver'] = driver;
+
+      expect(poLokiDriver.getDriver()).toBe(driver);
+    });
+
+    it(`addCollection: should call 'db.addCollection' with 'options.storeName' and '{ unique: ['key'] }`, () => {
+      const fakeThis = {
+        db: {
+          addCollection: () => {}
+        }
+      };
+      const fakeOptions = { storeName: 'store' };
+
+      spyOn(fakeThis.db, 'addCollection');
+
+      poLokiDriver['addCollection'].call(fakeThis, fakeOptions);
+
+      expect(fakeThis.db.addCollection).toHaveBeenCalledWith(fakeOptions.storeName, { unique: ['key'] });
+    });
+
+    it(`clearCollection: should call 'collection.clear' with '{ removeIndices: false }'`, () => {
+      const fakeThis = {
+        collection: {
+          clear: () => {}
+        }
+      };
+      spyOn(fakeThis.collection, 'clear');
+
+      poLokiDriver['clearCollection'].call(fakeThis);
+
+      expect(fakeThis.collection.clear).toHaveBeenCalledWith({ removeIndices: false });
+    });
+
+    it('configureLokiStorage: should set lokijs options with set up default values', () => {
+      const databaseInitializedMock = function databaseInitialize() {};
+
+      poLokiDriver['configureLokiStorage'](getConfigMock(), databaseInitializedMock);
+
+      const dbOptions = poLokiDriver['db'].options;
+
+      // O LokiJs cria uma instancia interna com o valor do adapter para gerenciar as configurações do adapter e em seguida
+      // seta o valor do adapter para null. (pode ser verificado na linha 1011 do arquivo lokijs.js no nodeModules).
+      expect(dbOptions.adapter).toBeNull();
+
+      expect(dbOptions.autoload).toBe(true);
+      expect(dbOptions.autoloadCallback).toBe(databaseInitializedMock);
+      expect(dbOptions.autosave).toBe(true);
+      expect(dbOptions.autosaveInterval).toBe(4000);
+    });
+
+    it(`findAndRemoveItem: should call 'collection.findAndRemove' with '{ key: <keyParameter> }'`, () => {
+      const fakeThis = {
+        collection: {
+          findAndRemove: () => {}
+        }
+      };
+      const keyParameter = 'key1';
+
+      spyOn(fakeThis.collection, 'findAndRemove');
+
+      poLokiDriver['findAndRemoveItem'].call(fakeThis, keyParameter);
+
+      expect(fakeThis.collection.findAndRemove).toHaveBeenCalledWith({ key: keyParameter });
+    });
+
+    it(`getCollection: should call 'db.getCollection' with 'options.storeName'`, () => {
+      const fakeThis = {
+        db: {
+          getCollection: () => {}
+        }
+      };
+      const fakeOptions = { storeName: 'store' };
+
+      spyOn(fakeThis.db, 'getCollection');
+
+      poLokiDriver['getCollection'].call(fakeThis, fakeOptions);
+
+      expect(fakeThis.db.getCollection).toHaveBeenCalledWith(fakeOptions.storeName);
+    });
+
+    it(`databaseInitialize: should call 'getCollection' with 'options' and call 'hasCollection'`, () => {
+      const fakeThis = {
+        collection: undefined,
+        getCollection: () => {},
+        hasCollection: () => {},
+        addCollection: () => {}
+      };
+      const fakeOptions = { storeName: 'store' };
+      const fakeResolve = () => {};
+
+      spyOn(fakeThis, 'getCollection');
+      spyOn(fakeThis, 'hasCollection');
+      spyOn(fakeThis, 'addCollection');
+
+      poLokiDriver['databaseInitialize'].call(fakeThis, fakeOptions, fakeResolve);
+
+      expect(fakeThis['getCollection']).toHaveBeenCalledWith(fakeOptions);
+      expect(fakeThis['hasCollection']).toHaveBeenCalled();
+    });
+
+    it(`databaseInitialize: should call 'addCollection' with 'options' if 'hasCollection' return false`, () => {
+      const fakeThis = {
+        collection: undefined,
+        getCollection: () => {},
+        hasCollection: () => false,
+        addCollection: () => {}
+      };
+      const fakeOptions = { storeName: 'store' };
+      const fakeResolve = () => {};
+
+      spyOn(fakeThis, 'getCollection');
+      spyOn(fakeThis, 'hasCollection').and.returnValue(false);
+      spyOn(fakeThis, 'addCollection');
+
+      poLokiDriver['databaseInitialize'].call(fakeThis, fakeOptions, fakeResolve);
+
+      expect(fakeThis['addCollection']).toHaveBeenCalledWith(fakeOptions);
+    });
+
+    it(`databaseInitialize: shouldn't call 'addCollection' with 'options' if 'hasCollection' return true`, () => {
+      const fakeThis = {
+        collection: undefined,
+        getCollection: () => {},
+        hasCollection: () => true,
+        addCollection: () => {}
+      };
+      const fakeOptions = { storeName: 'store' };
+      const fakeResolve = () => {};
+
+      spyOn(fakeThis, 'getCollection');
+      spyOn(fakeThis, 'hasCollection').and.returnValue(true);
+      spyOn(fakeThis, 'addCollection');
+
+      poLokiDriver['databaseInitialize'].call(fakeThis, fakeOptions, fakeResolve);
+
+      expect(fakeThis['addCollection']).not.toHaveBeenCalled();
+    });
+
+    it(`getItemInCollectionBy: should call 'collection.by' with 'fieldKey' and 'key' parameters`, () => {
+      const fakeThis = {
+        collection: {
+          by: () => {}
+        }
+      };
+      const fakeFieldKey = 'fieldKey';
+      const fakeKey = 'Key';
+
+      spyOn(fakeThis.collection, 'by');
+
+      poLokiDriver['getItemInCollectionBy'].call(fakeThis, fakeFieldKey, fakeKey);
+
+      expect(fakeThis.collection.by).toHaveBeenCalledWith(fakeFieldKey, fakeKey);
+    });
+
+    it(`getLokiMap: should return lokiMap`, () => {
+      const fakeThis = {
+        collection: {
+          constraints: {
+            unique: {
+              key: {
+                lokiMap: 'lokiMapValue'
+              }
+            }
+          }
+        }
+      };
+
+      expect(poLokiDriver['getLokiMap'].call(fakeThis)).toBe('lokiMapValue');
+    });
+
+    it(`hasCollection: should return a collection value`, () => {
+      const fakeThis = {
+        collection: 'collection'
+      };
+
+      expect(poLokiDriver['hasCollection'].call(fakeThis)).toBeTruthy();
+
+      fakeThis.collection = undefined;
+
+      expect( poLokiDriver['hasCollection'].call(fakeThis)).toBeUndefined();
+
+      fakeThis.collection = null;
+
+      expect(poLokiDriver['hasCollection'].call(fakeThis)).toBeNull();
+    });
+
+    it(`hasDataInCollection: should return true if has data in collection`, () => {
+      const fakeThis = {
+        collection: {
+          data: 'value1'
+        }
+      };
+
+      expect(poLokiDriver['hasDataInCollection'].call(fakeThis)).toBeTruthy();
+    });
+
+    it(`hasDataInCollection: should return false if doesn't has data in collection`, () => {
+      const fakeThis = {
+        collection: {
+          data: undefined
+        }
+      };
+
+      expect( poLokiDriver['hasDataInCollection'].call(fakeThis)).toBeFalsy();
+    });
+
+    it(`hasCollectionAndDataInCollection: should return true if 'hasCollection' and 'hasDataInCollection' return true`, () => {
+      spyOn(poLokiDriver, <any>'hasCollection').and.returnValue(true);
+      spyOn(poLokiDriver, <any>'hasDataInCollection').and.returnValue(true);
+
+      expect(poLokiDriver['hasCollectionAndDataInCollection']()).toBeTruthy();
+    });
+
+    it(`hasCollectionAndDataInCollection: should return false if 'hasCollection' return false`, () => {
+      spyOn(poLokiDriver, <any>'hasCollection').and.returnValue(false);
+      spyOn(poLokiDriver, <any>'hasDataInCollection').and.returnValue(true);
+
+      expect(poLokiDriver['hasCollectionAndDataInCollection']()).toBeFalsy();
+    });
+
+    it(`hasCollectionAndDataInCollection: should return false if 'hasDataInCollection' return false`, () => {
+      spyOn(poLokiDriver, <any>'hasCollection').and.returnValue(true);
+      spyOn(poLokiDriver, <any>'hasDataInCollection').and.returnValue(false);
+
+      expect(poLokiDriver['hasCollectionAndDataInCollection']()).toBeFalsy();
+    });
+
+    it(`insertOrUpdate: should call 'update' with item with value and doesn't call 'insert' if has item parameter`, () => {
+      const fakeThis = {
+        collection: {
+          update: () => {},
+          insert: () => {}
+        }
+      };
+      const itemParameter = { value : 'value1' };
+      const valueParameter = 'value2';
+      const keyParameter = 'key';
+
+      spyOn(fakeThis.collection, 'update');
+      spyOn(fakeThis.collection, 'insert');
+
+      poLokiDriver['insertOrUpdate'].call(fakeThis, itemParameter, valueParameter, keyParameter);
+
+      expect(fakeThis.collection.update).toHaveBeenCalledWith({value: valueParameter});
+      expect(fakeThis.collection.insert).not.toHaveBeenCalled();
+    });
+
+    it(`insertOrUpdate: should call 'insert' with key and value and doesn't call 'insert' if doesn't have
+    item parameter`, () => {
+      const fakeThis = {
+        collection: {
+          update: () => {},
+          insert: () => {}
+        }
+      };
+      const itemParameter = undefined;
+      const valueParameter = 'value2';
+      const keyParameter = 'key';
+
+      spyOn(fakeThis.collection, 'update');
+      spyOn(fakeThis.collection, 'insert');
+
+      poLokiDriver['insertOrUpdate'].call(fakeThis, itemParameter, valueParameter, keyParameter);
+
+      expect(fakeThis.collection.update).not.toHaveBeenCalled();
+      expect(fakeThis.collection.insert).toHaveBeenCalledWith({key: keyParameter, value: valueParameter});
+    });
+
+    it(`iterateWithDataItem: should call 'forEach'`, () => {
+      const fakeThis = {
+        collection: {
+          data: items
+        }
+      };
+
+      const iteratorParameter = {
+        iteratorCallbackFunctionMock: () => {}
+      };
+
+      spyOn(iteratorParameter, 'iteratorCallbackFunctionMock');
+
+      poLokiDriver['iterateWithDataItem'].call(fakeThis, iteratorParameter.iteratorCallbackFunctionMock);
+
+      expect(iteratorParameter.iteratorCallbackFunctionMock).toHaveBeenCalledTimes(5);
+    });
+
+    it(`getNumberItensInCollection: should call 'collection.count'`, () => {
+      const fakeThis = {
+        collection: {
+          count: () => {}
+        }
+      };
+
+      spyOn(fakeThis.collection, 'count');
+
+      poLokiDriver['getNumberItensInCollection'].call(fakeThis);
+
+      expect(fakeThis.collection.count).toHaveBeenCalled();
+    });
+
+  });
+
+});
+
+function createLocalForageInstance() {
+  return LocalForage.createInstance(getConfigMock());
+}
+
+function getConfigMock() {
+  return {
+    driverOrder: ['lokijs', 'WEBSQL', 'INDEXEDDB', 'LOCALSTORAGE'],
+    name: 'store',
+    storeName: 'storeName'
+  };
+}

--- a/projects/storage/src/lib/drivers/lokijs/po-loki-driver.ts
+++ b/projects/storage/src/lib/drivers/lokijs/po-loki-driver.ts
@@ -1,0 +1,239 @@
+import Loki from 'lokijs';
+import LokiIndexedAdapter from 'lokijs/src/loki-indexed-adapter';
+
+const keyField = 'key';
+
+export class PoLokiDriver {
+
+  private collection;
+  private db: any;
+  private driver: any;
+
+  constructor() {
+    const self = this;
+    this.driver = {
+      _driver: 'lokijs',
+      _initStorage: function(options: any) {
+        return self.initStorage(options);
+      },
+      clear: function() {
+        return self.clear(this);
+      },
+      getItem: function(key: any) {
+        return self.getItem(this, key);
+      },
+      iterate: function(iteratorCallback: any) {
+        return self.iterate(this, iteratorCallback);
+      },
+      key: function(n: any) {
+        return self.key(this, n);
+      },
+      keys: function() {
+        return self.keys(this);
+      },
+      length: function() {
+        return self.length(this);
+      },
+      removeItem: function(key: any) {
+        return self.removeItem(this, key);
+      },
+      setItem: function(key: any, value: any) {
+        return self.setItem(this, key, value);
+      }
+    };
+  }
+
+  // Funções de iteração
+
+  private clear(localforage: any) {
+    return new Promise(resolve => {
+      localforage.ready().then(() => {
+        if (this.hasCollectionAndDataInCollection()) {
+          this.clearCollection();
+        }
+        resolve();
+      });
+    });
+  }
+
+  private getItem(localforage: any, key: any) {
+    return new Promise(resolve => {
+      localforage.ready().then(() => {
+        if (this.hasCollectionAndDataInCollection()) {
+          const item = this.getItemInCollectionBy(keyField, key);
+          if (item) {
+            resolve(item.value);
+          }
+        }
+        resolve(null);
+      });
+    });
+  }
+
+  private initStorage(options: any) {
+    return new Promise(resolve => {
+      try {
+        this.configureLokiStorage(options, this.databaseInitialize.bind(this, options, resolve));
+      } catch {
+        throw new Error(`Cannot configure Loki Storage`);
+      }
+    });
+  }
+
+  private iterate(localforage: any, iteratorCallback: Function) {
+    return new Promise(resolve => {
+      localforage.ready().then(() => {
+        if (this.hasCollectionAndDataInCollection()) {
+          this.iterateWithDataItem(iteratorCallback);
+        }
+        resolve();
+      });
+    });
+  }
+
+  private key(localforage: any, n: string | number) {
+    return new Promise(resolve => {
+      localforage.ready().then(() => {
+        if (this.hasCollection()) {
+          const map = this.getLokiMap();
+          resolve(map[n]);
+        }
+        resolve(null);
+      });
+    });
+  }
+
+  private keys(localforage: any) {
+    return new Promise(resolve => {
+      localforage.ready().then(() => {
+        if (this.hasCollection()) {
+          const keys = [];
+          const map = this.getLokiMap();
+          for (const key of Object.keys(map)) {
+            keys.push(map[key]);
+          }
+          resolve(keys);
+        }
+        resolve(null);
+      });
+    });
+  }
+
+  private length(localforage: any) {
+    return new Promise(resolve => {
+      localforage.ready().then(() => {
+        if (this.hasCollection()) {
+          resolve(this.getNumberItensInCollection());
+        }
+        resolve(0);
+      });
+    });
+  }
+
+  private removeItem(localforage: any, key: any) {
+    return new Promise(resolve => {
+      localforage.ready().then(() => {
+        if (this.hasCollection()) {
+          this.findAndRemoveItem(key);
+        }
+        resolve();
+      });
+    });
+  }
+
+  private setItem(localforage: any, key: any, value: any) {
+    return new Promise(resolve => {
+      localforage.ready().then(() => {
+        if (this.hasCollection()) {
+          let item: any;
+          if (this.hasDataInCollection()) {
+            item = this.getItemInCollectionBy(keyField, key);
+          }
+          this.insertOrUpdate(item, value, key);
+        }
+        resolve(value);
+      });
+    });
+  }
+
+  // Funções de acesso ao storage
+
+  getDriver() {
+    return this.driver;
+  }
+
+  private addCollection(options: any): any {
+    return this.db.addCollection(options.storeName, { unique: [keyField] });
+  }
+
+  private clearCollection() {
+    this.collection.clear({ removeIndices: false });
+  }
+
+  private configureLokiStorage(options: any, databaseInitialize: any) {
+    const idbAdapter = new LokiIndexedAdapter();
+    this.db = new Loki(options.name, {
+      adapter: idbAdapter,
+      autoload: true,
+      autoloadCallback: databaseInitialize,
+      autosave: true,
+      autosaveInterval: 4000
+    });
+  }
+
+  private findAndRemoveItem(key: any) {
+    this.collection.findAndRemove({ [keyField]: key });
+  }
+
+  private getCollection(options: any): any {
+    return this.db.getCollection(options.storeName);
+  }
+
+  private databaseInitialize(options: any, resolve: Function) {
+    this.collection = this.getCollection(options);
+    if (!this.hasCollection()) {
+      this.collection = this.addCollection(options);
+    }
+    resolve();
+  }
+
+  private getItemInCollectionBy(fieldKey: string, key: any) {
+    return this.collection.by(fieldKey, key);
+  }
+
+  private getLokiMap() {
+    return this.collection.constraints.unique[keyField].lokiMap;
+  }
+
+  private hasCollection() {
+    return this.collection;
+  }
+
+  private hasDataInCollection() {
+    return this.collection.data && this.collection.data.length;
+  }
+
+  private hasCollectionAndDataInCollection() {
+    return this.hasCollection() && this.hasDataInCollection();
+  }
+
+  private insertOrUpdate(item: any, value: any, key: any) {
+    if (item) {
+      item.value = value;
+      this.collection.update(item);
+    } else {
+      this.collection.insert({ [keyField]: key, value: value });
+    }
+  }
+
+  private iterateWithDataItem(iteratorcallback: Function) {
+    this.collection.data.forEach(element => {
+      iteratorcallback(element.value, element[keyField], element.$loki);
+    });
+  }
+
+  private getNumberItensInCollection(): number {
+    return this.collection.count();
+  }
+
+}

--- a/projects/storage/src/lib/services/po-storage-config.interface.ts
+++ b/projects/storage/src/lib/services/po-storage-config.interface.ts
@@ -16,9 +16,10 @@ export interface PoStorageConfig {
    * Os *drivers* utilizados pelo `PoStorageService` são:
    * - `indexeddb`;
    * - `websql`;
-   * - `localstorage`.
+   * - `localstorage`;
+   * - `lokijs`.
    *
-   * Exemplo de ordem de preferência: `['websql', 'indexeddb', 'localstorage']`.
+   * Exemplo de ordem de preferência: `['lokijs', 'websql', 'indexeddb', 'localstorage']`.
    */
   driverOrder?: Array<string>;
 

--- a/projects/sync/src/lib/services/po-schema/po-schema.service.spec.ts
+++ b/projects/sync/src/lib/services/po-schema/po-schema.service.spec.ts
@@ -79,6 +79,12 @@ describe('PoSchemaService:', () => {
       expect(PoSchemaService['isSchemaKey'](data, 'schemaName')).toBeFalsy();
     });
 
+    it('isSchemaKey: should return false if doesn`t have data', () => {
+      const data = undefined;
+
+      expect(PoSchemaService['isSchemaKey'](data, 'schemaName')).toBeFalsy();
+    });
+
     it('create: should call PoSchemaUtil.getRecordId and save with schema, record, id and return value of save', async () => {
       const id = 'id';
       const saveReturn = { field: 'save return' };

--- a/projects/sync/src/lib/services/po-schema/po-schema.service.ts
+++ b/projects/sync/src/lib/services/po-schema/po-schema.service.ts
@@ -43,7 +43,7 @@ export class PoSchemaService {
    * @param {string} schemaName Nome do *schema*.
    */
   private static isSchemaKey(data: string, schemaName: string): boolean {
-    return data.startsWith(`${schemaName}:`);
+    return data ? data.startsWith(`${schemaName}:`) : false;
   }
 
   constructor(private poSchemaDefinitionService: PoSchemaDefinitionService , private poStorage: PoStorageService) { }


### PR DESCRIPTION
**PO-STORAGE**

**DTHFUI-1367**
_____________________________________________________________________________

**PR Checklist**

- [x] Código
- [x] Testes unitários
- [x] Documentação
- [ ] Samples

**Qual o comportamento atual?**
O LocalForage do po-storage apenas aceita os drivers: 'websql', 'indexeddb' e 'localstorage'.

**Qual o novo comportamento?**
Agora o localForage do po-storage passa a aceitar um novo driver 'lokijs' que permite salvar os dados em memória aumentando consideravelmente a performance de leitura e gravação dos dados.

**Simulação**
Foi enviado um link com duas aplicações que foram feitas no thf, uma para rodar localmente e a outra é uma aplicação no ionic para poder testar nos dispositivos.