### PR TITLE
fix(toolbar): corrige o funcionamento sem o p-profile

### DIFF
--- a/projects/ui/src/lib/components/po-toolbar/po-toolbar-base.component.spec.ts
+++ b/projects/ui/src/lib/components/po-toolbar/po-toolbar-base.component.spec.ts
@@ -2,14 +2,14 @@ import { expectPropertiesValues } from '../../util-test/util-expect.spec';
 
 import { PoToolbarBaseComponent } from './po-toolbar-base.component';
 
-describe('PoToolbarBaseComponent: ', () => {
+describe('PoToolbarBaseComponent:', () => {
   const component = new PoToolbarBaseComponent();
 
   it('should be created', () => {
     expect(component instanceof PoToolbarBaseComponent).toBeTruthy();
   });
 
-  describe('Properties: ', () => {
+  describe('Properties:', () => {
     it('notificationNumber: should set with invalid values and receive 0 value', () => {
       const invalidValues = [undefined, 'menu', true, false, NaN, [], {}];
 
@@ -25,23 +25,30 @@ describe('PoToolbarBaseComponent: ', () => {
 
   describe('Methods: ', () => {
 
-    describe('isShowProfile: ', () => {
+    describe('isShowProfile:', () => {
 
       beforeEach(() => {
         component.profile = undefined;
         component.profileActions = undefined;
       });
 
-      it('should return true when have a profile', () => {
+      it('should return `true` if have a profile.', () => {
         component.profile = {title: 'Jhony', avatar: 'link'};
 
-        expect(component.isShowProfile).toBeTruthy();
+        expect(component.isShowProfile).toBe(true);
       });
 
-      it('should return true when have a profileItems', () => {
+      it('should return `true` if have a profileItems.', () => {
         component.profileActions = [{ label: 'Ação', action: () => {} }];
 
-        expect(component.isShowProfile).toBeTruthy();
+        expect(component.isShowProfile).toBe(true);
+      });
+
+      it('should return `false` if not have a profile or profileItems', () => {
+        component.profile = undefined;
+        component.profileActions = undefined;
+
+        expect(component.isShowProfile).toBe(false);
       });
 
     });

--- a/projects/ui/src/lib/components/po-toolbar/po-toolbar-base.component.ts
+++ b/projects/ui/src/lib/components/po-toolbar/po-toolbar-base.component.ts
@@ -72,7 +72,7 @@ export class PoToolbarBaseComponent {
     return this._notificationNumber;
   }
 
-  get isShowProfile() {
-    return this.profile || this.profileActions;
+  get isShowProfile(): boolean {
+    return !!(this.profile || this.profileActions);
   }
 }

--- a/projects/ui/src/lib/components/po-toolbar/po-toolbar-profile/po-toolbar-profile.component.html
+++ b/projects/ui/src/lib/components/po-toolbar/po-toolbar-profile/po-toolbar-profile.component.html
@@ -1,5 +1,5 @@
 <div #profileElement class="po-toolbar-profile po-clickable" (click)="popup.toggle()">
-  <ng-container *ngIf="profile.avatar; then avatar; else userIcon"></ng-container>
+  <po-avatar p-size="xs" [p-src]="profileAvatar"></po-avatar>
 </div>
 
 <po-popup #popup
@@ -13,7 +13,7 @@
     <po-avatar
       class="po-toolbar-profile-item-avatar"
       p-size="sm"
-      [p-src]="profile.avatar || defaultAvatar">
+      [p-src]="profileAvatar">
     </po-avatar>
 
     <div>
@@ -28,11 +28,3 @@
   </div>
 
 </po-popup>
-
-<ng-template #avatar>
-  <po-avatar p-size="xs" [p-src]="profile.avatar"></po-avatar>
-</ng-template>
-
-<ng-template #userIcon>
-  <span class="po-icon po-icon-user po-toolbar-icon"></span>
-</ng-template>

--- a/projects/ui/src/lib/components/po-toolbar/po-toolbar-profile/po-toolbar-profile.component.spec.ts
+++ b/projects/ui/src/lib/components/po-toolbar/po-toolbar-profile/po-toolbar-profile.component.spec.ts
@@ -9,7 +9,7 @@ import { PoPopupComponent } from '../../po-popup//po-popup.component';
 
 import { PoToolbarProfileComponent } from './po-toolbar-profile.component';
 
-describe('PoToolbarProfileComponent: ', () => {
+describe('PoToolbarProfileComponent:', () => {
   let component: PoToolbarProfileComponent;
   let fixture: ComponentFixture<PoToolbarProfileComponent>;
   let nativeElement;
@@ -46,24 +46,34 @@ describe('PoToolbarProfileComponent: ', () => {
     expect(component).toBeTruthy();
   });
 
-  describe('Templates: ', () => {
+  describe('Templates:', () => {
 
-    it('should show template avatar when have profile avatar', () => {
+    it('should display avatar if have profile.', () => {
       component.profile = { title: 'teste', avatar: 'teste2' };
 
       fixture.detectChanges();
 
       expect(nativeElement.querySelector('po-avatar')).toBeTruthy();
-      expect(nativeElement.querySelector('.po-toolbar-icon')).toBeFalsy();
     });
 
-    it('should show template userIcon when not have profile avatar', () => {
-      component.profile = { title: 'teste' };
+  });
 
-      fixture.detectChanges();
+  describe('Methods:', () => {
 
-      expect(nativeElement.querySelector('.po-toolbar-icon')).toBeTruthy();
-      expect(nativeElement.querySelector('po-avatar:not(.po-toolbar-profile-item-avatar)')).toBeFalsy();
+    describe('isShowProfile: ', () => {
+
+      it('should return `true` if have a profile.', () => {
+        component.profile = {title: 'Jhony', avatar: 'link'};
+
+        expect(component.profileAvatar).toBeTruthy();
+      });
+
+      it('should return `undefined` if not have a profile.', () => {
+        component.profile = undefined;
+
+        expect(component.profileAvatar).toBeUndefined();
+      });
+
     });
 
   });

--- a/projects/ui/src/lib/components/po-toolbar/po-toolbar-profile/po-toolbar-profile.component.ts
+++ b/projects/ui/src/lib/components/po-toolbar/po-toolbar-profile/po-toolbar-profile.component.ts
@@ -5,8 +5,6 @@ import { PoControlPositionService } from '../../../services/po-control-position/
 import { PoToolbarProfile } from './po-toolbar-profile.interface';
 import { PoToolbarAction } from '../po-toolbar-action.interface';
 
-const poToolbarProfileDefaultAvatar = './assets/images/portinari-logo-user.svg';
-
 /**
  * @docsPrivate
  *
@@ -29,6 +27,8 @@ export class PoToolbarProfileComponent {
   /** Define uma lista de ações. */
   @Input('p-profile-actions') profileActions?: Array<PoToolbarAction>;
 
-  readonly defaultAvatar = poToolbarProfileDefaultAvatar;
+  get profileAvatar() {
+    return this.profile ? this.profile.avatar : undefined;
+  }
 
 }

--- a/projects/ui/src/lib/components/po-toolbar/samples/sample-po-toolbar-logged/sample-po-toolbar-logged.component.html
+++ b/projects/ui/src/lib/components/po-toolbar/samples/sample-po-toolbar-logged/sample-po-toolbar-logged.component.html
@@ -13,7 +13,7 @@
 <div class="po-row">
   <div class="sample-container">
     <po-widget class="po-sm-12">
-      <div class="po-font-title"> Hello, {{ profile.title }}. </div>
+      <div class="po-font-title">Hello, {{ profile.title }}.</div>
       <div class="po-font-subtitle"> Let's work hard! </div>
     </po-widget>
   </div>

--- a/projects/ui/src/lib/components/po-toolbar/samples/sample-po-toolbar-logged/sample-po-toolbar-logged.component.ts
+++ b/projects/ui/src/lib/components/po-toolbar/samples/sample-po-toolbar-logged/sample-po-toolbar-logged.component.ts
@@ -17,7 +17,7 @@ export class SamplePoToolbarLoggedComponent {
   ];
 
   profile: PoToolbarProfile = {
-    avatar: 'https://thf.totvs.com.br/assets/graphics/logo-po.png',
+    avatar: 'https://via.placeholder.com/48x48?text=AVATAR',
     subtitle: 'dev@portinari.com.br',
     title: 'Mr. Dev Portinari'
   };
@@ -44,7 +44,7 @@ export class SamplePoToolbarLoggedComponent {
   }
 
   onClickNotification(item: PoToolbarAction) {
-    window.open('https://thf.totvs.com.br/dev', '_blank');
+    window.open('https://github.com/portinariui/portinari-angular/blob/master/CHANGELOG.md', '_blank');
 
     item.type = 'default';
   }


### PR DESCRIPTION
**PO-TOOLBAR**

**DTHFUI-1936**
***

**PR Checklist**

- [x] Código
- [x] Testes unitários
- [ ] Documentação
- [x] Samples

***

**Qual o comportamento atual?**
O problema ocorre dada a falta de definição da propriedade `p-profile` tendo a definição de uma `p-profile-actions` definida no mesmo contexto.

**Qual o novo comportamento?**
Agora o componente permite utilizar a propriedade `p-profile-actions` sem que haja um `p-profile` definido.

**Simulação**
É possível simular o problema removendo a definição de `p-profile` no _sample logged_ do componente.

Style: https://github.com/portinariui/portinari-style/pull/38