### PR TITLE
feat(notification): permitir alterar tempo de duração

### DIFF
--- a/projects/ui/src/lib/services/po-notification/po-notification-base.service.spec.ts
+++ b/projects/ui/src/lib/services/po-notification/po-notification-base.service.spec.ts
@@ -171,6 +171,34 @@ describe('PoNotificationService ', () => {
     expect(notification.action).toHaveBeenCalledWith();
   });
 
+  describe('Methods: ', () => {
+
+    it('should be duration 10000 when not informed', () => {
+      spyOn(service, 'createToaster');
+      service.success({message: 'teste'});
+
+      expect(service.createToaster).toHaveBeenCalledWith(
+        mockToaster({type: PoToasterType.Success, duration: 10000})
+      );
+    });
+
+    it('should be duration equals 5 seconds', () => {
+      spyOn(service, 'createToaster');
+      service.success({message: 'teste', duration: 5000});
+
+      expect(service.createToaster).toHaveBeenCalledWith(
+        mockToaster({type: PoToasterType.Success, duration: 5000})
+      );
+    });
+
+    it('should change default duration to 3 seconds', () => {
+      spyOn(service, 'setDefaultDuration').and.callThrough();
+      service.setDefaultDuration(3000);
+
+      expect(service.setDefaultDuration).toHaveBeenCalledWith(3000);
+      expect(service['defaultDuration']).toBe(3000);
+    });
+  });
 });
 
 function mockToaster(obj: any) {
@@ -181,7 +209,8 @@ function mockToaster(obj: any) {
     orientation: PoToasterOrientation.Bottom,
     action: undefined,
     actionLabel: undefined,
-    position: 0
+    position: 0,
+    duration: 10000
   };
 
   for (const prop in obj) {

--- a/projects/ui/src/lib/services/po-notification/po-notification-base.service.ts
+++ b/projects/ui/src/lib/services/po-notification/po-notification-base.service.ts
@@ -18,7 +18,9 @@ import { PoToasterType } from './po-toaster/po-toaster-type.enum';
  * Cada um destes métodos recebe como parâmetro o objeto "PoNotification" que contém os dados da mensagem e o
  * objeto ViewContainerRef que é a representação do container do componente onde será criada a notificação.
  *
- * Estas notificações serão exibidas durante 10 segundos, após este tempo a mesma é removida automaticamente.
+ * Estas notificações serão exibidas durante 10 segundos por padrão, podendo ser alterada conforme necessidade.
+ * Após este tempo a mesma é removida automaticamente.
+ *
  */
 export abstract class PoNotificationBaseService {
 
@@ -28,8 +30,8 @@ export abstract class PoNotificationBaseService {
   // Array responsável por guardar a instância de po-toaster's inferiores.
   stackBottom: Array<ComponentRef<any>> = [];
 
-  // Duração do toaster ativo.
-  protected durationToaster = 10000;
+  // Duração da notificação ativa.
+  private defaultDuration = 10000;
 
   /**
    * Emite uma notificação de sucesso.
@@ -68,6 +70,17 @@ export abstract class PoNotificationBaseService {
   }
 
   /**
+   * Define em milissegundos a duração padrão para as notificações.
+   *
+   * > Padrão 10 segundos.
+   *
+   * @param defaultDuration {number} Duração em milisegundos
+   */
+  public setDefaultDuration(defaultDuration: number) {
+    this.defaultDuration = defaultDuration;
+  }
+
+  /**
    * @docsPrivate
    *
    * Cria um objeto do tipo PoToaster de acordo o tipo.
@@ -94,7 +107,8 @@ export abstract class PoNotificationBaseService {
       orientation: orientation,
       action: (<PoNotification>notification).action,
       actionLabel: (<PoNotification>notification).actionLabel,
-      position: index
+      position: index,
+      duration: (<PoNotification>notification).duration || this.defaultDuration
     };
 
     if ((<PoNotification>notification).action) {

--- a/projects/ui/src/lib/services/po-notification/po-notification.interface.ts
+++ b/projects/ui/src/lib/services/po-notification/po-notification.interface.ts
@@ -26,4 +26,7 @@ export interface PoNotification {
    * @default `Bottom`
    */
   orientation?: PoToasterOrientation;
+
+  /** Define em milissegundos o tempo de duração que a notificação ficará disponível em tela. */
+  duration?: number;
 }

--- a/projects/ui/src/lib/services/po-notification/po-notification.service.spec.ts
+++ b/projects/ui/src/lib/services/po-notification/po-notification.service.spec.ts
@@ -1,5 +1,5 @@
 import { Component, NgModule } from '@angular/core';
-import { TestBed, inject,  ComponentFixture } from '@angular/core/testing';
+import { TestBed, inject, ComponentFixture } from '@angular/core/testing';
 import { CommonModule } from '@angular/common';
 
 import { configureTestSuite } from './../../util-test/util-expect.spec';
@@ -25,7 +25,7 @@ class TestModule { }
 })
 class TestComponent {
 
-  constructor(service: PoNotificationService) {}
+  constructor(service: PoNotificationService) { }
 }
 
 describe('PoNotificationService ', () => {
@@ -58,7 +58,8 @@ describe('PoNotificationService ', () => {
       message: '',
       type: PoToasterType.Error,
       orientation: PoToasterOrientation.Top,
-      position: 1
+      position: 1,
+      duration: 10000
     });
 
     jasmine.clock().tick(10001);
@@ -73,7 +74,8 @@ describe('PoNotificationService ', () => {
       message: '',
       type: PoToasterType.Error,
       orientation: PoToasterOrientation.Bottom,
-      position: 1
+      position: 1,
+      duration: 10000
     });
 
     jasmine.clock().tick(5001);
@@ -82,7 +84,8 @@ describe('PoNotificationService ', () => {
       message: '',
       type: PoToasterType.Error,
       orientation: PoToasterOrientation.Bottom,
-      position: 1
+      position: 1,
+      duration: 10000
     });
 
     jasmine.clock().tick(5000);
@@ -105,4 +108,38 @@ describe('PoNotificationService ', () => {
     expect(poNotificationService.stackTop.length === 0).toBeFalsy();
   }));
 
- });
+  describe('Methods: ', () => {
+
+    it('should be a create toaster with 3 seconds duration',
+      inject([PoNotificationService], (poNotificationService: PoNotificationService) => {
+
+      poNotificationService.createToaster({
+        message: '',
+        type: PoToasterType.Success,
+        position: 1,
+        duration: 3000
+      });
+
+      jasmine.clock().tick(3001);
+
+      expect(poNotificationService.stackTop.length === 0).toBeTruthy();
+
+    }));
+
+    it('should be a create toaster with 3 seconds duration as default duration',
+      inject([PoNotificationService], (poNotificationService: PoNotificationService) => {
+
+      poNotificationService.setDefaultDuration(3000);
+      poNotificationService.createToaster({
+        message: '',
+        type: PoToasterType.Success,
+        position: 1
+      });
+
+      jasmine.clock().tick(3001);
+
+      expect(poNotificationService.stackTop.length === 0).toBeTruthy();
+
+    }));
+  });
+});

