### PR TITLE
feat(lookup): inclui coluna de ordenação na chamada do serviço 

### DIFF
--- a/projects/ui/src/lib/components/po-field/index.ts
+++ b/projects/ui/src/lib/components/po-field/index.ts
@@ -15,6 +15,7 @@ export * from './po-input/po-input.component';
 export * from './po-login/po-login.component';
 export * from './po-lookup/interfaces/po-lookup-column.interface';
 export * from './po-lookup/interfaces/po-lookup-filter.interface';
+export * from './po-lookup/interfaces/po-lookup-filtered-items-params.interface';
 export * from './po-lookup/interfaces/po-lookup-literals.interface';
 export * from './po-lookup/interfaces/po-lookup-response-api.interface';
 export * from './po-lookup/po-lookup.component';

--- a/projects/ui/src/lib/components/po-field/po-lookup/interfaces/po-lookup-filter.interface.ts
+++ b/projects/ui/src/lib/components/po-field/po-lookup/interfaces/po-lookup-filter.interface.ts
@@ -1,5 +1,6 @@
 import { Observable } from 'rxjs';
 
+import { PoLookupFilteredItemsParams } from './po-lookup-filtered-items-params.interface';
 import { PoLookupResponseApi } from './po-lookup-response-api.interface';
 
 /**
@@ -12,6 +13,8 @@ import { PoLookupResponseApi } from './po-lookup-response-api.interface';
 export interface PoLookupFilter {
 
   /**
+   * **Deprecated**
+   *
    * Método responsável por enviar um filtro para o serviço e receber os dados.
    *
    * Os parâmetros page e pageSize seguem o guia de implementação das APIs TOTVS, são utilizados para controlar a busca dos dados em cada
@@ -19,12 +22,27 @@ export interface PoLookupFilter {
    *
    * Este método deve retornar um *Observable* com a resposta da API no formato da interface `PoLookupResponseApi`.
    *
+   * > Este método está depreciado, deve-se utilizar a método `getFilteredItems`.
+   *
    * @param {any} filter Utilizado pelo serviço para filtrar os dados.
    * @param {number} page Controla a paginação dos dados e recebe valor automaticamente a cada clique no botão 'Carregar mais resultados'.
    * @param {number} pageSize Quantidade de itens retornados cada vez que o serviço é chamado, por padrão é 10.
    * @param {any} filterParams Valor informado através da propriedade `p-filter-params`.
+   *
+   * @deprecated 4.x.x
+   *
    */
-  getFilteredData(filter: any, page: number, pageSize?: number, filterParams?: any): Observable<PoLookupResponseApi>;
+  getFilteredData?(filter: any, page: number, pageSize?: number, filterParams?: any): Observable<PoLookupResponseApi>;
+
+  /**
+   * Método que será disparado ao filtrar a lista de itens ou carregar mais resultados no componente, deve-se retornar
+   * um *Observable* com a resposta da API no formato da interface `PoLookupResponseApi`.
+   *
+   * > Esta propriedade será priorizada se houver também o método `getFilteredData`.
+   *
+   * @param {PoLookupFilteredItemsParams} params Objeto enviado por parâmetro que implementa a interface `PoLookupFilteredItemsParams`.
+   */
+  getFilteredItems?(params: PoLookupFilteredItemsParams): Observable<PoLookupResponseApi>;
 
   /**
    * Método responsável por enviar um valor que será buscado no serviço.

--- a/projects/ui/src/lib/components/po-field/po-lookup/interfaces/po-lookup-filtered-items-params.interface.ts
+++ b/projects/ui/src/lib/components/po-field/po-lookup/interfaces/po-lookup-filtered-items-params.interface.ts
@@ -1,0 +1,38 @@
+/**
+ * @usedBy PoLookupComponent
+ *
+ * @description
+ *
+ * Interface do objeto enviado como parâmetro na função `getFilteredItems`.
+ */
+export interface PoLookupFilteredItemsParams {
+
+  /**
+   * Conteúdo utilizado para filtrar a lista de itens.
+   */
+  filter?: string;
+
+  /**
+   * Controla a paginação dos dados e recebe valor automaticamente a cada clique no botão 'Carregar mais resultados'.
+   */
+  page?: number;
+
+  /**
+   * Quantidade de itens retornados cada vez que o serviço é chamado, por padrão é 10.
+   */
+  pageSize?: number;
+
+  /**
+   * Valor informado através da propriedade `p-filter-params`.
+   */
+  filterParams?: any;
+
+  /**
+   * Coluna que está sendo ordenada na tabela.
+   *
+   * - Coluna decrescente será informada da seguinte forma: `-<colunaOrdenada>`, por exemplo `-name`.
+   * - Coluna ascendente será informada da seguinte forma: `<colunaOrdenada>`, por exemplo `name`.
+   */
+  order?: string;
+
+}

