### PR TITLE
feat(upload): adiciona opção para envio de pastas

### DIFF
--- a/projects/ui/src/lib/components/po-field/po-field.module.ts
+++ b/projects/ui/src/lib/components/po-field/po-field.module.ts
@@ -5,6 +5,7 @@ import { HttpClientModule } from '@angular/common/http';
 
 import { PoButtonGroupModule } from '../po-button-group/index';
 import { PoButtonModule } from '../po-button/index';
+import { PoContainerModule } from '../po-container/index';
 import { PoDisclaimerModule } from './../po-disclaimer/po-disclaimer.module';
 import { PoLoadingModule } from '../po-loading/index';
 import { PoModalModule } from '../po-modal/po-modal.module';
@@ -64,6 +65,7 @@ import { PoUrlComponent } from './po-url/po-url.component';
     HttpClientModule,
     PoButtonGroupModule,
     PoButtonModule,
+    PoContainerModule,
     PoDisclaimerModule,
     PoLoadingModule,
     PoModalModule,

--- a/projects/ui/src/lib/components/po-field/po-upload/interfaces/po-upload-literals.interface.ts
+++ b/projects/ui/src/lib/components/po-field/po-upload/interfaces/po-upload-literals.interface.ts
@@ -27,11 +27,23 @@ export interface PoUploadLiterals {
    */
   deleteFile?: string;
 
-  /** Texto exibido na área onde podem ser arrastados os arquivos ao utilizar a opção de *dragDrop*. */
+  /** Texto indicativo para a área onde os arquivos devem ser arrastados quando utilizada a propriedade `p-drag-drop`. */
   dragFilesHere?: string;
 
-  /** Texto exibido na área onde podem ser arrastados os arquivos ao utilizar a opção de *dragDrop*. */
+  /** Texto indicativo para a área onde os diretórios devem ser arrastados quando utilizada a propriedade `p-drag-drop`. */
+  dragFoldersHere?: string;
+
+  /** Texto indicativo para a área onde os arquivos devem ser soltos quando utilizada a propriedade `p-drag-drop` */
   dropFilesHere?: string;
+
+  /** Texto indicativo para a área onde os diretórios devem ser soltos quando utilizada a propriedade `p-drag-drop`. */
+  dropFoldersHere?: string;
+
+  /** Parâmetro *files* para o texto de exibição quando arrastado um arquivo para um local inválido com a opção de *dragDrop*. */
+  files?: string;
+
+  /** Parâmetro *folders* para o texto de exibição quando arrastado um arquivo para um local inválido com a opção de *dragDrop*. */
+  folders?: string;
 
   /** Texto exibido caso o usuário arrastar um arquivo para um local inválido ao utilizar a opção de *dragDrop*. */
   invalidDropArea?: string;
@@ -39,11 +51,23 @@ export interface PoUploadLiterals {
   /** Texto exibido no label do botão de seleção dos arquivos. */
   selectFile?: string;
 
+  /** Texto exibido no label do botão de seleção dos arquivos ao utilizar a propriedade `p-multiple`. */
+  selectFiles?: string;
+
+  /** Texto exibido no label do botão de seleção dos arquivos ao utilizar a propriedade `p-directory`. */
+  selectFolder?: string;
+
   /**
    * Texto utilizado para indicar a possibilidade de seleção de arquivos na área onde podem ser arrastados os arquivos
    * ao utilizar a opção de *dragDrop*.
    */
   selectFilesOnComputer?: string;
+
+  /**
+   * Texto utilizado para indicar a possibilidade de seleção de diretório na área onde podem ser arrastados os arquivos
+   * ao utilizar a opção de *dragDrop*.
+   */
+  selectFolderOnComputer?: string;
 
   /** Texto exibido no label do botão para iniciar o envio dos arquivos. */
   startSending?: string;

--- a/projects/ui/src/lib/components/po-field/po-upload/po-upload-base.component.spec.ts
+++ b/projects/ui/src/lib/components/po-field/po-upload/po-upload-base.component.spec.ts
@@ -28,6 +28,7 @@ class PoUploadComponent extends PoUploadBaseComponent {
   }
 
   sendFeedback() {}
+  setDirectoryAttribute() {}
 }
 
 describe('PoUploadBaseComponent:', () => {
@@ -431,6 +432,22 @@ describe('PoUploadBaseComponent:', () => {
       expect(component['updateExistsFileInFiles']).not.toHaveBeenCalled();
     });
 
+    it('insertFileInFiles: should call `files.push` with newFile if `directory` is true and `existsFileSameName` is false', () => {
+      const files = [];
+      component.directory = true;
+      component.isMultiple = true;
+
+      spyOn(files, 'push');
+      spyOn(component, <any> 'existsFileSameName').and.returnValue(false);
+      spyOn(component, <any> 'updateExistsFileInFiles');
+
+      component['insertFileInFiles'](file, files);
+
+      expect(files.push).toHaveBeenCalledWith(file);
+      expect(component['existsFileSameName']).toHaveBeenCalled();
+      expect(component['updateExistsFileInFiles']).not.toHaveBeenCalled();
+    });
+
     it('insertFileInFiles: should call `updateExistsFileInFiles` when `existsFileSameName` is true', () => {
       const files = [];
 
@@ -668,6 +685,96 @@ describe('PoUploadBaseComponent:', () => {
       const invalidValues = [null, undefined, NaN, false, 0, 'false', 'teste'];
 
       expectPropertiesValues(component, 'hideSendButton', invalidValues, false);
+    });
+
+    it('directory: should set `directory` with valid values', () => {
+      const validValues = ['', true, 1, [], {}, 'true'];
+
+      expectPropertiesValues(component, 'directory', validValues, true);
+    });
+
+    it('directory: should set `directory` to false with invalid values', () => {
+      const invalidValues = [null, undefined, NaN, false, 0, 'false', 'teste'];
+
+      expectPropertiesValues(component, 'directory', invalidValues, false);
+    });
+
+    it('directory: should apply true to `canHandleDirectory` if directory is true and `isIE` plus `isMobile` return false', () => {
+      component.canHandleDirectory = undefined;
+
+      spyOn(utilsFunctions, <any>'isIE').and.returnValue(false);
+      spyOn(utilsFunctions, <any>'isMobile').and.returnValue(false);
+
+      component.directory = true;
+
+      expect(component.canHandleDirectory).toBeTruthy();
+    });
+
+    it('directory: should apply false to `canHandleDirectory` if directory is true but `isIE` returns true', () => {
+      spyOn(utilsFunctions, <any>'isIE').and.returnValue(true);
+      spyOn(utilsFunctions, <any>'isMobile').and.returnValue(false);
+
+      component.directory = true;
+
+      expect(component.canHandleDirectory).toBeFalsy();
+    });
+
+    it('directory: should apply false to `canHandleDirectory` if directory is true but `isMobile` returns true', () => {
+      spyOn(utilsFunctions, <any>'isIE').and.returnValue(false);
+      spyOn(utilsFunctions, <any>'isMobile').and.returnValue(true);
+
+      component.directory = true;
+
+      expect(component.canHandleDirectory).toBeFalsy();
+    });
+
+    it('directory: should apply false to `canHandleDirectory` if directory is false', () => {
+      spyOn(utilsFunctions, <any>'isIE').and.returnValue(false);
+      spyOn(utilsFunctions, <any>'isMobile').and.returnValue(false);
+
+      component.directory = false;
+
+      expect(component.canHandleDirectory).toBeFalsy();
+    });
+
+    it(`directory: call 'setDirectoryAttribute' passing true as parameter`, () => {
+      spyOn(utilsFunctions, <any>'isIE').and.returnValue(false);
+      spyOn(utilsFunctions, <any>'isMobile').and.returnValue(false);
+      spyOn(component, 'setDirectoryAttribute');
+
+      component.directory = true;
+
+      expect(component['canHandleDirectory']).toBe(true);
+      expect(component.setDirectoryAttribute).toHaveBeenCalledWith(true);
+    });
+
+    it(`directory: should call 'setDirectoryAttribute' passing false as parameter`, () => {
+      spyOn(utilsFunctions, <any>'isIE').and.returnValue(false);
+      spyOn(utilsFunctions, <any>'isMobile').and.returnValue(true);
+      spyOn(component, 'setDirectoryAttribute');
+
+      component.directory = false;
+
+      expect(component['canHandleDirectory']).toBe(false);
+      expect(component.setDirectoryAttribute).toHaveBeenCalledWith(false);
+    });
+
+    it('isMultiple: should set `isMultiple` with `true` if valid values', () => {
+      const validValues = ['', true, 1, [], {}, 'true'];
+
+      expectPropertiesValues(component, 'isMultiple', validValues, true);
+    });
+
+    it('isMultiple: should set `isMultiple` with `false` if invalid values', () => {
+      const invalidValues = [null, undefined, NaN, false, 0, 'false', 'teste'];
+
+      expectPropertiesValues(component, 'isMultiple', invalidValues, false);
+    });
+
+    it('isMultiple: should return true if `diretory` is true', () => {
+      component.directory = true;
+
+      expect(component.isMultiple).toBe(true);
     });
 
   });

--- a/projects/ui/src/lib/components/po-field/po-upload/po-upload-drag-drop/po-upload-drag-drop-area-overlay/po-upload-drag-drop-area-overlay.component.html
+++ b/projects/ui/src/lib/components/po-field/po-upload/po-upload-drag-drop/po-upload-drag-drop-area-overlay/po-upload-drag-drop-area-overlay.component.html
@@ -2,6 +2,7 @@
 
   <po-upload-drag-drop-area #DragDropAreaFixed
     class="po-upload-drag-drop-area-overlay"
+    [p-directory-compatible]="directoryCompatible"
     [p-disabled]="disabled"
     [p-literals]="literals"
     [p-overlay]="true">

--- a/projects/ui/src/lib/components/po-field/po-upload/po-upload-drag-drop/po-upload-drag-drop-area-overlay/po-upload-drag-drop-area-overlay.component.ts
+++ b/projects/ui/src/lib/components/po-field/po-upload/po-upload-drag-drop/po-upload-drag-drop-area-overlay/po-upload-drag-drop-area-overlay.component.ts
@@ -12,6 +12,8 @@ export class PoUploadDragDropAreaOverlayComponent implements AfterViewInit {
 
   @ViewChild('DragDropAreaFixed', { read: ElementRef, static: true }) DragDropAreaFixed: ElementRef;
 
+  @Input('p-directory-compatible') directoryCompatible: boolean;
+
   @Input('p-disabled') disabled: boolean;
 
   @Input('p-literals') literals: PoUploadLiterals;

--- a/projects/ui/src/lib/components/po-field/po-upload/po-upload-drag-drop/po-upload-drag-drop-area/po-upload-drag-drop-area.component.html
+++ b/projects/ui/src/lib/components/po-field/po-upload/po-upload-drag-drop/po-upload-drag-drop-area/po-upload-drag-drop-area.component.html
@@ -13,21 +13,17 @@
 <ng-template #overlayTemplate>
   <span class="po-upload-drag-drop-area-overlay-icon po-icon po-icon-upload-cloud"></span>
 
-  <div class="po-upload-drag-drop-area-overlay-label"> {{ literals?.dropFilesHere }} </div>
+  <div class="po-upload-drag-drop-area-overlay-label">{{ directoryCompatible ? literals?.dropFoldersHere : literals?.dropFilesHere }}</div>
 </ng-template>
 
 <ng-template #defaultTemplate>
   <span class="po-upload-drag-drop-area-icon po-icon po-icon-upload-cloud"></span>
 
-  <div class="po-upload-drag-drop-area-label">
-    {{ literals?.dragFilesHere }}
-  </div>
+  <div class="po-upload-drag-drop-area-label">{{ directoryCompatible ? literals?.dragFoldersHere : literals?.dragFilesHere }}</div>
 
   <button #selectFilesLink
     class="po-upload-drag-drop-area-select-files"
     [disabled]="disabled"
     [ngClass]="{'po-clickable': !disabled}"
-    (click)="selectFiles.emit()">
-    {{ literals?.selectFilesOnComputer }}
-  </button>
+    (click)="selectFiles.emit()">{{ directoryCompatible ? literals?.selectFolderOnComputer : literals?.selectFilesOnComputer }}</button>
 </ng-template>

--- a/projects/ui/src/lib/components/po-field/po-upload/po-upload-drag-drop/po-upload-drag-drop-area/po-upload-drag-drop-area.component.spec.ts
+++ b/projects/ui/src/lib/components/po-field/po-upload/po-upload-drag-drop/po-upload-drag-drop-area/po-upload-drag-drop-area.component.spec.ts
@@ -2,8 +2,10 @@ import { ChangeDetectorRef } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { configureTestSuite } from '../../../../../util-test/util-expect.spec';
+import { poLocaleDefault } from 'projects/ui/src/lib/utils/util';
 
 import { PoUploadDragDropAreaComponent } from './po-upload-drag-drop-area.component';
+import { poUploadLiteralsDefault } from '../../po-upload-base.component';
 
 describe('PoUploadDragDropAreaComponent:', () => {
   let changeDetector: any;
@@ -134,6 +136,59 @@ describe('PoUploadDragDropAreaComponent:', () => {
       expect(areaContainer.classList).not.toContain('po-clickable');
     });
 
+    it('should apply literals `dropFoldersHere`, if directoryCompatible is true ', () => {
+      component.disabled = false;
+      component.overlay = true;
+      component.directoryCompatible = true;
+      component.literals = {...poUploadLiteralsDefault[poLocaleDefault]};
+
+      changeDetector.detectChanges();
+
+      const overlayLabel = nativeElement.querySelector('.po-upload-drag-drop-area-overlay-label');
+
+      expect(overlayLabel.innerHTML).toBe(poUploadLiteralsDefault[poLocaleDefault].dropFoldersHere);
+    });
+
+    it('should apply literals `dropFilesHere`, if directoryCompatible is true ', () => {
+      component.disabled = false;
+      component.overlay = true;
+      component.directoryCompatible = false;
+      component.literals = {...poUploadLiteralsDefault[poLocaleDefault]};
+
+      changeDetector.detectChanges();
+
+      const overlayLabel = nativeElement.querySelector('.po-upload-drag-drop-area-overlay-label');
+
+      expect(overlayLabel.innerHTML).toBe(poUploadLiteralsDefault[poLocaleDefault].dropFilesHere);
+    });
+
+    it('should apply literals `dragFoldersHere` and `selectFolderOnComputer`, if directoryCompatible is true ', () => {
+      component.disabled = false;
+      component.directoryCompatible = true;
+      component.literals = {...poUploadLiteralsDefault[poLocaleDefault]};
+
+      changeDetector.detectChanges();
+
+      const dragAreaLabel = nativeElement.querySelector('.po-upload-drag-drop-area-label');
+      const dragAreaButton = nativeElement.querySelector('.po-upload-drag-drop-area-select-files');
+
+      expect(dragAreaLabel.innerHTML).toBe(poUploadLiteralsDefault[poLocaleDefault].dragFoldersHere);
+      expect(dragAreaButton.innerHTML).toBe(poUploadLiteralsDefault[poLocaleDefault].selectFolderOnComputer);
+    });
+
+    it('should apply literals `dragFilesHere` and `selectFilesOnComputer`, if directoryCompatible is true ', () => {
+      component.disabled = false;
+      component.directoryCompatible = false;
+      component.literals = {...poUploadLiteralsDefault[poLocaleDefault]};
+
+      changeDetector.detectChanges();
+
+      const dragAreaLabel = nativeElement.querySelector('.po-upload-drag-drop-area-label');
+      const dragAreaButton = nativeElement.querySelector('.po-upload-drag-drop-area-select-files');
+
+      expect(dragAreaLabel.innerHTML).toBe(poUploadLiteralsDefault[poLocaleDefault].dragFilesHere);
+      expect(dragAreaButton.innerHTML).toBe(poUploadLiteralsDefault[poLocaleDefault].selectFilesOnComputer);
+    });
   });
 
 });

--- a/projects/ui/src/lib/components/po-field/po-upload/po-upload-drag-drop/po-upload-drag-drop-area/po-upload-drag-drop-area.component.ts
+++ b/projects/ui/src/lib/components/po-field/po-upload/po-upload-drag-drop/po-upload-drag-drop-area/po-upload-drag-drop-area.component.ts
@@ -9,6 +9,8 @@ import { PoUploadLiterals } from '../../interfaces/po-upload-literals.interface'
 })
 export class PoUploadDragDropAreaComponent {
 
+  @Input('p-directory-compatible') directoryCompatible: boolean;
+
   @Input('p-disabled') disabled: boolean;
 
   @Input('p-height') height: number;

--- a/projects/ui/src/lib/components/po-field/po-upload/po-upload-drag-drop/po-upload-drag-drop.component.html
+++ b/projects/ui/src/lib/components/po-field/po-upload/po-upload-drag-drop/po-upload-drag-drop.component.html
@@ -1,4 +1,5 @@
 <po-upload-drag-drop-area-overlay #dragDropOverlay *ngIf="isDragOver"
+  [p-directory-compatible]="directoryCompatible"
   [p-disabled]="disabled"
   [p-literals]="literals"
   [p-target]="dragDropAreaComponent.elementRef"
@@ -8,6 +9,7 @@
 <po-upload-drag-drop-area
   p-upload-drag-drop
   [p-area-element]="areaElement"
+  [p-directory-compatible]="directoryCompatible"
   [p-disabled]="disabled"
   [p-height]="dragDropHeight"
   [p-literals]="literals"

--- a/projects/ui/src/lib/components/po-field/po-upload/po-upload-drag-drop/po-upload-drag-drop.component.ts
+++ b/projects/ui/src/lib/components/po-field/po-upload/po-upload-drag-drop/po-upload-drag-drop.component.ts
@@ -23,6 +23,8 @@ export class PoUploadDragDropComponent {
   @ViewChild('dragDropOverlay', { read: ElementRef, static: false }) dragDropOverlayElement: ElementRef;
   @ViewChild(PoUploadDragDropAreaComponent, { static: true }) dragDropAreaComponent: PoUploadDragDropAreaComponent;
 
+  @Input('p-directory-compatible') directoryCompatible: boolean;
+
   @Input('p-disabled') disabled: boolean;
 
   @Input('p-drag-drop-height') set dragDropHeight(value: number) {

--- a/projects/ui/src/lib/components/po-field/po-upload/po-upload.component.html
+++ b/projects/ui/src/lib/components/po-field/po-upload/po-upload.component.html
@@ -16,6 +16,7 @@
       (change)="onFileChange($event)">
 
     <po-upload-drag-drop *ngIf="displayDragDrop"
+      [p-directory-compatible]="canHandleDirectory"
       [p-disabled]="isDisabled"
       [p-drag-drop-height]="dragDropHeight"
       [p-literals]="literals"
@@ -28,7 +29,7 @@
       class="po-upload-button"
       for="file"
       [p-disabled]="isDisabled"
-      [p-label]="literals.selectFile"
+      [p-label]="selectFileButtonLabel"
       (p-click)="selectFiles()">
     </po-button>
 
@@ -42,21 +43,30 @@
     </po-upload-file-restrictions>
 
     <div *ngIf="currentFiles && currentFiles.length" class="po-upload-progress-container">
-      <po-progress
-        *ngFor="let file of currentFiles; trackBy: trackByFn"
-        [p-info]="infoByUploadStatus[file.status]?.text(file.percent)"
-        [p-info-icon]="infoByUploadStatus[file.status]?.icon"
-        [p-status]="progressStatusByFileStatus[file.status]"
-        [p-text]="file.displayName"
-        [p-value]="file.percent"
-        (p-cancel)="cancel(file)"
-        (p-retry)="uploadFiles([file])">
-      </po-progress>
+      <po-container
+        p-no-shadow
+        [p-height]="hasMoreThanFourItems ? 280 : 'auto'"
+        [p-no-border]="!hasMoreThanFourItems"
+        [p-no-padding]="!hasMoreThanFourItems">
+        <div [ngClass]="{'po-upload-progress-container-area po-pt-2 po-pl-1': hasMoreThanFourItems}">
+          <po-progress
+            *ngFor="let file of currentFiles; trackBy: trackByFn"
+            [p-info]="infoByUploadStatus[file.status]?.text(file.percent)"
+            [p-info-icon]="infoByUploadStatus[file.status]?.icon"
+            [p-status]="progressStatusByFileStatus[file.status]"
+            [p-text]="file.displayName"
+            [p-value]="file.percent"
+            (p-cancel)="cancel(file)"
+            (p-retry)="uploadFiles([file])">
+          </po-progress>
+        </div>
+      </po-container>
     </div>
 
     <po-button
       *ngIf="displaySendButton"
       class="po-upload-send-button"
+      [class.po-mt-3]="hasMoreThanFourItems"
       p-type="primary"
       [p-disabled]="hasAnyFileUploading(currentFiles)"
       [p-label]="literals.startSending"

--- a/projects/ui/src/lib/components/po-field/po-upload/po-upload.component.spec.ts
+++ b/projects/ui/src/lib/components/po-field/po-upload/po-upload.component.spec.ts
@@ -5,6 +5,7 @@ import { HttpClient, HttpHandler } from '@angular/common/http';
 import * as utilsFunctions from '../../../utils/util';
 import { configureTestSuite } from './../../../util-test/util-expect.spec';
 import { PoButtonModule } from '../../po-button/po-button.module';
+import { PoContainerModule } from '../../po-container/po-container.module';
 import { PoProgressModule } from '../../po-progress/po-progress.module';
 
 import { PoFieldContainerBottomComponent } from './../po-field-container/po-field-container-bottom/po-field-container-bottom.component';
@@ -38,7 +39,7 @@ describe('PoUploadComponent:', () => {
 
   configureTestSuite(() => {
     TestBed.configureTestingModule({
-      imports: [ PoButtonModule, PoProgressModule, PoServicesModule ],
+      imports: [ PoButtonModule, PoContainerModule, PoProgressModule, PoServicesModule ],
       declarations: [
         PoUploadComponent,
         PoFieldContainerComponent,
@@ -288,6 +289,50 @@ describe('PoUploadComponent:', () => {
 
       expect(infoByUploadStatus.text(percent)).toBe(expectedValue);
       expect(infoByUploadStatus.icon).toBeUndefined();
+    });
+
+    it('selectFileButtonLabel: should return `literals.selectFolder` if canHandleDirectory is true', () => {
+      component.canHandleDirectory = true;
+
+      expect(component.selectFileButtonLabel).toBe(component.literals.selectFolder);
+    });
+
+    it('selectFileButtonLabel: should return `literals.selectFiles` if canHandleDirectory is false and isMultiple is true', () => {
+      component.canHandleDirectory = false;
+      component.isMultiple = true;
+
+      expect(component.selectFileButtonLabel).toBe(component.literals.selectFiles);
+    });
+
+    it('selectFileButtonLabel: should return `literals.selectFile` if canHandleDirectory and isMultiple are false', () => {
+      component.canHandleDirectory = false;
+      component.isMultiple = false;
+
+      expect(component.selectFileButtonLabel).toBe(component.literals.selectFile);
+    });
+
+    it('hasMoreThanFourItems: should return true if currentFiles.length is greater than 4', () => {
+      component.currentFiles = [fileMock, fileMock, fileMock, fileMock, fileMock];
+
+      expect(component.hasMoreThanFourItems).toBe(true);
+    });
+
+    it('hasMoreThanFourItems: should return false if currentFiles.length is lower than 4', () => {
+      component.currentFiles = [fileMock];
+
+      expect(component.hasMoreThanFourItems).toBe(false);
+    });
+
+    it('hasMultipleFiles: should return true if currentFiles.length is greater than 1', () => {
+      component.currentFiles = [fileMock, fileMock];
+
+      expect(component.hasMultipleFiles).toBe(true);
+    });
+
+    it('hasMultipleFiles: should return false if currentFiles.length lower than 1', () => {
+      component.currentFiles = [fileMock];
+
+      expect(component.hasMultipleFiles).toBe(false);
     });
 
   });
@@ -617,7 +662,7 @@ describe('PoUploadComponent:', () => {
     });
 
     it('updateFiles: should call `parseFiles` with `files` and `updateModel` with `currentFiles`', () => {
-      const files = 'fileMock';
+      const files = ['fileMock'];
 
       spyOn(component, <any>'parseFiles').and.returnValue(files);
       spyOn(component, <any>'updateModel');
@@ -629,7 +674,7 @@ describe('PoUploadComponent:', () => {
     });
 
     it('updateFiles: should call `uploadFiles` with files if `autoUpload` is `true`', () => {
-      const files = 'fileMock';
+      const files = ['fileMock'];
       component.autoUpload = true;
 
       spyOn(component, <any>'parseFiles').and.returnValue(files);
@@ -643,7 +688,7 @@ describe('PoUploadComponent:', () => {
     });
 
     it('updateFiles: shouldn`t call `uploadFiles` with files if `autoUpload` is `false`', () => {
-      const files = 'fileMock';
+      const files = ['fileMock'];
       component.autoUpload = false;
 
       spyOn(component, <any>'parseFiles').and.returnValue(files);
@@ -818,6 +863,27 @@ describe('PoUploadComponent:', () => {
       expect(component.isAllowCancelEvent(fileStatus)).toBe(false);
     });
 
+    it(`setDirectoryAttribute: should call 'setAttribute' if canHandleDirectory is true`, () => {
+      const canHandleDirectory = true;
+
+      spyOn(component.renderer, <any>'setAttribute');
+
+      component.setDirectoryAttribute(canHandleDirectory);
+
+      expect(component.renderer.setAttribute).toHaveBeenCalledTimes(1);
+    });
+
+    it(`setDirectoryAttribute: should call 'removeAttribute' if 'canHandleDirectory' is false`, () => {
+      component.canHandleDirectory = false;
+
+      spyOn(component.renderer, <any>'removeAttribute');
+
+      component.setDirectoryAttribute(component.canHandleDirectory);
+
+      expect(component.renderer.removeAttribute).toHaveBeenCalledWith(component['inputFile'].nativeElement, 'webkitdirectory');
+      expect(component.renderer.removeAttribute).toHaveBeenCalledTimes(1);
+    });
+
   });
 
   describe('Templates:', () => {
@@ -916,6 +982,42 @@ describe('PoUploadComponent:', () => {
       fixture.detectChanges();
 
       expect(fixture.debugElement.nativeElement.querySelector('.po-upload-progress-container')).toBeNull();
+    });
+
+    it('should add `po-upload-progress-container-area` class if `hasMoreThanFourItems` is true', () => {
+      component.currentFiles = [file];
+      spyOnProperty(component, 'hasMoreThanFourItems').and.returnValue(true);
+
+      fixture.detectChanges();
+
+      expect(fixture.debugElement.nativeElement.querySelector('.po-upload-progress-container-area')).toBeTruthy();
+    });
+
+    it('shouldn`t add `po-upload-progress-container-area` class if `hasMoreThanFourItems` is false', () => {
+      component.currentFiles = [file];
+      spyOnProperty(component, 'hasMoreThanFourItems').and.returnValue(false);
+
+      fixture.detectChanges();
+
+      expect(fixture.debugElement.nativeElement.querySelector('.po-upload-progress-container-area')).toBeFalsy();
+    });
+
+    it('should fix the height of `po-container` to `280px` if `hasMoreThanFourItems` is true', () => {
+      component.currentFiles = [file];
+      spyOnProperty(component, 'hasMoreThanFourItems').and.returnValue(true);
+
+      fixture.detectChanges();
+
+      expect(fixture.debugElement.nativeElement.querySelector('.po-container').style.height).toBe('280px');
+    });
+
+    it('should fix the height of `po-container` to `auto` if `hasMoreThanFourItems` is false', () => {
+      component.currentFiles = [file];
+      spyOnProperty(component, 'hasMoreThanFourItems').and.returnValue(false);
+
+      fixture.detectChanges();
+
+      expect(fixture.debugElement.nativeElement.querySelector('.po-container').style.height).toBe('auto');
     });
 
   });

--- a/projects/ui/src/lib/components/po-field/po-upload/samples/sample-po-upload-labs/sample-po-upload-labs.component.html
+++ b/projects/ui/src/lib/components/po-field/po-upload/samples/sample-po-upload-labs/sample-po-upload-labs.component.html
@@ -2,6 +2,7 @@
   name="upload"
   [(ngModel)]="upload"
   [p-auto-upload]="properties.includes('autoupload')"
+  [p-directory]="properties.includes('directory')"
   [p-disabled]="properties.includes('disabled')"
   [p-drag-drop]="properties.includes('dragDrop')"
   [p-drag-drop-height]="dragDropHeight"

--- a/projects/ui/src/lib/components/po-field/po-upload/samples/sample-po-upload-labs/sample-po-upload-labs.component.ts
+++ b/projects/ui/src/lib/components/po-field/po-upload/samples/sample-po-upload-labs/sample-po-upload-labs.component.ts
@@ -26,6 +26,7 @@ export class SamplePoUploadLabsComponent implements OnInit {
 
   public readonly propertiesOptions: Array<PoCheckboxGroupOption> = [
     { value: 'autoupload', label: 'Automatic upload' },
+    { value: 'directory', label: 'Directory' },
     { value: 'disabled', label: 'Disabled' },
     { value: 'dragDrop', label: 'Drag Drop' },
     { value: 'multiple', label: 'Multiple upload' },


### PR DESCRIPTION
**Upload**


**DTHFUI-787**
_____________________________________________________________________________

**PR Checklist**

- [x] Código
- [x] Testes unitários
- [x] Documentação
- [x] Samples

**Qual o comportamento atual?**
Como usuário eu gostaria de poder selecionar uma pasta para que o componente carregasse todos os arquivos de uma única vez.

**Qual o novo comportamento?**
• Criada propriedade `t-directory` para opção de seleção de diretórios;
• Quando habilitada a `t-directory`, o comportamento de seleção permite apenas seleção de diretórios;
• Tratamento para as literais para que alternem entre diretórios e arquivos;
• Tratamento específico para o browser IE pois não suporta essa funcionalidade. Para esse caso, o comportamento prevalecido é de seleção de arquivos.
• Plus: tratado encapsulamento dos itens selecionados para dentro de um container caso a quantidade seja >= 5. Para <5 o comportamento prevalece igual.

**Simulação**
Pode-se testar o comportamento adicionando-se a propriedade `t-directory` e também adicionando a `t-drag-drop`. 
* O sample labs não funciona adequadamente para a funcionalidade de drag and drop.