### PR TITLE
feat(tag): permitir o uso da paleta de cores e ícones

### DIFF
--- a/projects/ui/src/lib/components/po-tag/enums/po-tag-icon.enum.ts
+++ b/projects/ui/src/lib/components/po-tag/enums/po-tag-icon.enum.ts
@@ -7,15 +7,15 @@
  */
 export enum PoTagIcon {
 
-  /** Ícone fechar */
-  Danger = 'close',
+  /** Ícone fechar. */
+  Danger = 'po-icon-close',
 
-  /** Ícone de informação */
-  Info = 'info',
+  /** Ícone de informação. */
+  Info = 'po-icon-info',
 
-  /** Ícone que representa confirmação */
-  Success = 'ok',
+  /** Ícone que representa confirmação. */
+  Success = 'po-icon-ok',
 
-  /** Ícone com ponto de exclamação */
-  Warning = 'warning'
+  /** Ícone com ponto de exclamação. */
+  Warning = 'po-icon-warning'
 }

--- a/projects/ui/src/lib/components/po-tag/po-tag-base.component.spec.ts
+++ b/projects/ui/src/lib/components/po-tag/po-tag-base.component.spec.ts
@@ -1,12 +1,14 @@
 import { expectPropertiesValues } from '../../util-test/util-expect.spec';
 
+import { PoColorPaletteEnum } from '../../enums/po-color-palette.enum';
+
 import { PoTagBaseComponent } from './po-tag-base.component';