--- a/projects/ui/src/lib/components/po-field/po-lookup/po-lookup-base.component.ts
+++ b/projects/ui/src/lib/components/po-field/po-lookup/po-lookup-base.component.ts
@@ -150,6 +150,17 @@ export abstract class PoLookupBaseComponent implements ControlValueAccessor, OnD
    * url + ?page=1&pageSize=20&filter=Peter
    * ```
    *
+   * Caso utilizar ordenação, a coluna ordenada será enviada através do parâmetro `order`, por exemplo:
+   * - Coluna decrescente:
+   * ```
+   *  url + ?page=1&pageSize=20&filter=Peter&order=-name
+   * ```
+   *
+   * - Coluna ascendente:
+   * ```
+   *  url + ?page=1&pageSize=20&filter=Peter&order=name
+   * ```
+   *
    * Se for definido a propriedade `p-filter-params`, o mesmo também será concatenado. Por exemplo, para o
    * parâmetro `{ age: 23 }` a URL ficaria:
    *

--- a/projects/ui/src/lib/components/po-field/po-lookup/po-lookup-modal/po-lookup-modal-base.component.spec.ts
+++ b/projects/ui/src/lib/components/po-field/po-lookup/po-lookup-modal/po-lookup-modal-base.component.spec.ts
@@ -2,6 +2,8 @@ import { Observable, of } from 'rxjs';
 
 import * as UtilsFunctions from '../../../../utils/util';
 import { expectPropertiesValues } from '../../../../util-test/util-expect.spec';
+import { PoTableColumnSort } from '../../../po-table/interfaces/po-table-column-sort.interface';
+import { PoTableColumnSortType } from '../../../po-table/enums/po-table-column-sort-type.enum';
 
 import { poLookupLiteralsDefault, PoLookupModalBaseComponent } from './po-lookup-modal-base.component';
 
@@ -18,7 +20,7 @@ describe('PoLookupModalBaseComponent:', () => {
     component = new PoLookupModalComponent();
 
     component.filterService = {
-      getFilteredData: (searchValue, pageSize: number) => of({ items: [], hasNext: false }),
+      getFilteredItems: ({filter, pageSize}) => of({ items: [], hasNext: false }),
       getObjectByValue: () => of()
     };
 
@@ -34,11 +36,11 @@ describe('PoLookupModalBaseComponent:', () => {
   });
 
   it('should init modal with items', () => {
-    spyOn(component.filterService, 'getFilteredData').and.returnValue(of({ items: [].concat(items), hasNext : true }));
+    spyOn(component.filterService, 'getFilteredItems').and.returnValue(of({ items: [].concat(items), hasNext : true }));
 
     component.ngOnInit();
 
-    expect(component.filterService.getFilteredData).toHaveBeenCalled();
+    expect(component.filterService.getFilteredItems).toHaveBeenCalled();
     expect(component.items.length).toBe(5);
     expect(component.hasNext).toBeTruthy();
   });
@@ -213,34 +215,59 @@ describe('PoLookupModalBaseComponent:', () => {
       expect(fakeSubscription.unsubscribe).not.toHaveBeenCalled();
     });
 
-    it('getFilteredData: shoud call `getFilteredData` and return a Observable.', () => {
+    it('getFilteredItems: shoud call `getFilteredItems` and return a Observable if `getFilteredItems` is truthy', () => {
       const page = 1;
       const pageSize = 1;
       const filterParams = { code: 1 };
-      const searchValue = 'po';
+      const filter = 'po';
 
       component.page = page;
       component.pageSize = pageSize;
       component.filterParams = filterParams;
 
-      spyOn(component.filterService, 'getFilteredData').and.returnValue(of(<any> {items}));
+      spyOn(component.filterService, 'getFilteredItems').and.returnValue(of(<any> {items}));
+      spyOn(component, <any> 'getFilteredParams').and.callThrough();
 
-      const filteredDataObservable = component['getFilteredData'](searchValue);
+      const filteredDataObservable = component['getFilteredItems'](filter);
 
+      expect(component['getFilteredParams']).toHaveBeenCalled();
       expect(filteredDataObservable instanceof Observable);
-      expect(component.filterService.getFilteredData).toHaveBeenCalledWith(searchValue, page, pageSize, filterParams);
+      expect(component.filterService.getFilteredItems).toHaveBeenCalledWith({filter, page, pageSize, filterParams});
     });
 
-    it('search: should call `getFilteredData` if `searchValue` it`s truthy.', () => {
+    it('getFilteredItems: shoud call `getFilteredData` and return a Observable if `getFilteredItems` is falsy', () => {
+      const page = 1;
+      const pageSize = 1;
+      const filterParams = { code: 1 };
+      const filter = 'po';
+
+      component.page = page;
+      component.pageSize = pageSize;
+      component.filterParams = filterParams;
+
+      component.filterService.getFilteredItems = undefined;
+      component.filterService.getFilteredData = () => of({ items: [], hasNext: false });
+
+      spyOn(component.filterService, 'getFilteredData').and.returnValue(of(<any> {items}));
+      spyOn(component, <any> 'getFilteredParams');
+
+      const filteredDataObservable = component['getFilteredItems'](filter);
+
+      expect(component['getFilteredParams']).not.toHaveBeenCalled();
+      expect(filteredDataObservable instanceof Observable);
+      expect(component.filterService.getFilteredData).toHaveBeenCalledWith(filter, page, pageSize, filterParams);
+    });
+
+    it('search: should call `getFilteredItems` if `searchValue` it`s truthy.', () => {
       component.searchValue = 'Suco';
 
       const filteredItems = items.filter(f => f.label.includes(component.searchValue));
 
-      spyOn(component, <any> 'getFilteredData').and.returnValue(of({ items: filteredItems, hasNext: true }));
+      spyOn(component, <any> 'getFilteredItems').and.returnValue(of({ items: filteredItems, hasNext: true }));
 
       component.search();
 
-      expect(component['getFilteredData']).toHaveBeenCalledWith('Suco');
+      expect(component['getFilteredItems']).toHaveBeenCalledWith('Suco');
       expect(component.items.length).toBe(2);
       expect(component.hasNext).toBeTruthy();
     });
