### PR TITLE
fix(page-dynamic-edit): corrige importação do DynamicForm

### DIFF
--- a/projects/templates/src/lib/components/po-page-dynamic-edit/po-page-dynamic-edit.component.spec.ts
+++ b/projects/templates/src/lib/components/po-page-dynamic-edit/po-page-dynamic-edit.component.spec.ts
@@ -1,6 +1,6 @@
 import { ComponentFixture, fakeAsync, TestBed, tick } from '@angular/core/testing';
 import { NO_ERRORS_SCHEMA } from '@angular/core';
-import { FormsModule } from '@angular/forms';
+import { FormsModule, NgForm } from '@angular/forms';
 import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { RouterTestingModule } from '@angular/router/testing';
 
@@ -13,6 +13,7 @@ import { configureTestSuite, expectPropertiesValues } from './../../util-test/ut
 
 import { PoPageDynamicEditComponent } from './po-page-dynamic-edit.component';
 import { PoPageDynamicEditActions } from './po-page-dynamic-edit-actions.interface';
+import { PoDynamicFormStubComponent } from './test/po-dynamic-form-stub-component';
 
 describe('PoPageDynamicEditComponent: ', () => {
   let component: PoPageDynamicEditComponent;
@@ -28,7 +29,8 @@ describe('PoPageDynamicEditComponent: ', () => {
       ],
       providers: [],
       declarations: [
-        PoPageDynamicEditComponent
+        PoPageDynamicEditComponent,
+        PoDynamicFormStubComponent
       ],
       schemas: [ NO_ERRORS_SCHEMA ]
     });
@@ -43,6 +45,15 @@ describe('PoPageDynamicEditComponent: ', () => {
 
   it('should be created', () => {
     expect(component).toBeTruthy();
+  });
+
+  it('should set dynamicForm ViewChild properly', () => {
+    const form: NgForm = {
+      dirty: true
+    } as NgForm;
+
+    component.dynamicForm.form = form;
+    expect(component.dynamicForm.form.dirty).toBeTruthy();
   });
 
   describe('Properties: ', () => {

--- a/projects/templates/src/lib/components/po-page-dynamic-edit/po-page-dynamic-edit.component.ts
+++ b/projects/templates/src/lib/components/po-page-dynamic-edit/po-page-dynamic-edit.component.ts
@@ -251,8 +251,8 @@ export class PoPageDynamicEditComponent implements OnInit {
   /** Título da página. */
   @Input('p-title') title: string;
 
-  @ViewChild('dynamicForm', { static: true }) dynamicForm: PoDynamicFormComponent;
-  @ViewChild('gridDetail', { static: true }) gridDetail: PoGridComponent;
+  @ViewChild('dynamicForm', { static: false }) dynamicForm: PoDynamicFormComponent;
+  @ViewChild('gridDetail', { static: false }) gridDetail: PoGridComponent;
 
   constructor(
     private router: Router,

--- a/projects/templates/src/lib/components/po-page-dynamic-edit/test/po-dynamic-form-stub-component.ts
+++ b/projects/templates/src/lib/components/po-page-dynamic-edit/test/po-dynamic-form-stub-component.ts
@@ -1,0 +1,27 @@
+import { Component } from '@angular/core';
+import { NgForm } from '@angular/forms';
+import { PoDynamicFormComponent } from '@portinari/portinari-ui';
+
+@Component({
+  selector: 'po-dynamic-form',
+  template: '',
+  providers: [
+    {
+      provide: PoDynamicFormComponent,
+      useClass: PoDynamicFormStubComponent
+    }
+  ]
+})
+
+export class PoDynamicFormStubComponent {
+
+  private _form: NgForm;
+
+  get form(): NgForm {
+    return this._form;
+  }
+
+  set form(form: NgForm) {
+    this._form = form;
+  }
+}


### PR DESCRIPTION

**po-page-dynamic-edit**

****
_____________________________________________________________________________

**PR Checklist**

- [X] Código
- [X] Testes unitários
- [X] Documentação
- [X] Samples

**Qual o comportamento atual?**
O formulário dynamicForm não era carregado corretamente causando o seguinte erro
ERROR TypeError: Cannot read property 'form' of undefined
quando usuário selecinonava as opções de salvar ou salvar novo

**Qual o novo comportamento?**
Alterada a importação do ViewChild utilizando a flag static como false
Ver (https://angular.io/api/core/ViewChild)

**Simulação**
No exemplo na documentação(https://portinari.io/documentation/po-page-dynamic-edit) clique em salvar no exemplo Portinari Page Dynamic Edit - User, a ação não será executada e aparecerá o erro ERROR TypeError: Cannot read property 'form' of undefined no console.