### PR TITLE
fix(dynamic-form): name ignorado quando utilizado po-lookup

### DIFF
--- a/projects/ui/src/lib/components/po-dynamic/po-dynamic-form/po-dynamic-form-fields/po-dynamic-form-fields.component.html
+++ b/projects/ui/src/lib/components/po-dynamic/po-dynamic-form/po-dynamic-form-fields/po-dynamic-form-fields.component.html
@@ -104,7 +104,7 @@
     </po-combo>
 
     <po-lookup *ngIf="compareTo(field.control, 'lookup')"
-      name="field.property"
+      [name]="field.property"
       [(ngModel)]="value[field.property]"
       p-field-label="label"
       p-field-value="value"


### PR DESCRIPTION
Fixes DTHFUI-2091

**po-dynamic-form-fields**

**DTHFUI-2091**
_____________________________________________________________________________

**PR Checklist**

- [x] Código
- [ ] Testes unitários
- [ ] Documentação
- [ ] Samples

**Qual o comportamento atual?**
Retorna "field.property" quanto utilizado um componente lookup  

**Qual o novo comportamento?**
Retorna o valor informado na propriedade property do array de  campos do dynamic-form

**Simulação**