--- a/projects/ui/src/lib/services/po-notification/po-notification.service.ts
+++ b/projects/ui/src/lib/services/po-notification/po-notification.service.ts
@@ -55,7 +55,7 @@ export class PoNotificationService extends PoNotificationBaseService {
     if (toaster.action === undefined) {
       setTimeout(() => {
         this.destroyToaster(componentRef);
-      }, this.durationToaster);
+      }, toaster.duration);
     }
   }
 

--- a/projects/ui/src/lib/services/po-notification/samples/sample-po-notification-labs/sample-po-notification-labs.component.html
+++ b/projects/ui/src/lib/services/po-notification/samples/sample-po-notification-labs/sample-po-notification-labs.component.html
@@ -7,13 +7,24 @@
 
 <form #f="ngForm">
 
-  <po-radio-group
-    class="po-md-12"
-    name="type"
-    [(ngModel)]="type"
-    p-label="Type"
-    [p-options]="typeOptions">
-  </po-radio-group>
+  <div class="po-row">
+
+    <po-radio-group
+      class="po-md-6"
+      name="type"
+      [(ngModel)]="type"
+      p-label="Type"
+      [p-options]="typeOptions">
+    </po-radio-group>
+
+    <po-radio-group
+      class="po-md-6"
+      name="orientation"
+      [(ngModel)]="orientation"
+      p-label="Orientation"
+      [p-options]="orientationOptions">
+    </po-radio-group>
+  </div>
 
   <po-input
     class="po-md-6"