-import { PoTagIcon } from './enums/po-tag-icon.enum';
 import { PoTagOrientation } from './enums/po-tag-orientation.enum';
 import { PoTagType } from './enums/po-tag-type.enum';
 
 describe('PoTagBaseComponent:', () => {
   const component = new PoTagBaseComponent();
+  const poTagColors = (<any>Object).values(PoColorPaletteEnum);
 
   it('should be created', () => {
     expect(component instanceof PoTagBaseComponent).toBeTruthy();
@@ -14,16 +16,37 @@ describe('PoTagBaseComponent:', () => {
 
   describe('Properties:', () => {
 
-    it('icon: should update with true value.', () => {
+    it('color: should update to true value.', () => {
+      const colorsValidTrueValues = poTagColors;
+
+      expectPropertiesValues(component, 'color', colorsValidTrueValues, colorsValidTrueValues);
+    });
+
+    it('color: shouldn´t update to false value.', () => {
+      const colorsInalidTrueValues = [undefined, null, 2, 'string', 0, NaN];
+
+      expectPropertiesValues(component, 'color', colorsInalidTrueValues, undefined);
+    });
+
+    it('icon: should update to true value with `type`.', () => {
+      component.type = PoTagType.Info;
       const booleanValidTrueValues = [true, 'true', 1, ''];
 
       expectPropertiesValues(component, 'icon', booleanValidTrueValues, true);
     });
 
-    it('icon: should update with false value.', () => {
+    it('icon: should update to false if `type` is true.', () => {
+      component.type = PoTagType.Info;
       const booleanInvalidValues = [undefined, null, 2, 'string', 0, NaN];
 
       expectPropertiesValues(component, 'icon', booleanInvalidValues, false);
+    });
+
+    it('icon: should update to true if `type` is undefined.', () => {
+      component.type = undefined;
+      const validValues = ['po-icon-ok', 'po-icon-company', 'po-icon-portinari'];
+
+      expectPropertiesValues(component, 'icon', validValues, validValues);
     });
 
     it('orientation: should update property with valid values', () => {
@@ -47,21 +70,7 @@ describe('PoTagBaseComponent:', () => {
     it('type: should update property with `info` if values are invalid', () => {
       const invalidValues = [undefined, null, '', true, false, 0, -1, 12, 15, 'aa', [], {}];
 
-      expectPropertiesValues(component, 'type', invalidValues, 'info');
-    });
-
-    it('iconFromType: should update property with valid values', () => {
-      component.type = PoTagType.Danger;
-      expect(component.iconFromType).toBe(PoTagIcon.Danger);
-
-      component.type = PoTagType.Danger;
-      expect(component.iconFromType).toBe(PoTagIcon.Danger);
-
-      component.type = PoTagType.Danger;
-      expect(component.iconFromType).toBe(PoTagIcon.Danger);
-
-      component.type = PoTagType.Danger;
-      expect(component.iconFromType).toBe(PoTagIcon.Danger);
+      expectPropertiesValues(component, 'type', invalidValues, undefined);
     });
 
   });

--- a/projects/ui/src/lib/components/po-tag/po-tag-base.component.ts
+++ b/projects/ui/src/lib/components/po-tag/po-tag-base.component.ts
@@ -1,27 +1,32 @@
 import { EventEmitter, Input, Output } from '@angular/core';
 
 import { convertToBoolean } from '../../utils/util';
+import { PoColorPaletteEnum } from '../../enums/po-color-palette.enum';
 
-import { PoTagIcon } from './enums/po-tag-icon.enum';
 import { PoTagItem } from './interfaces/po-tag-item.interface';
 import { PoTagOrientation } from './enums/po-tag-orientation.enum';
 import { PoTagType } from './enums/po-tag-type.enum';
 
+const poTagColors = (<any>Object).values(PoColorPaletteEnum);
 const poTagOrientationDefault = PoTagOrientation.Vertical;
-const poTagTypeDefault = PoTagType.Info;
 
 /**
  * @description
  *
- * Este componente apresenta um valor em um marcador colorido que pode conter ícone e *label*, as cores são definidas conforme o tipo
- * escolhido.
- * Seu uso é indicado para informações que necessitam de destaque em forma de marcação.
+ * Este componente permite exibir um valor em forma de um marcador colorido, sendo possível definir uma legenda e realizar customizações
+ * na cor, iconografia e tipo.
+ *
+ * Além disso, é possível definir uma ação que será executada tanto ao *click* quanto através das teclas *enter/space* enquanto navega
+ * utilizando a tecla *tab*.
+ *
+ * Seu uso é recomendado para informações que necessitem de destaque em forma de marcação.
  */
 export class PoTagBaseComponent {
 
-  private _icon?: boolean;
+  private _color?: string;
+  private _icon?: boolean | string;
   private _orientation?: PoTagOrientation = poTagOrientationDefault;
-  private _type?: PoTagType = poTagTypeDefault;
+  private _type?: PoTagType;
 
   public readonly poTagOrientation = PoTagOrientation;
 
@@ -30,27 +35,60 @@ export class PoTagBaseComponent {
    *
    * @description
    *
-   * Texto antes da tag.
+   * Define uma cor para a *tag*.
+   *
+   * Valores válidos:
+   *  - <span class="dot po-color-01"></span> `color-01`
+   *  - <span class="dot po-color-02"></span> `color-02`
+   *  - <span class="dot po-color-03"></span> `color-03`
+   *  - <span class="dot po-color-04"></span> `color-04`
+   *  - <span class="dot po-color-05"></span> `color-05`
+   *  - <span class="dot po-color-06"></span> `color-06`
+   *  - <span class="dot po-color-07"></span> `color-07`
+   *  - <span class="dot po-color-08"></span> `color-08`
+   *  - <span class="dot po-color-09"></span> `color-09`
+   *  - <span class="dot po-color-10"></span> `color-10`
+   *  - <span class="dot po-color-11"></span> `color-11`
+   *  - <span class="dot po-color-12"></span> `color-12`
+   *
+   * > **Atenção:** A propriedade `p-type` sobrepõe esta definição.
    */
-  @Input('p-label') label?: string;
+  @Input('p-color') set color(value: string) {
+    this._color = poTagColors.includes(value) ? value : undefined;
+  }
+
+  get color(): string {
+    return this._color;
+  }
 
   /**
    * @optional
    *
    * @description
    *
-   * Apresenta um ícone na tag conforme o tipo:
-   * - `danger`: <span class="po-icon po-icon-close"></span>
-   * - `info`: <span class="po-icon po-icon-info"></span>
-   * - `success`: <span class="po-icon po-icon-ok"></span>
-   * - `warning`: <span class="po-icon po-icon-warning"></span>
+   * Define ou ativa um ícone que será exibido ao lado do valor da *tag*.
+   *
+   * > Veja os valores válidos na [biblioteca de ícones](guides/icons).
+   *
+   * Quando `p-type` estiver definida, basta informar um valor igual a `true` para que o ícone seja exibido conforme descrições abaixo:
+   * - <span class="po-icon po-icon-ok"></span> - `success`
+   * - <span class="po-icon po-icon-warning"></span> - `warning`
+   * - <span class="po-icon po-icon-close"></span> - `danger`
+   * - <span class="po-icon po-icon-info"></span> - `info`
    *
    * @default `false`
    */
-  @Input('p-icon') set icon(value: boolean) {
-    this._icon = <any>value === '' ? true : convertToBoolean(value);
+  @Input('p-icon') set icon(value: boolean | string) {
+    if (this.type) {
+      this._icon = convertToBoolean(value);
+
+    } else {
+      this._icon = value;
+
+    }
   }
-  get icon(): boolean {
+
+  get icon(): boolean | string {
     return this._icon;
   }
 
@@ -59,13 +97,23 @@ export class PoTagBaseComponent {
    *
    * @description
    *
-   * Define o layout de exibição.
+   * Define uma legenda que será exibida acima ou ao lado da *tag*, de acordo com a `p-orientation`.
+   */
+  @Input('p-label') label?: string;
+
+  /**
+   * @optional
+   *
+   * @description
+   *
+   * Define o *layout* de exibição.
    *
    * @default `vertical`
    */
   @Input('p-orientation') set orientation(value: PoTagOrientation) {
     this._orientation = (<any>Object).values(PoTagOrientation).includes(value) ? value : poTagOrientationDefault;
   }
+
   get orientation(): PoTagOrientation {
     return this._orientation;
   }
@@ -75,7 +123,7 @@ export class PoTagBaseComponent {
    *
    * @description
    *
-   * Define o tipo e determina a cor do `po-tag`.
+   * Define o tipo da *tag*.
    *
    * Valores válidos:
    *  - `success`: cor verde utilizada para simbolizar sucesso ou êxito.
@@ -83,11 +131,14 @@ export class PoTagBaseComponent {
    *  - `danger`: cor vermelha para erro ou aviso crítico.
    *  - `info`: cor cinza escuro que caracteriza conteúdo informativo.
    *
+   * > Quando esta propriedade for definida, irá sobrepor a definição de `p-color` e `p-icon` somente será exibido caso seja `true`.
+   *
    * @default `info`
    */
   @Input('p-type') set type(value: PoTagType) {
-    this._type = (<any>Object).values(PoTagType).includes(value) ? value : poTagTypeDefault;
+    this._type = (<any>Object).values(PoTagType).includes(value) ? value : undefined;
   }
+
   get type(): PoTagType {
     return this._type;
   }
@@ -100,21 +151,8 @@ export class PoTagBaseComponent {
    *
    * @description
    *
-   * Ação que será executada quando o usuário clicar sobre o `po-tag`
-   * e que receberá como parâmetro um objeto contendo o valor e tipo de tag.
+   * Ação que será executada ao clicar sobre o `po-tag` e que receberá como parâmetro um objeto contendo o seu valor e tipo.
    */
   @Output('p-click') click?: EventEmitter<any> = new EventEmitter<PoTagItem>();
-
-  get iconFromType() {
-    switch (this.type) {
-      case PoTagType.Danger: return PoTagIcon.Danger;
-
-      case PoTagType.Info: return PoTagIcon.Info;
-
-      case PoTagType.Success: return PoTagIcon.Success;
-
-      case PoTagType.Warning: return PoTagIcon.Warning;
-    }
-  }
 
 }

--- a/projects/ui/src/lib/components/po-tag/po-tag.component.html
+++ b/projects/ui/src/lib/components/po-tag/po-tag.component.html
@@ -1,12 +1,19 @@
-<div class="po-tag-container" [class.po-tag-container-horizontal]="orientation === poTagOrientation.Horizontal">
+<div class="po-tag-container" [class.po-tag-container-horizontal]="tagOrientation">
   <div *ngIf="label" class="po-tag-title po-text-nowrap">
-    <span class="po-tag-label">{{ orientation === poTagOrientation.Horizontal ? label + ':' : label }}</span>
+    <span class="po-tag-label">{{ tagOrientation ? label + ':' : label }}</span>
   </div>
-  <div 
-    class="po-tag po-tag-{{ type }}" 
-    [ngClass]="{'po-clickable': isClickable}"
-    (click)="onClick()">
-    <span *ngIf="icon" class="po-icon po-icon-{{ iconFromType }}"></span>
-    <span class="po-tag-value">{{value}}</span>
+
+  <div class="po-tag-sub-container">
+    <div class="po-tag"
+      [class.po-clickable]="isClickable"
+      [ngClass]="tagColor"
+      tabindex="0"
+      (click)="onClick()"
+      (keydown)="onKeyPressed($event, 'enter')"
+      (keyup)="onKeyPressed($event, 'space')">
+
+      <span *ngIf="icon" class="po-icon" [ngClass]="!type && iconTypeString ? icon : iconFromType"></span>
+      <span class="po-tag-value">{{value}}</span>
+    </div>
   </div>
 </div>

--- a/projects/ui/src/lib/components/po-tag/po-tag.component.spec.ts
+++ b/projects/ui/src/lib/components/po-tag/po-tag.component.spec.ts
@@ -36,7 +36,7 @@ describe('PoTagComponent:', () => {
     expect(component instanceof PoTagComponent).toBeTruthy();
   });
 
-  describe('Methods', () => {
+  describe('Methods:', () => {
     it('ngOnInit: should set `isClickable` with `true` if `p-click` @Output is wire up', () => {
       component.click.observers.push(<any>[new Observable()]);
 
@@ -53,6 +53,57 @@ describe('PoTagComponent:', () => {
       expect(component.isClickable).toBe(false);
     });
 
+    it('iconFromType: should update property with valid values', () => {
+      component.type = PoTagType.Danger;
+      expect(component.iconFromType).toBe(PoTagIcon.Danger);
+
+      component.type = PoTagType.Info;
+      expect(component.iconFromType).toBe(PoTagIcon.Info);
+
+      component.type = PoTagType.Success;
+      expect(component.iconFromType).toBe(PoTagIcon.Success);
+
+      component.type = PoTagType.Warning;
+      expect(component.iconFromType).toBe(PoTagIcon.Warning);
+    });
+
+    it('iconTypeString: should return `true` if is string value.', () => {
+      component.icon = 'po-icon-portinari';
+      expect(component.iconTypeString).toBe(true);
+    });
+
+    it('iconTypeString: should return `false` if isn`t string value.', () => {
+      component.icon = false;
+      expect(component.iconTypeString).toBe(false);
+    });
+
+    it('tagColor: should return tag type.', () => {
+      component.type = PoTagType.Danger;
+      expect(component.tagColor).toBe('po-tag-danger');
+    });
+
+    it('tagColor: should return tag color.', () => {
+      component.color = 'color-07';
+      component.type = undefined;
+      expect(component.tagColor).toBe('po-color-07');
+    });
+
+    it('tagColor: should return tag type default.', () => {
+      component.color = undefined;
+      component.type = undefined;
+      expect(component.tagColor).toBe('po-tag-info');
+    });
+
+    it('tagOrientation: should return true if orientation is horizontal.', () => {
+      component.orientation = PoTagOrientation.Horizontal;
+      expect(component.tagOrientation).toBe(true);
+    });
+
+    it('tagOrientation: should return false if orientation isn`t horizontal.', () => {
+      component.orientation = PoTagOrientation.Vertical;
+      expect(component.tagOrientation).toBe(false);
+    });
+
     it('onClick: click should emit submittedTagItem value', () => {
       component.value = 'value';
       component.type = PoTagType.Danger;
@@ -63,9 +114,38 @@ describe('PoTagComponent:', () => {
 
       expect(component.click.emit).toHaveBeenCalledWith({ 'value': component.value, 'type': component.type });
     });
+
+    it('onKeyPressed: should call `onClick` if is key enter.', () => {
+      const eventEscKey = new KeyboardEvent('keydown', <any>{ keyCode: 13 });
+      const spyOnClick = spyOn(component, 'onClick');
+
+      component.onKeyPressed(eventEscKey, 'enter');
+
+      expect(spyOnClick).toHaveBeenCalled();
+    });
+
+    it('onKeyPressed: should call `onClick` if is key space.', () => {
+      const eventSpaceKey = new KeyboardEvent('keydown', <any>{ keyCode: 32 });
+      const spyOnClick = spyOn(component, 'onClick');
+
+      component.onKeyPressed(eventSpaceKey, 'space');
+
+      expect(spyOnClick).toHaveBeenCalled();
+    });
+
+    it('onKeyPressed: shouldn`t call `onClick` if isn`t key space or enter.', () => {
+      const eventCapsLockKey = new KeyboardEvent('keypress', <any>{ keyCode: 20 });
+      const spyOnClick = spyOn(component, 'onClick');
+
+      component.onKeyPressed(eventCapsLockKey, 'CapsLock');
+
+      expect(spyOnClick).not.toHaveBeenCalled();
+    });
+
   });
 
-  describe('Template:', () => {
+  describe('Templates:', () => {
+
     it('should only start with default classes, shouldn`t have variations.', () => {
       const value = 'Po Tag';
       component.value = value;
@@ -163,22 +243,13 @@ describe('PoTagComponent:', () => {
       expect(nativeElement.querySelector('.po-tag-warning')).toBeTruthy();
     });
 
-    it('should add `po-icon` and `po-icon-info` default icon if `icon` is true.', () => {
-      component.icon = true;
-
-      fixture.detectChanges();
-
-      expect(nativeElement.querySelector('.po-icon')).toBeTruthy();
-      expect(nativeElement.querySelector(`.po-icon-${PoTagIcon.Info}`)).toBeTruthy();
-    });
-
     it('should add `PoTagIcon.Danger` if type is `PoTagType.Danger and `icon` is true`.', () => {
       component.type = PoTagType.Danger;
       component.icon = true;
 
       fixture.detectChanges();
 
-      expect(nativeElement.querySelector(`.po-icon-${PoTagIcon.Danger}`)).toBeTruthy();
+      expect(nativeElement.querySelector(`.${PoTagIcon.Danger}`)).toBeTruthy();
     });
 
     it('should add `PoTagIcon.Info` if type is `PoTagType.Info and `icon` is true`.', () => {
@@ -187,7 +258,7 @@ describe('PoTagComponent:', () => {
 
       fixture.detectChanges();
 
-      expect(nativeElement.querySelector(`.po-icon-${PoTagIcon.Info}`)).toBeTruthy();
+      expect(nativeElement.querySelector(`.${PoTagIcon.Info}`)).toBeTruthy();
     });
 
     it('should add `PoTagIcon.Success` if type is `PoTagType.Success and `icon` is true`.', () => {
@@ -196,7 +267,7 @@ describe('PoTagComponent:', () => {
 
       fixture.detectChanges();
 
-      expect(nativeElement.querySelector(`.po-icon-${PoTagIcon.Success}`)).toBeTruthy();
+      expect(nativeElement.querySelector(`.${PoTagIcon.Success}`)).toBeTruthy();
     });
 
     it('should add `PoTagIcon.Warning` if type is `PoTagType.Warning and `icon` is true`.', () => {
@@ -205,7 +276,7 @@ describe('PoTagComponent:', () => {
 
       fixture.detectChanges();
 
-      expect(nativeElement.querySelector(`.po-icon-${PoTagIcon.Warning}`)).toBeTruthy();
+      expect(nativeElement.querySelector(`.${PoTagIcon.Warning}`)).toBeTruthy();
     });
 
     it('should add `po-clickable` if `p-click` @Output is wire up`.', () => {
@@ -221,6 +292,7 @@ describe('PoTagComponent:', () => {
       fixture.detectChanges();
       expect(nativeElement.querySelector('.po-clickable')).toBeFalsy();
     });
+
   });
 
 });

--- a/projects/ui/src/lib/components/po-tag/po-tag.component.ts
+++ b/projects/ui/src/lib/components/po-tag/po-tag.component.ts
@@ -1,7 +1,13 @@
 import { Component, OnInit } from '@angular/core';
 
+import { PoKeyCodeEnum } from '../../enums/po-key-code.enum';
+
 import { PoTagBaseComponent } from './po-tag-base.component';
+import { PoTagIcon } from './enums/po-tag-icon.enum';
 import { PoTagItem } from './interfaces/po-tag-item.interface';
+import { PoTagType } from './enums/po-tag-type.enum';
+
+const poTagTypeDefault = 'po-tag-' + PoTagType.Info;
 
 /**
  * @docsExtends PoTagBaseComponent
@@ -35,9 +41,53 @@ export class PoTagComponent extends PoTagBaseComponent implements OnInit {
     this.isClickable = this.click.observers.length > 0;
   }
 
+  get iconFromType() {
+    switch (this.type) {
+      case PoTagType.Danger: return PoTagIcon.Danger;
+
+      case PoTagType.Info: return PoTagIcon.Info;
+
+      case PoTagType.Success: return PoTagIcon.Success;
+
+      case PoTagType.Warning: return PoTagIcon.Warning;
+    }
+  }
+
+  get iconTypeString() {
+    return typeof this.icon === 'string';
+  }
+
+  get tagColor() {
+    if (this.type) {
+      return 'po-tag-' + this.type;
+    }
+
+    if (this.color && !this.type) {
+      return 'po-' + this.color;
+    }
+
+    if (!this.type && !this.color) {
+      return poTagTypeDefault;
+    }
+  }
+
+  get tagOrientation() {
+    return this.orientation === this.poTagOrientation.Horizontal;
+  }
+
   onClick() {
     const submittedTagItem: PoTagItem = { value: this.value, type: this.type };
-
     this.click.emit(submittedTagItem);
   }
+
+  onKeyPressed(event: any, keyCode: string) {
+    const isValidKey = event.keyCode === PoKeyCodeEnum[keyCode];
+
+    if (isValidKey) {
+      event.preventDefault();
+      event.stopPropagation();
+      this.onClick();
+    }
+  }
+
 }

--- a/projects/ui/src/lib/components/po-tag/samples/sample-po-tag-labs/sample-po-tag-labs.component.html
+++ b/projects/ui/src/lib/components/po-tag/samples/sample-po-tag-labs/sample-po-tag-labs.component.html
@@ -1,4 +1,5 @@
 <po-tag
+  [p-color]="color"
   [p-icon]="icon"
   [p-label]="label"
   [p-orientation]="orientation"
@@ -37,26 +38,55 @@
       p-label="Value"
       p-required>
     </po-input>
+  </div>
 
-    <po-switch
-      class="po-md-12"
+  <div class="po-row">
+    <po-select
+      class="po-md-6"
+      name="color"
+      [(ngModel)]="color"
+      p-label="Color"
+      [p-options]="colorList">
+
+      <ng-template p-select-option-template let-option>
+        <div>
+          <span class="sample-tag-color-circle po-{{ option.value }}"></span>
+          <span class="sample-menu-vertical-middle"> {{ option.label }} </span>
+        </div>
+      </ng-template>
+    </po-select>
+
+    <po-select *ngIf="!type"
+      class="po-md-6"
+      name="icon"
+      [(ngModel)]="icon"
+      p-label="Icon"
+      [p-options]="iconList">
+    </po-select>
+
+    <po-switch *ngIf="type"
+      class="po-md-6"
       name="icon"
       [(ngModel)]="icon"
       p-label="Icon">
     </po-switch>
+  </div>
 
+  <div class="po-row">
     <po-radio-group
-      class="po-md-6"
+      class="po-md-4"
       name="orientation"
       [(ngModel)]="orientation"
+      p-columns="1"
       p-label="Orientation"
       [p-options]="orientationOptions">
     </po-radio-group>
 
     <po-radio-group
-      class="po-md-6"
+      class="po-md-8"
       name="type"
       [(ngModel)]="type"
+      p-columns="3"
       p-label="Type"
       [p-options]="typeOptions">
     </po-radio-group>

--- a/projects/ui/src/lib/components/po-tag/samples/sample-po-tag-labs/sample-po-tag-labs.component.ts
+++ b/projects/ui/src/lib/components/po-tag/samples/sample-po-tag-labs/sample-po-tag-labs.component.ts
@@ -1,19 +1,54 @@
 import { Component, OnInit } from '@angular/core';
 
-import { PoRadioGroupOption, PoTagOrientation, PoTagType } from '@portinari/portinari-ui';
+import { PoRadioGroupOption, PoSelectOption, PoTagOrientation, PoTagType } from '@portinari/portinari-ui';
 
 @Component({
   selector: 'sample-po-tag-labs',
   templateUrl: './sample-po-tag-labs.component.html',
+  styles: [`
+    .sample-tag-color-circle {
+      border-radius: 10px;
+      display: inline-block;
+      height: 16px;
+      margin-right: 4px;
+      vertical-align: middle;
+      width: 16px;
+    }
+  `]
 })
 export class SamplePoTagLabsComponent implements OnInit {
 
+  color: string;
   event: string;
-  icon: boolean;
+  icon: boolean | string;
   label: string;
   orientation: PoTagOrientation;
   type: PoTagType;
   value: string;
+
+  public readonly colorList: Array<PoSelectOption> = [
+    { label: 'color-01', value: 'color-01' },
+    { label: 'color-02', value: 'color-02' },
+    { label: 'color-03', value: 'color-03' },
+    { label: 'color-04', value: 'color-04' },
+    { label: 'color-05', value: 'color-05' },
+    { label: 'color-06', value: 'color-06' },
+    { label: 'color-07', value: 'color-07' },
+    { label: 'color-08', value: 'color-08' },
+    { label: 'color-09', value: 'color-09' },
+    { label: 'color-10', value: 'color-10' },
+    { label: 'color-11', value: 'color-11' },
+    { label: 'color-12', value: 'color-12' },
+  ];
+
+  public readonly iconList: Array<PoSelectOption> = [
+    { label: 'po-icon-bluetooth', value: 'po-icon-bluetooth' },
+    { label: 'po-icon-like', value: 'po-icon-like' },
+    { label: 'po-icon-light', value: 'po-icon-light' },
+    { label: 'po-icon-star', value: 'po-icon-star' },
+    { label: 'po-icon-settings', value: 'po-icon-settings' },
+    { label: 'po-icon-world', value: 'po-icon-world' }
+  ];
 
   public readonly orientationOptions: Array<PoRadioGroupOption> = [
     { label: 'Horizontal', value: PoTagOrientation.Horizontal },
@@ -21,6 +56,7 @@ export class SamplePoTagLabsComponent implements OnInit {
   ];
 
   public readonly typeOptions: Array<PoRadioGroupOption> = [
+    { label: 'None', value: undefined },
     { label: 'Info', value: PoTagType.Info },
     { label: 'Danger', value: PoTagType.Danger },
     { label: 'Success', value: PoTagType.Success },
@@ -36,6 +72,7 @@ export class SamplePoTagLabsComponent implements OnInit {
   }
 
   restore() {
+    this.color = undefined;
     this.icon = undefined;
     this.label = undefined;
     this.orientation = undefined;


### PR DESCRIPTION
**PO-TAG**

**DTHFUI-1762**

***

**PR Checklist**

- [x] Código
- [x] Testes unitários
- [x] Documentação
- [x] Samples

***

**Qual o comportamento atual?**
O componente não permite utilizar as paletas de cores, ícones e navegar através do teclado.

**Qual o novo comportamento?**
Agora o componente permite a utilização da paleta de cores, além de ícones e navegação através do teclado.

**Simulação**
Utilizar sample labs.

Style: https://github.com/portinariui/portinari-style/pull/39