### PR TITLE
feat(page-dynamic-table): inclui coluna de ordenação na requisição

### DIFF
--- a/projects/templates/src/lib/components/po-page-dynamic-table/po-page-dynamic-list-base.component.ts
+++ b/projects/templates/src/lib/components/po-page-dynamic-table/po-page-dynamic-list-base.component.ts
@@ -65,6 +65,15 @@ export class PoPageDynamicListBaseComponent {
    *
    * Endpoint usado pelo template para requisição dos recursos que serão exibidos.
    *
+   * Ao realizar requisições de busca, podem ser enviados os parâmetros (caso possuam valor): `page`, `pageSize`, `search` e `order`.
+   *
+   * Caso a coluna estiver ordenada descendentemente será enviada da seguinte forma: `-name`, se for ordenada
+   * ascendentemente será enviada apenas com o nome da coluna, por exemplo: `name`.
+   *
+   * Exemplo de uma requisição de busca:
+   *
+   * > `GET {end-point}/{resource}?page=1&pageSize=10&search=components&order=-name`
+   *
    * Caso a ação `remove` estiver configurada, será feito uma requisição de exclusão nesse mesmo endpoint passando os campos
    * setados como `key: true`.
    *

--- a/projects/templates/src/lib/components/po-page-dynamic-table/po-page-dynamic-table.component.html
+++ b/projects/templates/src/lib/components/po-page-dynamic-table/po-page-dynamic-table.component.html
@@ -14,7 +14,8 @@
     [p-columns]="columns"
     [p-items]="items"
     [p-show-more-disabled]="!hasNext"
-    (p-show-more)="showMore()">
+    (p-show-more)="showMore()"
+    (p-sort-by)="onSort($event)">
   </po-table>
 
 </po-page-dynamic-search>

--- a/projects/templates/src/lib/components/po-page-dynamic-table/po-page-dynamic-table.component.spec.ts
+++ b/projects/templates/src/lib/components/po-page-dynamic-table/po-page-dynamic-table.component.spec.ts
@@ -6,7 +6,7 @@ import { RouterTestingModule } from '@angular/router/testing';
 
 import { Observable } from 'rxjs';
 
-import { PoDialogModule, PoNotificationModule } from '@portinari/portinari-ui';
+import { PoDialogModule, PoNotificationModule, PoTableColumnSort, PoTableColumnSortType } from '@portinari/portinari-ui';
 
 import * as utilsFunctions from '../../utils/util';
 import { configureTestSuite, expectPropertiesValues } from '../../util-test/util-expect.spec';
@@ -571,6 +571,45 @@ describe('PoPageDynamicTableComponent:', () => {
       component['setTableActions'](actions);
 
       expect(component.tableActions).toEqual(tableActions);
+    });
+
+    it('getOrderParam: should return { order: `column.property` } of PoTableColumnSort object if sort type is Ascending', () => {
+      const sortedColumn: PoTableColumnSort = { column: { property: 'name' }, type: PoTableColumnSortType.Ascending };
+      const expectedValue = { order: 'name' };
+
+      const orderParam = component['getOrderParam'](sortedColumn);
+
+      expect(orderParam).toEqual(expectedValue);
+    });
+
+    it('getOrderParam: should return { order: `-column.property` } of PoTableColumnSort object if sort type is Descending', () => {
+      const sortedColumn: PoTableColumnSort = { column: { property: 'name' }, type: PoTableColumnSortType.Descending };
+      const expectedValue = { order: '-name' };
+
+      const orderParam = component['getOrderParam'](sortedColumn);
+
+      expect(orderParam).toEqual(expectedValue);
+    });
+
+    it('getOrderParam: should return {} if PoTableColumnSort.column is undefined', () => {
+      const expectedValue = {};
+
+      component['sortedColumn'] = undefined;
+
+      const orderParam = component['getOrderParam']();
+
+      expect(orderParam).toEqual(expectedValue);
+    });
+
+    it('onSort: should set sortedColumn property', () => {
+      const sortedColumn = { column: { property: 'name' }, type: PoTableColumnSortType.Ascending };
+      const expectedValue: PoTableColumnSort = { ...sortedColumn };
+
+      component['sortedColumn'] = undefined;
+
+      component.onSort(sortedColumn);
+
+      expect(component['sortedColumn']).toEqual(expectedValue);
     });
 
   });

--- a/projects/templates/src/lib/components/po-page-dynamic-table/samples/sample-po-page-dynamic-table-basic/sample-po-page-dynamic-table-basic.component.html
+++ b/projects/templates/src/lib/components/po-page-dynamic-table/samples/sample-po-page-dynamic-table-basic/sample-po-page-dynamic-table-basic.component.html
@@ -1,4 +1,4 @@
 <po-page-dynamic-table
   p-title="Po Page Dynamic Table"
-  p-service-api="https://thf.totvs.com.br/sample/api/po-metadata/v1/people">
+  p-service-api="https://thf.totvs.com.br/sample/api/thf-metadata/v1/people">
 </po-page-dynamic-table>

--- a/projects/templates/src/lib/components/po-page-dynamic-table/samples/sample-po-page-dynamic-table-users/sample-po-page-dynamic-table-users.component.ts
+++ b/projects/templates/src/lib/components/po-page-dynamic-table/samples/sample-po-page-dynamic-table-users/sample-po-page-dynamic-table-users.component.ts
@@ -9,7 +9,7 @@ import { PoPageDynamicTableActions } from '@portinari/portinari-templates';
 })
 export class SamplePoPageDynamicTableUsersComponent {
 
-  public readonly serviceApi = 'https://thf.totvs.com.br/sample/api/po-metadata/v1/people';
+  public readonly serviceApi = 'https://thf.totvs.com.br/sample/api/thf-metadata/v1/people';
 
   public readonly actions: PoPageDynamicTableActions = {
     detail: 'dynamic-detail/:id',


### PR DESCRIPTION
**PAGE DYNAMIC TABLE**

**DTHFUI-1743**
_____________________________________________________________________________

**PR Checklist**

- [x] Código
- [x] Testes unitários
- [x] Documentação
- [x] Samples

**Qual o comportamento atual?**
Não era possível saber qual coluna estava sendo ordenada ao realizar a requisição de paginação dos resultados.

**Qual o novo comportamento?**
Inclui coluna ordenação na requisição de paginação dos resultados.
Caso for decrescente será enviada: order=-name
Caso for ascendente será enviada: order=name


**Simulação**
Utilizar samples do componente, ordenar colunas e filtrar registros para avaliar a inclusão do queryParam "order";