@@ -24,6 +35,21 @@
     p-required>
   </po-input>
 
+  <po-number
+    class="po-md-6"
+    name="duration"
+    [(ngModel)]="duration"
+    p-clean
+    p-label="Duration">
+  </po-number>
+
+  <po-switch
+    class="po-md-6"
+    name="action"
+    [(ngModel)]="action"
+    p-label="Action">
+  </po-switch>
+
   <po-input
     class="po-md-6"
     name="actionLabel"
@@ -31,21 +57,6 @@
     p-clean
     p-label="Action Label">
   </po-input>
-
-  <po-radio-group
-    class="po-md-12"
-    name="orientation"
-    [(ngModel)]="orientation"
-    p-label="Orientation"
-    [p-options]="orientationOptions">
-  </po-radio-group>
-
-  <po-switch
-    class="po-md-3"
-    name="action"
-    [(ngModel)]="action"
-    p-label="Action">
-  </po-switch>
 
   <div class="po-row">
     <po-button

--- a/projects/ui/src/lib/services/po-notification/samples/sample-po-notification-labs/sample-po-notification-labs.component.ts
+++ b/projects/ui/src/lib/services/po-notification/samples/sample-po-notification-labs/sample-po-notification-labs.component.ts
@@ -21,6 +21,7 @@ export class SamplePoNotificationLabsComponent implements OnInit {
   message: string;
   orientation: number ;
   type: number;
+  duration: number;
 
   public readonly orientationOptions: Array<PoRadioGroupOption> = [
     { label: 'Top', value: PoToasterOrientation.Top },
@@ -48,6 +49,7 @@ export class SamplePoNotificationLabsComponent implements OnInit {
     this.orientation = undefined;
     this.action = false;
     this.actionLabel = '';
+    this.duration = undefined;
   }
 
   showNotification() {
@@ -55,7 +57,8 @@ export class SamplePoNotificationLabsComponent implements OnInit {
       message: this.message,
       orientation: this.orientation,
       action: undefined,
-      actionLabel: this.actionLabel
+      actionLabel: this.actionLabel,
+      duration: this.duration
     };
 
     if (this.action) {


### PR DESCRIPTION
**PoNotificationService**

**DTHFUI-1979**
_____________________________________________________________________________

**PR Checklist**

- [X] Código
- [X] Testes unitários
- [X] Documentação
- [X] Samples

**Qual o comportamento atual?**
Atualmente o serviço não permite alterar o tempo de duração de uma notificação.

**Qual o novo comportamento?**
Serviço permite através de uma nova propriedade **duration** na interface **PoNotification**, informar a duração em milisegundos da notificação.
Ou através do método setDurationDefault, alterar o tempo padrão de todas as notificações.

**Simulação**
Ao apresentar uma duração, o tempo é sempre de 10 segundos.
Ao definir o tempo através da propriedade, a duração passa a se manter no tempo definido pelo usuário;
Ao definir o tempo através do método, todas as notificações (mesmo sem passar a duração), passam a ter o tempo definido pelo usuário;