### PR TITLE
fix(page-login): corrige erro ao usar title e loginHint com undefined

### DIFF
--- a/projects/templates/src/lib/components/po-page-login/po-page-login-base.component.spec.ts
+++ b/projects/templates/src/lib/components/po-page-login/po-page-login-base.component.spec.ts
@@ -266,7 +266,7 @@ describe('ThPageLoginBaseComponent: ', () => {
 
     });
 
-    it('p-literals: should set `constainsLiterals` with true if `literals.title` and `literalsDefault.title` don`t match', () => {
+    it('p-literals: should set `containsCustomLiterals` with true if `literals.title` and `literalsDefault.loginHint` don`t match', () => {
       component['_literals'] = { title: 'Title', loginHint: poPageLoginLiteralsDefault[poLocaleDefault].loginHint };
       component.selectedLanguage = poLocaleDefault;
       const validLiterals = component['_literals'];
@@ -279,7 +279,19 @@ describe('ThPageLoginBaseComponent: ', () => {
 
     });
 
-    it('p-literals: should set `constainsLiterals` with false if `literals.title` and `literalsDefault.title` match', () => {
+    it('p-literals: should set `containsCustomLiterals` with false if `literals.title` and `literals.loginHint` are undefined', () => {
+      component['_literals'] = { title: undefined, loginHint: undefined };
+      component.selectedLanguage = poLocaleDefault;
+      const validLiterals = component['_literals'];
+
+      spyOn(component, <any>'getLiterals');
+
+      expectPropertiesValues(component, 'literals', validLiterals, validLiterals);
+      expect(component.getLiterals).toHaveBeenCalledWith(poLocaleDefault, validLiterals);
+      expect(component.containsCustomLiterals).toBe(false);
+    });
+
+    it('p-literals: should set `containsCustomLiterals` with false if `literals.title` and `literalsDefault.loginHint` match', () => {
       component['_literals'] = {
         title: poPageLoginLiteralsDefault[poLocaleDefault].title,
         loginHint: poPageLoginLiteralsDefault[poLocaleDefault].loginHint
@@ -295,7 +307,7 @@ describe('ThPageLoginBaseComponent: ', () => {
 
     });
 
-    xit('p-literals: should set `constainsLiterals` with true if `literals.loginHint` and `literalsDefault.loginHint` match', () => {
+    xit('p-literals: should set `containsCustomLiterals` with true if `literals.loginHint` and `literalsDefault.loginHint` match', () => {
       component['_literals'] = poPageLoginLiteralsDefault[poLocaleDefault];
       const validLiterals = component['_literals'];
 
@@ -792,6 +804,20 @@ describe('ThPageLoginBaseComponent: ', () => {
       component.setTitleLiteral(poLocaleDefault, title);
 
       expect(component.literals.title).toBe(poPageLoginLiteralsDefault[poLocaleDefault].title);
+      expect(component['concatenateLiteral']).not.toHaveBeenCalled();
+    });
+
+    it(`setTitleLiteral: shouldn´t set literals.title with default value if value is undefined`, () => {
+      const title = undefined;
+      const literals = { title, loginHint: 'Teste 1' };
+
+      component.literals = { ...literals };
+
+      spyOn(component, <any>'concatenateLiteral');
+
+      component.setTitleLiteral(poLocaleDefault, title);
+
+      expect(component.literals.title).toEqual(title);
       expect(component['concatenateLiteral']).not.toHaveBeenCalled();
     });
 

--- a/projects/templates/src/lib/components/po-page-login/po-page-login-base.component.ts
+++ b/projects/templates/src/lib/components/po-page-login/po-page-login-base.component.ts
@@ -454,9 +454,11 @@ export abstract class PoPageLoginBaseComponent implements OnDestroy {
 
     if (value) {
       this.getLiterals(language, value);
+      const { title, loginHint} = this.literals;
+
       this.containsCustomLiterals =
-        !this.literals.title.includes(poPageLoginLiteralsDefault[language].title) ||
-        !this.literals.loginHint.includes(poPageLoginLiteralsDefault[language].loginHint);
+        !!(title && !title.includes(poPageLoginLiteralsDefault[language].title)) ||
+        !!(loginHint && !loginHint.includes(poPageLoginLiteralsDefault[language].loginHint));
     } else {
       this.containsCustomLiterals = false;
       this._literals = poPageLoginLiteralsDefault[language];
@@ -922,11 +924,14 @@ export abstract class PoPageLoginBaseComponent implements OnDestroy {
   setTitleLiteral(language: string, value: string) {
     const defaultTitleLiteral = poPageLoginLiteralsDefault[language].title;
     const prepositionLiteral = poPageLoginLiteralTo[language];
+
+    const customTitle = this.literals.title || '';
+
     if (value) {
       this.concatenateLiteral(value, 'title', defaultTitleLiteral, prepositionLiteral);
-    } else if (!value && this.literals.title.includes(defaultTitleLiteral)) {
-        this.literals = { title: defaultTitleLiteral };
-      }
+    } else if (!value && customTitle.includes(defaultTitleLiteral)) {
+      this.literals = { title: defaultTitleLiteral };
+    }
   }
 
   private concatenate(defaultLiteral: string, prefixLiteral: string, value: string) {


### PR DESCRIPTION
**PAGE-LOGIN**

**DTHFUI-1516**
_____________________________________________________________________________

**PR Checklist**

- [x] Código
- [x] Testes unitários
- [ ] Documentação
- [ ] Samples

**Qual o comportamento atual?**
Ao utilizar literals.title e literals.loginHint com undefined ocorria erro no componente, fazendo com que o mesmo não carregue por completo e impossibilitando seu uso.

**Qual o novo comportamento?**
Alterado a comparação de valores para que não ocorra o erro quando ambas propriedades estiverem com undefined.


**Simulação**
- Utilizar o page-login com [p-literals]="{ title: undefined, loginHint: undefined }".