@@ -255,18 +282,18 @@ describe('PoLookupModalBaseComponent:', () => {
       expect(component['initializeData']).toHaveBeenCalled();
     });
 
-    it('showMoreEvent: should call `getFilteredData`, increment `page` and assign returned items to `items`.', () => {
+    it('showMoreEvent: should call `getFilteredItems`, increment `page` and assign returned items to `items`.', () => {
       const searchValue = 'Chocolate';
       const returnedItems = [{ value: 6, label: 'Chocolate quente' }];
       component.page = 1;
       component.items = [].concat(items);
       component.searchValue = searchValue;
 
-      spyOn(component, <any> 'getFilteredData').and.returnValue(of({items: returnedItems }));
+      spyOn(component, <any> 'getFilteredItems').and.returnValue(of({items: returnedItems }));
 
       component.showMoreEvent();
 
-      expect(component['getFilteredData']).toHaveBeenCalledWith(searchValue);
+      expect(component['getFilteredItems']).toHaveBeenCalledWith(searchValue);
       expect(component.items.length).toBe([...items, ...returnedItems].length);
       expect(component.page).toBe(2);
       expect(component.isLoading).toBeFalsy();
@@ -291,6 +318,48 @@ describe('PoLookupModalBaseComponent:', () => {
 
       expect(component.tableLiterals).toEqual(result);
 
+    });
+
+    it('getFilteredParams: should return object with only truthy values', () => {
+      const page = 1;
+      const pageSize = 10;
+      const filter = '';
+      const expectedValue = { page, pageSize };
+
+      component.page = page;
+      component.pageSize = pageSize;
+      component.filterParams = undefined;
+      component['sort'] = undefined;
+
+      const filteredParams = component['getFilteredParams'](filter);
+
+      expect(filteredParams).toEqual(expectedValue);
+    });
+
+    it('getOrderParam: should return `column.property` of PoTableColumnSort object if PoTableColumnSortType is Ascending', () => {
+      const sort: PoTableColumnSort = { column: { property: 'name' }, type: PoTableColumnSortType.Ascending };
+      const expectedValue = 'name';
+
+      const orderParam = component['getOrderParam'](sort);
+
+      expect(orderParam).toBe(expectedValue);
+    });
+
+    it('getOrderParam: should return `-column.property` of PoTableColumnSort object if PoTableColumnSortType is Descending', () => {
+      const sort: PoTableColumnSort = { column: { property: 'name' }, type: PoTableColumnSortType.Descending };
+      const expectedValue = '-name';
+
+      const orderParam = component['getOrderParam'](sort);
+
+      expect(orderParam).toBe(expectedValue);
+    });
+
+    it('getOrderParam: should return undefined if PoTableColumnSort.column is undefined', () => {
+      const expectedValue = undefined;
+
+      const orderParam = component['getOrderParam']();
+
+      expect(orderParam).toBe(expectedValue);
     });
 
   });

--- a/projects/ui/src/lib/components/po-field/po-lookup/po-lookup-modal/po-lookup-modal.component.html
+++ b/projects/ui/src/lib/components/po-field/po-lookup/po-lookup-modal/po-lookup-modal.component.html
@@ -42,7 +42,8 @@
       [p-literals]="tableLiterals"
       [p-loading]="isLoading"
       [p-show-more-disabled]="!hasNext"
-      (p-show-more)="showMoreEvent()">
+      (p-show-more)="showMoreEvent()"
+      (p-sort-by)="sortBy($event)">
     </po-table>
 
   </div>

--- a/projects/ui/src/lib/components/po-field/po-lookup/po-lookup-modal/po-lookup-modal.component.spec.ts
+++ b/projects/ui/src/lib/components/po-field/po-lookup/po-lookup-modal/po-lookup-modal.component.spec.ts
@@ -4,15 +4,17 @@ import { NO_ERRORS_SCHEMA } from '@angular/core';
 import { Observable, of } from 'rxjs';
 
 import { changeBrowserInnerHeight, configureTestSuite } from '../../../../util-test/util-expect.spec';
-
 import { PoComponentInjectorService } from '../../../../services/po-component-injector/po-component-injector.service';
+import { PoModalModule } from '../../../../components/po-modal/po-modal.module';
+import { PoTableColumnSort } from '../../../po-table/interfaces/po-table-column-sort.interface';
+import { PoTableColumnSortType } from '../../../po-table/enums/po-table-column-sort-type.enum';
+
 import { PoLookupFilter } from '../../../../components/po-field/po-lookup/interfaces/po-lookup-filter.interface';
 import { PoLookupModalComponent } from '../../../../components/po-field/po-lookup/po-lookup-modal/po-lookup-modal.component';
-import { PoModalModule } from '../../../../components/po-modal/po-modal.module';
 
 class LookupFilterService implements PoLookupFilter {
 
-  getFilteredData(params: any): Observable<any> {
+  getFilteredItems(params: any): Observable<any> {
     return of({items: [{value: 123, label: 'teste'}]});
   }
   getObjectByValue(id: string): Observable<any> {
@@ -41,7 +43,7 @@ describe('PoLookupModalComponent', () => {
     fixture = TestBed.createComponent(PoLookupModalComponent);
     component = fixture.componentInstance;
     component.filterService = {
-      getFilteredData: () => of({ items: [{ value: 123, label: 'teste' }, { value: 456, label: 'teste 2' }], hasNext: false }),
+      getFilteredItems: () => of({ items: [{ value: 123, label: 'teste' }, { value: 456, label: 'teste 2' }], hasNext: false }),
       getObjectByValue: () => of({ items: [{ value: 123, label: 'teste' }]}),
     };
     fixture.detectChanges();
@@ -174,6 +176,19 @@ describe('PoLookupModalComponent', () => {
 
     expect(component.tableHeight).toBe(defaultTableHeight);
     expect(component.containerHeight).toBe(defaultContainerHeight);
+  });
+
+  describe('Methods: ', () => {
+
+    it('sortBy: should set sort property', () => {
+      const expectedValue: PoTableColumnSort = { column: { property: 'name' }, type: PoTableColumnSortType.Ascending };
+
+      component['sort'] = undefined;
+
+      component.sortBy(expectedValue);
+
+      expect(component['sort']).toEqual(expectedValue);
+    });
   });
 
 });

--- a/projects/ui/src/lib/components/po-field/po-lookup/po-lookup-modal/po-lookup-modal.component.ts
+++ b/projects/ui/src/lib/components/po-field/po-lookup/po-lookup-modal/po-lookup-modal.component.ts
@@ -3,6 +3,8 @@ import { Component, ElementRef, OnInit, ViewChild } from '@angular/core';
 import { fromEvent, Observable } from 'rxjs';
 import { debounceTime, filter } from 'rxjs/operators';
 
+import { PoTableColumnSort } from '../../../po-table/interfaces/po-table-column-sort.interface';
+
 import { PoLookupModalBaseComponent } from '../po-lookup-modal/po-lookup-modal-base.component';
 
 /**
@@ -44,6 +46,10 @@ export class PoLookupModalComponent extends PoLookupModalBaseComponent implement
 
   openModal() {
     this.poModal.open();
+  }
+
+  sortBy(sort: PoTableColumnSort) {
+    this.sort = sort;
   }
 
   private setTableHeight() {

--- a/projects/ui/src/lib/components/po-field/po-lookup/samples/sample-po-lookup-basic/sample-po-lookup-basic.component.html
+++ b/projects/ui/src/lib/components/po-field/po-lookup/samples/sample-po-lookup-basic/sample-po-lookup-basic.component.html
@@ -2,6 +2,6 @@
   name="lookup"
   p-field-label="label"
   p-field-value="value"
-  p-filter-service="https://thf.totvs.com.br/sample/api/comboOption/heroes"
+  p-filter-service="https://thf.totvs.com.br/sample/api/new/heroes?fields=id,name,nickname,email"
   p-label="Portinari Lookup">
 </po-lookup>

--- a/projects/ui/src/lib/components/po-field/po-lookup/samples/sample-po-lookup-hero-reactive-form/sample-po-lookup-hero-reactive-form.component.ts
+++ b/projects/ui/src/lib/components/po-field/po-lookup/samples/sample-po-lookup-hero-reactive-form/sample-po-lookup-hero-reactive-form.component.ts
@@ -18,7 +18,7 @@ export class SamplePoLookupHeroReactiveFormComponent implements OnInit {
 
   public readonly columns: Array<PoLookupColumn> = [
     { property: 'nickname', label: 'Hero' },
-    { property: 'label', label: 'Name' }
+    { property: 'name', label: 'Name' }
   ];
 
   public readonly vehicles: Array<PoSelectOption> = [

--- a/projects/ui/src/lib/components/po-field/po-lookup/samples/sample-po-lookup-hero/sample-po-lookup-hero.component.ts
+++ b/projects/ui/src/lib/components/po-field/po-lookup/samples/sample-po-lookup-hero/sample-po-lookup-hero.component.ts
@@ -18,7 +18,7 @@ export class SamplePoLookupHeroComponent {
 
   public readonly columns: Array<PoLookupColumn> = [
     { property: 'nickname', label: 'Hero' },
-    { property: 'label', label: 'Name' }
+    { property: 'name', label: 'Name' }
   ];
 
   public readonly vehicles: Array<PoSelectOption> = [

--- a/projects/ui/src/lib/components/po-field/po-lookup/samples/sample-po-lookup-labs/sample-po-lookup-labs.component.ts
+++ b/projects/ui/src/lib/components/po-field/po-lookup/samples/sample-po-lookup-labs/sample-po-lookup-labs.component.ts
@@ -27,8 +27,8 @@ export class SamplePoLookupLabsComponent implements OnInit {
   properties: Array<string>;
 
   private readonly columnsDefinition = {
-    value: <PoLookupColumn>{ property: 'value', label: 'Id' },
-    label: <PoLookupColumn>{ property: 'label', label: 'Name' },
+    value: <PoLookupColumn>{ property: 'id', label: 'Id' },
+    label: <PoLookupColumn>{ property: 'name', label: 'Name' },
     phone: <PoLookupColumn>{ property: 'phone', label: 'Phone' },
     email: <PoLookupColumn>{ property: 'email', label: 'Email' }
   };

--- a/projects/ui/src/lib/components/po-field/po-lookup/samples/sample-po-lookup-sw-films/sample-po-lookup-sw-films.service.ts
+++ b/projects/ui/src/lib/components/po-field/po-lookup/samples/sample-po-lookup-sw-films/sample-po-lookup-sw-films.service.ts
@@ -4,7 +4,7 @@ import { Injectable } from '@angular/core';
 import { map } from 'rxjs/operators';
 import { Observable } from 'rxjs';
 
-import { PoLookupFilter, PoLookupResponseApi } from '@portinari/portinari-ui';
+import { PoLookupFilter, PoLookupResponseApi, PoLookupFilteredItemsParams } from '@portinari/portinari-ui';
 
 @Injectable()
 export class SamplePoLookupSwFilmsService implements PoLookupFilter {
@@ -18,10 +18,14 @@ export class SamplePoLookupSwFilmsService implements PoLookupFilter {
     return this.http.get(this.filmsUrl);
   }
 
-  getFilteredData(filter: string, page: number, pageSize, filterParams: any): Observable<PoLookupResponseApi> {
-    const searchParam = { params: { page: page.toString(), search: filter } };
+  getFilteredItems({ filter, page, filterParams }: PoLookupFilteredItemsParams): Observable<PoLookupResponseApi> {
+    const params = { page: page.toString() };
 
-    return this.http.get(`${this.baseUrl}/${filterParams}`, searchParam)
+    if (filter) {
+      params['search'] = filter;
+    }
+
+    return this.http.get(`${this.baseUrl}/${filterParams}`, { params })
       .pipe(map((response: { results: Array<any>, next: string }) => {
         return {
           items: response.results,

--- a/projects/ui/src/lib/components/po-field/po-lookup/samples/sample-po-lookup.service.ts
+++ b/projects/ui/src/lib/components/po-field/po-lookup/samples/sample-po-lookup.service.ts
@@ -1,8 +1,9 @@
 import { HttpClient } from '@angular/common/http';
 import { Injectable } from '@angular/core';
+
 import { Observable } from 'rxjs';
 
-import { PoLookupFilter } from '@portinari/portinari-ui';
+import { PoLookupFilter, PoLookupFilteredItemsParams } from '@portinari/portinari-ui';
 
 @Injectable()
 export class SamplePoLookupService implements PoLookupFilter {
@@ -11,8 +12,11 @@ export class SamplePoLookupService implements PoLookupFilter {
 
   constructor(private httpClient: HttpClient) { }
 
-  getFilteredData(filter: string, page: number, pageSize: number): Observable<any> {
-    return this.httpClient.get(this.url, { params: { page: page.toString(), pageSize: pageSize.toString(), filter } });
+  getFilteredItems(filteredParams: PoLookupFilteredItemsParams): Observable<any> {
+    const { page, pageSize } = filteredParams;
+    const params = { ...filteredParams, page: page.toString(), pageSize: pageSize.toString() };
+
+    return this.httpClient.get(this.url, { params });
   }
 
   getObjectByValue(value: string): Observable<any> {

--- a/projects/ui/src/lib/components/po-field/po-lookup/services/po-lookup-filter.service.spec.ts
+++ b/projects/ui/src/lib/components/po-field/po-lookup/services/po-lookup-filter.service.spec.ts
@@ -28,43 +28,43 @@ describe('PoLookupFilterService', () => {
 
   describe('Methods:', () => {
 
-    it(`getFilteredData: should return the request response and create request with url, page, pageSize, filter
+    it(`getFilteredItems: should return the request response and create request with url, page, pageSize, filter
       and params correctly`, () => {
 
       service['url'] = 'http://url.com';
       const page = 1;
       const pageSize = 20;
       const filter = 'name';
-      const params = { name: 'test' };
+      const filterParams = { name: 'test' };
       const expectedResponse = { user: 'test' };
 
-      service.getFilteredData(filter, page, pageSize, params).subscribe(response =>
+      service.getFilteredItems({ filter, page, pageSize, filterParams }).subscribe(response =>
         expect(response).toEqual(expectedResponse)
       );
 
       httpMock.expectOne(httpRequest => {
         return httpRequest.url === service['url'] &&
           httpRequest.method === 'GET' &&
-          httpRequest.params.get('page') === page.toString() &&
-          httpRequest.params.get('pageSize') === pageSize.toString() &&
+          httpRequest.params.get('page') === <any> page &&
+          httpRequest.params.get('pageSize') === <any> pageSize &&
           httpRequest.params.get('filter') === 'name' &&
           httpRequest.params.get('name') === 'test';
       }).flush(expectedResponse);
 
     });
 
-    it(`getFilteredData: should call 'validateParams' and set its return as the request parameter`, () => {
+    it(`getFilteredItems: should call 'validateParams' and set its return as the request parameter`, () => {
 
       service['url'] = 'http://url.com';
       const page = 1;
       const pageSize = 20;
       const filter = undefined;
-      const params = { name: 'test' };
+      const filterParams = { name: 'test' };
 
-      spyOn(service, <any>'validateParams').and.returnValue(params);
+      spyOn(service, <any>'validateParams').and.returnValue(filterParams);
 
-      service.getFilteredData(filter, page, pageSize, params).subscribe(() => {
-        expect(service['validateParams']).toHaveBeenCalledWith(params);
+      service.getFilteredItems({ filter, page, pageSize, filterParams }).subscribe(() => {
+        expect(service['validateParams']).toHaveBeenCalledWith(filterParams);
       });
 
       httpMock.expectOne(httpRequest => httpRequest.params.get('name') === 'test').flush({});

--- a/projects/ui/src/lib/components/po-field/po-lookup/services/po-lookup-filter.service.ts
+++ b/projects/ui/src/lib/components/po-field/po-lookup/services/po-lookup-filter.service.ts
@@ -6,6 +6,7 @@ import { Observable } from 'rxjs';
 import { isTypeof } from '../../../../utils/util';
 
 import { PoLookupFilter } from '../interfaces/po-lookup-filter.interface';
+import { PoLookupFilteredItemsParams } from '../interfaces/po-lookup-filtered-items-params.interface';
 
 /**
  * @docsPrivate
@@ -21,13 +22,14 @@ export class PoLookupFilterService implements PoLookupFilter {
 
   constructor(private httpClient: HttpClient) {}
 
-  getFilteredData(filter: any, page: number, pageSize?: number, filterParams?: any): Observable<any> {
+  getFilteredItems(filteredItemsParams: PoLookupFilteredItemsParams): Observable<any> {
+    const { filterParams, ...restFilteredItemsParams } = filteredItemsParams;
+
     const validatedFilterParams = this.validateParams(filterParams);
 
-    return this.httpClient.get(
-      this.url,
-      { params: { page: page.toString(), pageSize: pageSize.toString(), ...validatedFilterParams, filter } }
-    );
+    const params = { ...restFilteredItemsParams, ...validatedFilterParams };
+
+    return this.httpClient.get(this.url, { params });
   }
 
   getObjectByValue(value: string, filterParams?: any): Observable<any> {

--- a/projects/ui/src/lib/components/po-table/po-table-base.component.spec.ts
+++ b/projects/ui/src/lib/components/po-table/po-table-base.component.spec.ts
@@ -1,5 +1,3 @@
-import { Observable } from 'rxjs';
-
 import * as utilsFunctions from '../../utils/util';
 import { expectPropertiesValues, expectSettersMethod } from '../../util-test/util-expect.spec';
 import { PoDateService } from '../../services/po-date/po-date.service';
@@ -830,7 +828,7 @@ describe('PoTableBaseComponent:', () => {
     });
 
     it(`sortColumn: should emit sortBy twice toggling the object parameter value between
-    'ascending', 'descending' and not call 'sortArray'`, () => {
+    'ascending', 'descending'`, () => {
       const column = component.columns[1];
       component.sort = true;
       component.sortBy.observers = <any>[{ next: () => { }}];
@@ -840,11 +838,11 @@ describe('PoTableBaseComponent:', () => {
 
       component.sortColumn(column);
       expect(component.sortBy.emit).toHaveBeenCalledWith({column, type: 'ascending'});
-      expect(component.sortArray).not.toHaveBeenCalled();
+      expect(component.sortArray).toHaveBeenCalled();
 
       component.sortColumn(column);
       expect(component.sortBy.emit).toHaveBeenCalledWith({column, type: 'descending'});
-      expect(component.sortArray).not.toHaveBeenCalled();
+      expect(component.sortArray).toHaveBeenCalled();
     });
 
     it(`onShowMore: 'showMore' should emit an object parameter containing 'ascending' as value of property 'type'` , () => {
@@ -871,7 +869,6 @@ describe('PoTableBaseComponent:', () => {
 
     it(`onShowMore: 'showMore' should emit an object parameter containing 'undefined' if 'sortedColumn.property' is 'undefined'` , () => {
       component.sortedColumn.property = undefined;
-      spyOnProperty(component, <any>'isSortBy');
 
       spyOn(component.showMore, 'emit');
 
@@ -1008,18 +1005,6 @@ describe('PoTableBaseComponent:', () => {
 
       expectPropertiesValues(component, 'container', invalidValues, 'border');
       expect(component['showContainer']).toHaveBeenCalled();
-    });
-
-    it('isSortBy: should return `true` if `observers.length` is greater than 0.', () => {
-      component.sortBy.observers.length = 1;
-
-      expect(component['isSortBy']).toBe(true);
-    });
-
-    it('isSortBy: should return `false` if `observers.length` is 0.', () => {
-      component.sortBy.observers.length = 0;
-
-      expect(component['isSortBy']).toBe(false);
     });
 
     it('sortType: should return `ascending` if `sortedColumn.ascending` is `true`.', () => {

--- a/projects/ui/src/lib/components/po-table/po-table-base.component.ts
+++ b/projects/ui/src/lib/components/po-table/po-table-base.component.ts
@@ -402,7 +402,7 @@ export abstract class PoTableBaseComponent implements OnChanges {
   @Output('p-show-more') showMore?: EventEmitter<PoTableColumnSort> = new EventEmitter<PoTableColumnSort>();
 
   /**
-   * Ação executada ao ordenar colunas da tabela. Se houver ação definida, a ordenação padrão da tabela não será executada.
+   * Ação executada ao ordenar colunas da tabela.
    *
    * Recebe um objeto `{ column, type }` onde:
    *
@@ -418,10 +418,6 @@ export abstract class PoTableBaseComponent implements OnChanges {
 
   selectAll = false;
   sortedColumn = { property: <PoTableColumn>null, ascending: true };
-
-  private get isSortBy(): boolean {
-    return this.sortBy.observers.length > 0;
-  }
 
   private get sortType(): PoTableColumnSortType {
     return this.sortedColumn.ascending ? PoTableColumnSortType.Ascending : PoTableColumnSortType.Descending;
@@ -544,7 +540,8 @@ export abstract class PoTableBaseComponent implements OnChanges {
 
     this.sortedColumn.ascending = this.sortedColumn.property === column ? !this.sortedColumn.ascending : true;
 
-    this.isSortBy ? this.sortBy.emit({ column, type: this.sortType }) : this.sortArray(column, this.sortedColumn.ascending);
+    this.sortArray(column, this.sortedColumn.ascending);
+    this.sortBy.emit({ column, type: this.sortType});
 
     this.sortedColumn.property = column;
   }


### PR DESCRIPTION
**LOOKUP**

**DTHFUI-1742**
_____________________________________________________________________________

**PR Checklist**

- [x] Código
- [x] Testes unitários
- [x] Documentação
- [x] Samples

**Qual o comportamento atual?**
Atualmente não é repassado a coluna ordenada para o serviço.

**Qual o novo comportamento?**
Repassa a coluna ordenada como parametro no método getFilteredItems caso usar serviço ou inclui diretamente na URL.

Foi depreciado o método getFilteredData e criado o novo método getFilteredItems.

**Simulação**
- Utilizar Samples do Lookup do Portal
  - Clicar em alguma coluna para ordenar e realizar os filtros (busca/carregar mais resultados)
  - Verificar se a URL está sendo construída corretamente e se os parâmetros estão chegando corretamente no serviço customizado. 