### PR TITLE
fix(page-login): corrige literais customizadas ao trocar de idioma

### DIFF
--- a/projects/templates/src/lib/components/po-page-login/interfaces/po-page-login-literals.interface.ts
+++ b/projects/templates/src/lib/components/po-page-login/interfaces/po-page-login-literals.interface.ts
@@ -7,14 +7,29 @@
  */
 export interface PoPageLoginLiterals {
 
+  /** Texto que informa a quantidade de tentativas restantes no popover de aviso de bloqueio. */
+  attempts?: string;
+
+  /** Texto exibido no popover de aviso de bloqueio, que orienta o usuário, caso ele tenha esquecido a senha, a criar uma nova senha. */
+  createANewPasswordNow?: string;
+
   /** Mensagem de erro apresentada quando o campo customizado está inválido */
   customFieldErrorPattern?: string;
 
   /** Placeholder para o campo customizado. */
   customFieldPlaceholder?: string;
 
+  /** Texto que questiona o esquecimento da senha no popover de aviso de bloqueio. */
+  forgotYourPassword?: string;
+
   /** Título exibido no topo da página. */
   title?: string;
+
+  /** Texto do link de 'esqueci minha senha' exibido no popover de aviso de bloqueio. */
+  iForgotMyPassword?: string;
+
+  /** Texto de aviso de tentativas exibido no popover de aviso de bloqueio. */
+  ifYouTryHarder?: string;
 
   /** Mensagem de erro apresentada quando o campo de login está inválido. */
   loginErrorPattern?: string;
@@ -57,5 +72,11 @@ export interface PoPageLoginLiterals {
 
   /** Texto exibido no link de novo cadastro. */
   registerUrl?: string;
+
+  /** Título do popover para aviso de bloqueio. */
+  titlePopover?: string;
+
+  /** Texto que informa ao usuário que o mesmo será bloqueado e por quanto tempo no popover de aviso de bloqueio. */
+  yourUserWillBeBlocked?: string;
 
 }

--- a/projects/templates/src/lib/components/po-page-login/po-page-login-popover/po-page-login-popover.component.html
+++ b/projects/templates/src/lib/components/po-page-login/po-page-login-popover/po-page-login-popover.component.html
@@ -11,7 +11,7 @@
       <p class="po-font-text">
         {{ literals?.ifYouTryHarder }}
         <span class="po-font-text-bold po-page-login-popover-attempts">
-          {{ literals?.attempts | poI18n:literalParams }}
+          {{ literals?.attempts | poI18n:remainingAttempts }}
         </span>{{ literals?.yourUserWillBeBlocked }}
       </p>
       <br>

--- a/projects/templates/src/lib/components/po-page-login/po-page-login-popover/po-page-login-popover.component.spec.ts
+++ b/projects/templates/src/lib/components/po-page-login/po-page-login-popover/po-page-login-popover.component.spec.ts
@@ -60,41 +60,9 @@ describe('ThPageLoginPopoverComponent: ', () => {
       expect(component.recovery).toBe(url);
       expect(component.recoveryType).toBe(undefined);
     });
-
-    it('p-selected-language: should call `getLiterals` with valid `value`', () => {
-      spyOn(component, <any>'getLiterals');
-      component.selectedLanguage = 'es';
-
-      expect(component['getLiterals']).toHaveBeenCalledWith(component.selectedLanguage);
-    });
-
-    it('p-remaining-attempts: should call `getLiterals` with valid `value`', () => {
-      spyOn(component, <any>'getLiterals');
-      component.selectedLanguage = 'es';
-
-      expect(component['getLiterals']).toHaveBeenCalledWith(component.selectedLanguage);
-    });
   });
 
   describe('Methods: ', () => {
-
-    it('ngOnInit: should call `getLiterals`', () => {
-      spyOn(component, <any>'getLiterals');
-      component.ngOnInit();
-      expect(component['getLiterals']).toHaveBeenCalled();
-    });
-
-    it('getLiterals: should call `changeDetector.detectChanges`', () => {
-      spyOn(UtilFunctions, <any>'browserLanguage').and.returnValue('en');
-      spyOn(component['changeDetector'], 'detectChanges');
-      component.remainingAttempts = 3;
-      const expectedValue = 3;
-
-      component['getLiterals']();
-
-      expect(component.literalParams).toBe(expectedValue);
-      expect(component['changeDetector'].detectChanges).toHaveBeenCalled();
-    });
 
     it('onForgotPasswordClick: should emit forgotPassword with recovery as param', () => {
       component.recovery = { url: 'url'};

--- a/projects/templates/src/lib/components/po-page-login/po-page-login-popover/po-page-login-popover.component.ts
+++ b/projects/templates/src/lib/components/po-page-login/po-page-login-popover/po-page-login-popover.component.ts
@@ -1,8 +1,8 @@
-import { ChangeDetectorRef, Component, EventEmitter, Input, OnInit, Output } from '@angular/core';
+import { Component, EventEmitter, Input, Output } from '@angular/core';
 
-import { browserLanguage, isExternalLink, isTypeof, poLocaleDefault } from '../../../utils/util';
+import { isExternalLink, isTypeof } from '../../../utils/util';
 
-import { poPageLoginLiteralsDefault } from './../po-page-login-base.component';
+import { PoPageLoginLiterals } from '../interfaces/po-page-login-literals.interface';
 import { PoPageLoginRecovery } from '../interfaces/po-page-login-recovery.interface';
 
 @Component({
@@ -17,15 +17,13 @@ import { PoPageLoginRecovery } from '../interfaces/po-page-login-recovery.interf
  *
  * Componente para definição da mensagem de aviso de bloqueio do `po-page-login`.
  */
-export class PoPageLoginPopoverComponent implements OnInit {
+export class PoPageLoginPopoverComponent {
 
-  literals;
-  literalParams;
   recoveryType: string;
 
   private _recovery: string | Function | PoPageLoginRecovery;
-  private _remainingAttempts: number;
-  private _selectedLanguage: string;
+
+  @Input('p-literals') literals: PoPageLoginLiterals;
 
   /** exibe o link de 'esqueci minha senha' e verifica se o valor é um link interno ou externo */
   @Input('p-recovery') set recovery(value: string | Function | PoPageLoginRecovery) {
@@ -41,49 +39,13 @@ export class PoPageLoginPopoverComponent implements OnInit {
   }
 
   /** define se a mensagem deverá ser exibida caso seja maior que 0(zero) */
-  @Input('p-remaining-attempts') set remainingAttempts(value: number) {
-    this._remainingAttempts = value;
-    this.getLiterals(this.selectedLanguage);
-  }
-
-  get remainingAttempts() {
-    return this._remainingAttempts;
-  }
-
-  /** define o idioma da mensagem conforme selecionado no 'po-page-login' */
-  @Input('p-selected-language') set selectedLanguage(value: string) {
-    this._selectedLanguage = value;
-    this.getLiterals(value);
-  }
-
-  get selectedLanguage() {
-    return this._selectedLanguage;
-  }
+  @Input('p-remaining-attempts') remainingAttempts: number;
 
   /** se 'p-recovery' for do tipo Function ou PoPageLoginRecovery, emite para o método 'openUrl' do componente 'po-page-login' */
   @Output('p-forgot-password') forgotPassword = new EventEmitter<any>();
 
-  constructor(private changeDetector: ChangeDetectorRef) {}
-
-  ngOnInit() {
-    this.getLiterals(this.selectedLanguage);
-  }
-
   onForgotPasswordClick(recovery) {
     this.forgotPassword.emit(recovery);
-  }
-
-  private getLiterals(language?: string) {
-    language = language || browserLanguage();
-
-    this.literalParams = this.remainingAttempts;
-
-    this.literals = {
-      ...poPageLoginLiteralsDefault[poLocaleDefault],
-      ...poPageLoginLiteralsDefault[language],
-    };
-
-    this.changeDetector.detectChanges();
   }
 
 }

--- a/projects/templates/src/lib/components/po-page-login/po-page-login.component.html
+++ b/projects/templates/src/lib/components/po-page-login/po-page-login.component.html
@@ -1,13 +1,13 @@
 <po-page-background #pageLogin
   p-show-select-language
   [p-background]="background"
-  [p-highlight-info]="literals.highlightInfo"
+  [p-highlight-info]="pageLoginLiterals.highlightInfo"
   [p-logo]="logo"
   [p-secondary-logo]="secondaryLogo"
   (p-selected-language)="onSelectedLanguage($event)">
 
   <div class="po-page-login-header po-mb-2 po-mb-sm-1 po-pt-sm-1">
-    <div class="po-page-login-header-title po-mb-sm-1">{{ literals.title }}</div>
+    <div class="po-page-login-header-title po-mb-sm-1">{{ pageLoginLiterals.title }}</div>
     <po-tag
       *ngIf="environment"
       p-type="warning"
@@ -25,9 +25,9 @@
             [(ngModel)]="login"
             p-focus
             p-required
-            [p-label]="literals.loginLabel"
+            [p-label]="pageLoginLiterals.loginLabel"
             [p-pattern]="loginPattern"
-            [p-placeholder]="literals.loginPlaceholder"
+            [p-placeholder]="pageLoginLiterals.loginPlaceholder"
             (click)="closePopover()"
             (keyup.enter)="loginForm.valid && onLoginSubmit()"
             (p-change-model)="changeLoginModel()">
@@ -37,7 +37,7 @@
             <span
               class="po-icon po-field-icon po-icon-info"
               p-tooltip-position="right"
-              [p-tooltip]="literals.loginHint">
+              [p-tooltip]="pageLoginLiterals.loginHint">
             </span>
           </div>
         </div>
@@ -57,18 +57,18 @@
             name="password"
             [(ngModel)]="password"
             p-required
-            [p-label]="literals.passwordLabel"
+            [p-label]="pageLoginLiterals.passwordLabel"
             [p-pattern]="passwordPattern"
-            [p-placeholder]="literals.passwordPlaceholder"
+            [p-placeholder]="pageLoginLiterals.passwordPlaceholder"
             (click)="closePopover()"
             (keyup.enter)="loginForm.valid && onLoginSubmit()"
             (p-change-model)="changePasswordModel()">
           </po-password>
           <div class="po-page-login-password-item po-page-login-password-popover-container">
             <po-page-login-popover *ngIf="showExceededAttemptsWarning && exceededAttemptsWarning"
+              [p-literals]="pageLoginLiterals"
               [p-recovery]="recovery"
               [p-remaining-attempts]="exceededAttemptsWarning"
-              [p-selected-language]="selectedLanguage"
               (p-forgot-password) = "openUrl($event)">
             </po-page-login-popover>
           </div>
@@ -86,9 +86,9 @@
         name="customFieldInput"
         [(ngModel)]="customFieldObject.value"
         p-required
-        [p-error-pattern]="customFieldObject.errorPattern || literals.customFieldErrorPattern"
+        [p-error-pattern]="customFieldObject.errorPattern || pageLoginLiterals.customFieldErrorPattern"
         [p-pattern]="customFieldObject.pattern"
-        [p-placeholder]="customFieldObject.placeholder || literals.customFieldPlaceholder"
+        [p-placeholder]="customFieldObject.placeholder || pageLoginLiterals.customFieldPlaceholder"
         (keyup.enter)="loginForm.valid && onLoginSubmit()">
       </po-input>
 
@@ -99,7 +99,7 @@
         p-required
         [p-field-value]="customFieldObject.fieldValue"
         [p-filter-service]="customFieldObject.url"
-        [p-placeholder]="customFieldObject.placeholder || literals.customFieldPlaceholder">
+        [p-placeholder]="customFieldObject.placeholder || pageLoginLiterals.customFieldPlaceholder">
       </po-combo>
 
       <po-select *ngIf="customField && customFieldType === 'select'"
@@ -107,7 +107,7 @@
         name="customFieldSelect"
         [(ngModel)]="customFieldObject.value"
         p-required
-        [p-placeholder]="customFieldObject.placeholder || literals.customFieldPlaceholder"
+        [p-placeholder]="customFieldObject.placeholder || pageLoginLiterals.customFieldPlaceholder"
         [p-options]="customFieldObject.options">
       </po-select>
 
@@ -118,8 +118,8 @@
             name="rememberUser"
             [(ngModel)]="rememberUser"
             p-label-position="1"
-            [p-label-off]="literals.rememberUser"
-            [p-label-on]="literals.rememberUser"
+            [p-label-off]="pageLoginLiterals.rememberUser"
+            [p-label-on]="pageLoginLiterals.rememberUser"
             (keyup.enter)="loginForm.valid && onLoginSubmit()">
           </po-switch>
 
@@ -127,7 +127,7 @@
             <span
               class="po-icon po-field-icon po-icon-info"
               p-tooltip-position="right"
-              [p-tooltip]="literals.rememberUserHint">
+              [p-tooltip]="pageLoginLiterals.rememberUserHint">
             </span>
           </div>
         </div>
@@ -138,19 +138,19 @@
         class="po-lg-12 po-page-login-button po-page-login-field-size"
         p-type="primary"
         [p-disabled]="loginForm.invalid"
-        [p-label]="loading ? literals.submittedLabel : literals.submitLabel"
+        [p-label]="loading ? pageLoginLiterals.submittedLabel : pageLoginLiterals.submitLabel"
         [p-loading]="loading"
         (p-click)="onLoginSubmit()">
       </po-button>
 
       <div *ngIf="recovery"
         class="po-page-login-recovery-link">
-        <a class="po-font-text-large-bold" (click)="openUrl(recovery)">{{ literals.forgotPassword }}</a>
+        <a class="po-font-text-large-bold" (click)="openUrl(recovery)">{{ pageLoginLiterals.forgotPassword }}</a>
       </div>
 
       <div *ngIf="registerUrl"
         class="po-page-login-register-link">
-        <a class="po-font-text-large-bold" (click)="openUrl(registerUrl)">{{ literals.registerUrl }}</a>
+        <a class="po-font-text-large-bold" (click)="openUrl(registerUrl)">{{ pageLoginLiterals.registerUrl }}</a>
       </div>
     </div>
   </form>

--- a/projects/templates/src/lib/components/po-page-login/po-page-login.component.spec.ts
+++ b/projects/templates/src/lib/components/po-page-login/po-page-login.component.spec.ts
@@ -20,7 +20,8 @@ import { poLocaleDefault } from './../../utils/util';
 import { PoModalPasswordRecoveryComponent } from '../po-modal-password-recovery/po-modal-password-recovery.component';
 import { PoModalPasswordRecoveryType } from '../po-modal-password-recovery/enums/po-modal-password-recovery-type.enum';
 import { PoPageLoginAuthenticationType } from './enums/po-page-login-authentication-type.enum';
-import { PoPageLoginBaseComponent, poPageLoginLiteralsDefault } from './po-page-login-base.component';
+import { PoPageLoginBaseComponent, poPageLoginLiteralIn, poPageLoginLiteralTo, poPageLoginLiteralsDefault
+} from './po-page-login-base.component';
 import { PoPageLoginComponent } from './po-page-login.component';
 import { PoPageLoginCustomField } from './interfaces/po-page-login-custom-field.interface';
 import { PoPageLoginLiterals } from './interfaces/po-page-login-literals.interface';
@@ -144,7 +145,7 @@ describe('PoPageLoginComponent: ', () => {
     const divRecovery = nativeElement.querySelector('div.po-page-login-recovery-link');
 
     expect(divRecovery).toBeTruthy();
-    expect(divRecovery.innerHTML).toContain(component.literals.forgotPassword);
+    expect(divRecovery.innerHTML).toContain(component.pageLoginLiterals.forgotPassword);
   });
 
   it('should show a new user when `p-register` set a value', () => {
@@ -155,7 +156,7 @@ describe('PoPageLoginComponent: ', () => {
     const divRegisterUrl = nativeElement.querySelector('div.po-page-login-register-link');
 
     expect(divRegisterUrl).toBeTruthy();
-    expect(divRegisterUrl.innerHTML).toContain(component.literals.registerUrl);
+    expect(divRegisterUrl.innerHTML).toContain(component.pageLoginLiterals.registerUrl);
   });
 
   describe('Methods:', () => {
@@ -534,39 +535,11 @@ describe('PoPageLoginComponent: ', () => {
       expect(component['setControlErrors']).toHaveBeenCalled();
     });
 
-    it('onSelectedLanguage: should set `selectedLanguage` and call `setLoginHintLiteral` and `setTitleLiteral`', () => {
-      component.contactEmail = 'email';
-      component.productName = 'product';
-
-      spyOn(component, <any>'setLoginHintLiteral');
-      spyOn(component, <any>'setTitleLiteral');
+    it('onSelectedLanguage: should set `selectedLanguage` with `en`', () => {
 
       component.onSelectedLanguage('en');
 
       expect(component.selectedLanguage).toBe('en');
-      expect(component.setLoginHintLiteral).toHaveBeenCalledWith('en', component.contactEmail );
-      expect(component.setTitleLiteral).toHaveBeenCalledWith('en', component.productName );
-    });
-
-    it('onSelectedLanguage: should call `getLiterals` passing the language and `customizedDefaultLiterals` as parameters', () => {
-      component.containsCustomLiterals = true;
-      component.customizedDefaultLiterals = {};
-
-      spyOn(component, <any>'getLiterals');
-
-      component.onSelectedLanguage('en');
-
-      expect(component.getLiterals).toHaveBeenCalledWith('en', component.customizedDefaultLiterals);
-    });
-
-    it('onSelectedLanguage: should call `getLiterals` passing the language and `undefined` as parameters', () => {
-      component.containsCustomLiterals = false;
-
-      spyOn(component, <any>'getLiterals');
-
-      component.onSelectedLanguage('en');
-
-      expect(component.getLiterals).toHaveBeenCalledWith('en', undefined);
     });
 
     it('setUrlRedirect: should call `window.open` with external url', () => {
@@ -770,6 +743,52 @@ describe('PoPageLoginComponent: ', () => {
       expect(component.authenticationType).toEqual(PoPageLoginAuthenticationType.Bearer);
     });
 
+    it(`concatenateLoginHintWithContactEmail: should call 'concatenateLiteral'`, () => {
+      const email = 'email@mail.com';
+      const defaultLoginHintLiteral = poPageLoginLiteralsDefault[poLocaleDefault].loginHint;
+      const prepositionLiteral = poPageLoginLiteralIn[poLocaleDefault];
+
+      spyOn(component, <any>'concatenateLiteral');
+      spyOnProperty(component, 'language').and.returnValue(poLocaleDefault);
+
+      component['concatenateLoginHintWithContactEmail'](email);
+
+      expect(component['concatenateLiteral']).toHaveBeenCalledWith(email, 'loginHint', defaultLoginHintLiteral, prepositionLiteral);
+    });
+
+    it(`concatenateTitleWithProductName: should call 'concatenateLiteral'`, () => {
+      const title = 'email@mail.com';
+      const defaultTitleLiteral = poPageLoginLiteralsDefault[poLocaleDefault].title;
+      const prepositionLiteral = poPageLoginLiteralTo[poLocaleDefault];
+
+      spyOn(component, <any>'concatenateLiteral');
+      spyOnProperty(component, 'language').and.returnValue(poLocaleDefault);
+
+      component['concatenateTitleWithProductName'](title);
+
+      expect(component['concatenateLiteral']).toHaveBeenCalledWith(title, 'title', defaultTitleLiteral, prepositionLiteral);
+    });
+
+    it(`concatenateLiteral: should call 'concatenate' and return expected value`, () => {
+      const value = 'Portal RH';
+      const currentLiteral = 'title';
+      const defaultLiteral = 'Welcome';
+      const prepositionLiteral = 'to';
+      const result = { title: 'Welcome to Portal RH' };
+
+      spyOn(component, <any>'concatenate').and.callThrough();
+
+      const expectedResult = component['concatenateLiteral'](value, currentLiteral, defaultLiteral, prepositionLiteral);
+
+      expect(component['concatenate']).toHaveBeenCalledWith(defaultLiteral, prepositionLiteral, value);
+      expect(expectedResult).toEqual(result);
+    });
+
+    it('concatenate: should concatenate the received parameters', () => {
+      const expectedResult = component['concatenate']('Welcome', 'to', 'Company');
+
+      expect(expectedResult).toBe('Welcome to Company');
+    });
   });
 
   describe('Templates: ', () => {

--- a/projects/templates/src/lib/components/po-page-login/po-page-login.component.ts
+++ b/projects/templates/src/lib/components/po-page-login/po-page-login.component.ts
@@ -8,7 +8,8 @@ import { PoComponentInjectorService } from '@portinari/portinari-ui';
 
 import { PoModalPasswordRecoveryComponent } from '../po-modal-password-recovery/po-modal-password-recovery.component';
 import { PoModalPasswordRecoveryType } from '../po-modal-password-recovery/enums/po-modal-password-recovery-type.enum';
-import { PoPageLoginBaseComponent } from './po-page-login-base.component';
+import { PoPageLoginBaseComponent, poPageLoginLiteralIn, poPageLoginLiteralTo, poPageLoginLiteralsDefault
+} from './po-page-login-base.component';
 import { PoPageLoginRecovery } from './interfaces/po-page-login-recovery.interface';
 import { PoPageLoginService } from './po-page-login.service';
 
@@ -96,6 +97,10 @@ export class PoPageLoginComponent extends PoPageLoginBaseComponent implements Af
     }
   }
 
+  onSelectedLanguage(language: string) {
+    this.selectedLanguage = language;
+  }
+
   openUrl(recovery: any): void {
     switch (typeof recovery) {
       case 'string': {
@@ -127,6 +132,14 @@ export class PoPageLoginComponent extends PoPageLoginBaseComponent implements Af
       this.recovery = this.checkingForMetadataProperty(data, 'recovery') || this.recovery;
       this.registerUrl = this.checkingForMetadataProperty(data, 'registerUrl') || this.registerUrl;
     }
+  }
+
+  private concatenate(defaultLiteral: string, prefixLiteral: string, value: string) {
+    return `${defaultLiteral} ${prefixLiteral} ${value}`;
+  }
+
+  private concatenateLiteral(value: string, literal: string, defaultLiteral: string, prepositionLiteral: string) {
+    return { [literal]: this.concatenate(defaultLiteral, prepositionLiteral, value) };
   }
 
   private createModalPasswordRecoveryComponent(poPageLoginRecovery: PoPageLoginRecovery) {
@@ -186,7 +199,6 @@ export class PoPageLoginComponent extends PoPageLoginBaseComponent implements Af
         control.setErrors(this.customPasswordError);
       }
     }
-
   }
 
   private setUrlRedirect(url) {
@@ -204,21 +216,28 @@ export class PoPageLoginComponent extends PoPageLoginBaseComponent implements Af
     });
   }
 
+  protected concatenateLoginHintWithContactEmail(contactEmail: string) {
+    const defaultLoginHintLiteral = poPageLoginLiteralsDefault[this.language].loginHint;
+    const prepositionLiteral = poPageLoginLiteralIn[this.language];
+
+    return this.concatenateLiteral(contactEmail, 'loginHint', defaultLoginHintLiteral, prepositionLiteral);
+  }
+
+  protected concatenateTitleWithProductName(productName: string) {
+    const defaultTitleLiteral = poPageLoginLiteralsDefault[this.language].title;
+    const prepositionLiteral = poPageLoginLiteralTo[this.language];
+
+    return this.concatenateLiteral(productName, 'title', defaultTitleLiteral, prepositionLiteral);
+  }
+
   protected setLoginErrors(errors: Array<string>) {
     const control = this.loginForm.form.controls['login'];
-    this.setControlErrors('allLoginErrors', control, errors, this.literals.loginErrorPattern);
+    this.setControlErrors('allLoginErrors', control, errors, this.pageLoginLiterals.loginErrorPattern);
   }
 
   protected setPasswordErrors(errors: Array<string>) {
     const control = this.loginForm.form.controls['password'];
-    this.setControlErrors('allPasswordErrors', control, errors, this.literals.passwordErrorPattern);
-  }
-
-  onSelectedLanguage(language: string) {
-    this.selectedLanguage = language;
-    this.getLiterals(language, this.containsCustomLiterals ? this.customizedDefaultLiterals : undefined);
-    this.setTitleLiteral(language, this.productName);
-    this.setLoginHintLiteral(language, this.contactEmail);
+    this.setControlErrors('allPasswordErrors', control, errors, this.pageLoginLiterals.passwordErrorPattern);
   }
 
 }


### PR DESCRIPTION
**PO-PAGE-LOGIN**

**DTHFUI-2053**
_____________________________________________________________________________

**PR Checklist**

- [x] Código
- [x] Testes unitários
- [x] Documentação
- [ ] Samples

**Qual o comportamento atual?**
- Ao modificar o idioma no seletor do template, as literais title e loginHint não respeitam a customização.
- As literais do popover relacionado ao excesso de tentativas não eram definidas na interface poPageLogin.

**Qual o novo comportamento?**
- Reestruturação do método getLiterals para que faça atruição correta dos objetos. Método renomeado para **assignLiterals** para uma melhor compreensão;
- Nova propriedade **pageLoginLiterals** para que a propriedade **p-literals** seja preservada;
- Repassados métodos relacionados com a concatenação das propriedades **title** e **loginHint** para fora do base;
- Refatoração do componente **pageLoginPopover** para remoção de elementos desnecessários;
- Novas propriedades na interface **PageLoginLiterals** para contemplar as literais do pageLoginPopover.
- Refatoração dos testes unitários;
- Adicionada na **documentação de p-literals** as literais relativas ao popover

**Simulação**
O sample Labs é o melhor lugar para testar todas as situações, sobretudo:
- Concatenação de title com productName;
- Concatenação de loginHint com contactEmail;
- Popover;
- Sobrescrição das literais customizadas.