### PR TITLE
feat(rich-text): permite que o usuário edite um link adicionado

### DIFF
--- a/projects/ui/src/lib/components/po-field/po-rich-text/po-rich-text-body/po-rich-text-body.component.html
+++ b/projects/ui/src/lib/components/po-field/po-rich-text/po-rich-text-body/po-rich-text-body.component.html
@@ -9,6 +9,6 @@
   (cut)="update()"
   (focus)="onFocus()"
   (keydown)="onKeyDown($event)"
-  (keyup)="onKeyUp()"
-  (paste)="update()">
+  (keyup)="onKeyUp($event)"
+  (paste)="onPaste()">
 </div>

--- a/projects/ui/src/lib/components/po-field/po-rich-text/po-rich-text-body/po-rich-text-body.component.spec.ts
+++ b/projects/ui/src/lib/components/po-field/po-rich-text/po-rich-text-body/po-rich-text-body.component.spec.ts
@@ -116,288 +116,12 @@ describe('PoRichTextBodyComponent:', () => {
 
     });
 
-    it('focus: should call `focus` of rich-text', () => {
+    it('linkEditing: should set value to `isLinkEditing`', () => {
+      const fakeEvent = true;
 
-      spyOn(component.bodyElement.nativeElement, 'focus');
+      component.linkEditing(fakeEvent);
 
-      component.focus();
-
-      expect(component.bodyElement.nativeElement.focus).toHaveBeenCalled();
-    });
-
-    it('onClick: should call `emitSelectionCommands`', () => {
-      spyOn(component, <any>'emitSelectionCommands');
-      component.onClick();
-
-      expect(component['emitSelectionCommands']).toHaveBeenCalled();
-    });
-
-    it('onKeyUp: should remove tag `br`', () => {
-      const element = document.createElement('br');
-      element.classList.add('teste');
-      component.bodyElement.nativeElement.appendChild(element);
-      component.onKeyUp();
-      expect(nativeElement.querySelector('.teste')).toBeFalsy();
-    });
-
-    it('onKeyUp: should`t remove tag `br`', () => {
-      const div = document.createElement('div');
-      const br = document.createElement('br');
-
-      br.classList.add('teste-br');
-      div.classList.add('teste-div');
-
-      component.bodyElement.nativeElement.appendChild(div);
-      component.bodyElement.nativeElement.appendChild(br);
-
-      component.onKeyUp();
-
-      expect(nativeElement.querySelector('.teste-br')).toBeTruthy();
-      expect(nativeElement.querySelector('.teste-div')).toBeTruthy();
-    });
-
-    it('onKeyUp: should call `updateModel`', () => {
-      spyOn(component, <any>'updateModel');
-      component.onKeyUp();
-
-      expect(component['updateModel']).toHaveBeenCalled();
-    });
-
-    it('onKeyUp: should call `emitSelectionCommands`', () => {
-      spyOn(component, <any>'emitSelectionCommands');
-      component.onKeyUp();
-
-      expect(component['emitSelectionCommands']).toHaveBeenCalled();
-    });
-
-    it('onKeyDown: should call `event.preventDefault` and `shortcutCommand.emit` if keyCode is `76` and ctrlKey is `true`', () => {
-      const fakeEvent = {
-        keyCode: 76,
-        ctrlKey: true,
-        preventDefault: () => {},
-      };
-
-      spyOn(component.shortcutCommand, 'emit');
-      spyOn(fakeEvent, 'preventDefault');
-
-      component.onKeyDown(fakeEvent);
-
-      expect(fakeEvent.preventDefault).toHaveBeenCalled();
-      expect(component.shortcutCommand.emit).toHaveBeenCalled();
-    });
-
-    it('onKeyDown: should call `event.preventDefault` and `shortcutCommand.emit` if keyCode is `76` and metaKey is `true`', () => {
-      const fakeEvent = {
-        keyCode: 76,
-        metaKey: true,
-        preventDefault: () => {},
-      };
-
-      spyOn(component.shortcutCommand, 'emit');
-      spyOn(fakeEvent, 'preventDefault');
-
-      component.onKeyDown(fakeEvent);
-
-      expect(fakeEvent.preventDefault).toHaveBeenCalled();
-      expect(component.shortcutCommand.emit).toHaveBeenCalled();
-    });
-
-    it('onKeyDown: shouldn`t call `event.preventDefault` and `shortcutCommand.emit` if keyCode isn`t `76`', () => {
-      const fakeEvent = {
-        keyCode: 18,
-        cmdKey: true,
-        preventDefault: () => {},
-      };
-
-      spyOn(component.shortcutCommand, 'emit');
-      spyOn(fakeEvent, 'preventDefault');
-
-      component.onKeyDown(fakeEvent);
-
-      expect(fakeEvent.preventDefault).not.toHaveBeenCalled();
-      expect(component.shortcutCommand.emit).not.toHaveBeenCalled();
-    });
-
-    it('onKeyDown: shouldn`t call `event.preventDefault` and `shortcutCommand.emit` if ctrlKey isn`t true', () => {
-      const fakeEvent = {
-        keyCode: 76,
-        ctrlKey: false,
-        preventDefault: () => {},
-      };
-
-      spyOn(component.shortcutCommand, 'emit');
-      spyOn(fakeEvent, 'preventDefault');
-
-      component.onKeyDown(fakeEvent);
-
-      expect(fakeEvent.preventDefault).not.toHaveBeenCalled();
-      expect(component.shortcutCommand.emit).not.toHaveBeenCalled();
-    });
-
-    it('cursorPositionedInALink: should return true if tag element is a link', () => {
-      const fakeSelection = { focusNode: { parentElement: { tagName: 'A' } } };
-
-      spyOn(document, 'getSelection').and.returnValue(<any>fakeSelection);
-
-      const expectedValue = component['cursorPositionedInALink']();
-
-      expect(expectedValue).toBe(true);
-    });
-
-    it('cursorPositionedInALink: should return false if tag element isn`t a link', () => {
-      const fakeSelection = { focusNode: { parentElement: { tagName: 'B' } } };
-
-      spyOn(document, 'getSelection').and.returnValue(<any>fakeSelection);
-
-      const expectedValue = component['cursorPositionedInALink']();
-
-      expect(expectedValue).toBe(false);
-    });
-
-    it('update: should call `updateModel`', fakeAsync(() => {
-      spyOn(component, <any>'updateModel');
-
-      component.update();
-      tick(50);
-
-      expect(component['updateModel']).toHaveBeenCalled();
-    }));
-
-    it('update: should call `onKeyUp`', fakeAsync(() => {
-      spyOn(component, <any>'onKeyUp');
-
-      component.update();
-      tick(50);
-
-      expect(component['onKeyUp']).toHaveBeenCalled();
-    }));
-
-    it('emitSelectionCommands: should call `commands.emit`', () => {
-      spyOn(component.commands, 'emit');
-      component['emitSelectionCommands']();
-
-      expect(component.commands.emit).toHaveBeenCalled();
-    });
-
-    it(`emitSelectionCommands: the object property 'commands'
-    should contain 'Createlink' if 'cursorPositionedInALink' returns 'true'`, () => {
-
-      spyOn(component, <any>'cursorPositionedInALink').and.returnValue(true);
-      spyOn(document, 'queryCommandState').and.returnValue(false);
-      spyOn(document, 'queryCommandValue').and.returnValue('rgb');
-      spyOn(component, <any>'rgbToHex').and.returnValue('hex');
-      spyOn(component.commands, 'emit');
-
-      component['emitSelectionCommands']();
-
-      expect(component.commands.emit).toHaveBeenCalledWith({commands: ['Createlink'], hexColor: 'hex'});
-    });
-
-    it(`emitSelectionCommands: the object property 'commands'
-    shouldn't contain 'Createlink' if 'cursorPositionedInALink' returns 'false'`, () => {
-
-      spyOn(component, <any>'cursorPositionedInALink').and.returnValue(false);
-      spyOn(document, 'queryCommandState').and.returnValue(false);
-      spyOn(document, 'queryCommandValue').and.returnValue('rgb');
-      spyOn(component, <any>'rgbToHex').and.returnValue('hex');
-      spyOn(component.commands, 'emit');
-
-      component['emitSelectionCommands']();
-
-      expect(component.commands.emit).toHaveBeenCalledWith({commands: [], hexColor: 'hex'});
-    });
-
-    it('handleCommandLink: should call `insertHtmlLinkElement` if isIE returns `true`', () => {
-      const fakeValue = {
-        command: 'InsertHTML',
-        urlLink: 'urlLink',
-        urlLinkText: 'url link text'
-      };
-
-      spyOn(UtilsFunction, 'isIE').and.returnValue(true);
-      spyOn(component, <any>'insertHtmlLinkElement');
-      spyOn(document, <any>'execCommand');
-
-      component['handleCommandLink'](fakeValue.command, fakeValue.urlLink, fakeValue.urlLinkText);
-
-      expect(document.execCommand).not.toHaveBeenCalled();
-      expect(UtilsFunction.isIE).toHaveBeenCalled();
-      expect(component['insertHtmlLinkElement']).toHaveBeenCalledWith(fakeValue.urlLink, fakeValue.urlLinkText);
-    });
-
-    it('handleCommandLink: should call `document.execCommand` with `command`, `false` and linkValue as params if isIE is `false`', () => {
-      const linkValue = `<a class="po-rich-text-link" href="urlLink" target="_blank">url link text</a>`;
-      const fakeValue = {
-        command: 'InsertHTML',
-        urlLink: 'urlLink',
-        urlLinkText: 'url link text'
-      };
-
-      spyOn(UtilsFunction, 'isIE').and.returnValue(false);
-      spyOn(component, <any>'insertHtmlLinkElement');
-      spyOn(document, <any>'execCommand');
-
-      component['handleCommandLink'](fakeValue.command, fakeValue.urlLink, fakeValue.urlLinkText);
-
-      expect(document.execCommand).toHaveBeenCalledWith(fakeValue.command, false, linkValue);
-      expect(component['insertHtmlLinkElement']).not.toHaveBeenCalled();
-    });
-
-    it(`handleCommandLink: the parameter 'linkvalue' should be concatenated with 'urlLink' if 'urlLinkText' is undefined`, () => {
-      const linkValue = `<a class="po-rich-text-link" href="urlLink" target="_blank">urlLink</a>`;
-      const fakeValue = {
-        command: 'InsertHTML',
-        urlLink: 'urlLink',
-        urlLinkText: undefined
-      };
-
-      spyOn(UtilsFunction, 'isIE').and.returnValue(false);
-      spyOn(document, <any>'execCommand');
-
-      component['handleCommandLink'](fakeValue.command, fakeValue.urlLink, fakeValue.urlLinkText);
-
-      expect(document.execCommand).toHaveBeenCalledWith(fakeValue.command, false, linkValue);
-    });
-
-    it('updateModel: should update `modelValue`', () => {
-      component.bodyElement.nativeElement.innerHTML = 'teste';
-      component['updateModel']();
-      fixture.detectChanges();
-      expect(component.modelValue).toContain('teste');
-    });
-
-    it('updateModel: should call `value.emit` with `modelValue`', () => {
-      component.modelValue = 'teste';
-
-      spyOn(component.value, 'emit');
-      component['updateModel']();
-
-      expect(component.value.emit).toHaveBeenCalledWith(component.modelValue);
-    });
-
-    it('updateValueWithModelValue: should call `bodyElement.nativeElement.insertAdjacentHTML`', () => {
-      component.modelValue = 'teste';
-
-      spyOn(component.bodyElement.nativeElement, 'insertAdjacentHTML');
-      component['updateValueWithModelValue']();
-
-      expect(component.bodyElement.nativeElement.insertAdjacentHTML).toHaveBeenCalledWith('afterbegin', component.modelValue);
-    });
-
-    it('onFocus: should set a value to `valueBeforeChange`', () => {
-      component.modelValue = 'value';
-
-      component.onFocus();
-
-      expect(component['valueBeforeChange']).toBe('value');
-    });
-
-    it('rgbToHex: should return the hexadecimal value`', () => {
-      const rbg = 'rgb(0, 128, 255)';
-      const hex = '#0080ff';
-      const result = component['rgbToHex'](rbg);
-
-      expect(result).toBe(hex);
+      expect(component['isLinkEditing']).toEqual(fakeEvent);
     });
 
     it('onBlur: should emit modelValue change', fakeAsync((): void => {
@@ -440,6 +164,366 @@ describe('PoRichTextBodyComponent:', () => {
       expect(fakeThis.change.emit).not.toHaveBeenCalled();
     }));
 
+    it('focus: should call `focus` of rich-text', () => {
+
+      spyOn(component.bodyElement.nativeElement, 'focus');
+
+      component.focus();
+
+      expect(component.bodyElement.nativeElement.focus).toHaveBeenCalled();
+    });
+
+    it('onClick: should call `emitSelectionCommands`', () => {
+      spyOn(component, <any>'emitSelectionCommands');
+      component.onClick();
+
+      expect(component['emitSelectionCommands']).toHaveBeenCalled();
+    });
+
+    it('onFocus: should set a value to `valueBeforeChange`', () => {
+      component.modelValue = 'value';
+
+      component.onFocus();
+
+      expect(component['valueBeforeChange']).toBe('value');
+    });
+
+    it('onKeyDown: should call `event.preventDefault` and `shortcutCommand.emit` if keyCode is `75` and ctrlKey is `true`', () => {
+      const fakeEvent = {
+        keyCode: 75,
+        ctrlKey: true,
+        preventDefault: () => {},
+      };
+
+      spyOn(component.shortcutCommand, 'emit');
+      spyOn(fakeEvent, 'preventDefault');
+      spyOn(component, <any>'toggleCursorOnLink');
+
+      component.onKeyDown(fakeEvent);
+
+      expect(fakeEvent.preventDefault).toHaveBeenCalled();
+      expect(component.shortcutCommand.emit).toHaveBeenCalled();
+    });
+
+    it('onKeyDown: should call `toggleCursorOnLink` with `event` and `add`', () => {
+      const fakeEvent = {
+        ctrlKey: false
+      };
+
+      spyOn(component, <any>'toggleCursorOnLink');
+
+      component.onKeyDown(fakeEvent);
+
+      expect(component['toggleCursorOnLink']).toHaveBeenCalledWith(fakeEvent, 'add');
+    });
+
+    it('onKeyDown: should call `event.preventDefault` and `shortcutCommand.emit` if keyCode is `75` and metaKey is `true`', () => {
+      const fakeEvent = {
+        keyCode: 75,
+        metaKey: true,
+        preventDefault: () => {},
+      };
+
+      spyOn(component.shortcutCommand, 'emit');
+      spyOn(fakeEvent, 'preventDefault');
+      spyOn(component, <any>'toggleCursorOnLink');
+
+      component.onKeyDown(fakeEvent);
+
+      expect(fakeEvent.preventDefault).toHaveBeenCalled();
+      expect(component.shortcutCommand.emit).toHaveBeenCalled();
+    });
+
+    it('onKeyDown: shouldn`t call `event.preventDefault` and `shortcutCommand.emit` if keyCode isn`t `75`', () => {
+      const fakeEvent = {
+        keyCode: 18,
+        cmdKey: true,
+        preventDefault: () => {},
+      };
+
+      spyOn(component.shortcutCommand, 'emit');
+      spyOn(fakeEvent, 'preventDefault');
+      spyOn(component, <any>'toggleCursorOnLink');
+
+      component.onKeyDown(fakeEvent);
+
+      expect(fakeEvent.preventDefault).not.toHaveBeenCalled();
+      expect(component.shortcutCommand.emit).not.toHaveBeenCalled();
+    });
+
+    it('onKeyDown: shouldn`t call `event.preventDefault` and `shortcutCommand.emit` if ctrlKey isn`t true', () => {
+      const fakeEvent = {
+        keyCode: 76,
+        ctrlKey: false,
+        preventDefault: () => {},
+      };
+
+      spyOn(component.shortcutCommand, 'emit');
+      spyOn(fakeEvent, 'preventDefault');
+      spyOn(component, <any>'toggleCursorOnLink');
+
+      component.onKeyDown(fakeEvent);
+
+      expect(fakeEvent.preventDefault).not.toHaveBeenCalled();
+      expect(component.shortcutCommand.emit).not.toHaveBeenCalled();
+    });
+
+    it('onKeyUp: should call `toggleCursorOnLink` with `event` and `remove` before `updateModel`', () => {
+      spyOn(component, <any>'toggleCursorOnLink');
+      const updateModelSpy = spyOn(component, <any>'updateModel');
+      spyOn(component, <any>'removeBrElement');
+      spyOn(component, <any>'emitSelectionCommands');
+
+      const event = { metaKey: true };
+
+      component.onKeyUp(event);
+
+      expect(component['toggleCursorOnLink']).toHaveBeenCalledBefore(updateModelSpy);
+    });
+
+    it('onKeyUp: should call `removeBrElement` and `emitSelectionCommands`', () => {
+      spyOn(component, <any>'toggleCursorOnLink');
+      spyOn(component, <any>'updateModel');
+      spyOn(component, <any>'removeBrElement');
+      spyOn(component, <any>'emitSelectionCommands');
+
+      const event = { metaKey: true };
+
+      component.onKeyUp(event);
+
+      expect(component['removeBrElement']).toHaveBeenCalled();
+      expect(component['emitSelectionCommands']).toHaveBeenCalled();
+    });
+
+    it('onPaste: should call `addClickListenerOnAnchorElements` and `update`', () => {
+      spyOn(component, <any>'addClickListenerOnAnchorElements');
+      spyOn(component, <any>'update');
+
+      component.onPaste();
+
+      expect(component['addClickListenerOnAnchorElements']).toHaveBeenCalled();
+      expect(component['update']).toHaveBeenCalled();
+    });
+
+    it('update: should call `updateModel`', fakeAsync(() => {
+      spyOn(component, <any>'updateModel');
+      spyOn(component, <any>'removeBrElement');
+      spyOn(component, <any>'emitSelectionCommands');
+
+      component.update();
+      tick(50);
+
+      expect(component['updateModel']).toHaveBeenCalled();
+    }));
+
+    it('update: should call `removeBrElement` and `emitSelectionCommands`', fakeAsync(() => {
+      spyOn(component, <any>'updateModel');
+      spyOn(component, <any>'removeBrElement');
+      spyOn(component, <any>'emitSelectionCommands');
+
+      component.update();
+      tick(50);
+
+      expect(component['removeBrElement']).toHaveBeenCalled();
+      expect(component['emitSelectionCommands']).toHaveBeenCalled();
+    }));
+
+    it(`addClickListenerOnAnchorElements: should call 'addEventListener' with 'click' and 'onAnchorClick'
+      based on the amount of anchor elements`, () => {
+
+      const spyListener = jasmine.createSpy('addEventListener');
+
+      const anchors = [
+        { parentNode: `<a>link1</a>`, addEventListener: spyListener },
+        { parentNode: `<a>link2</a>`, addEventListener: spyListener },
+        { parentNode: `<a>link3</a>`, addEventListener: spyListener },
+      ];
+
+      spyOn(component.bodyElement.nativeElement, 'querySelectorAll').and.returnValue(<any>anchors);
+
+      component['addClickListenerOnAnchorElements']();
+
+      expect(spyListener).toHaveBeenCalledTimes(anchors.length);
+      expect(spyListener).toHaveBeenCalledWith('click', component['onAnchorClick']);
+    });
+
+    it('emitSelectionCommands: should call `commands.emit`', () => {
+      spyOn(component.commands, 'emit');
+
+      component['emitSelectionCommands']();
+
+      expect(component.commands.emit).toHaveBeenCalled();
+    });
+
+    it('emitSelectionCommands: should call `isCursorPositionedInALink`', () => {
+      spyOn(component, <any> 'isCursorPositionedInALink');
+
+      component['emitSelectionCommands']();
+
+      expect(component['isCursorPositionedInALink']).toHaveBeenCalled();
+    });
+
+    it('emitSelectionCommands: should call `selectedLink.emit`', () => {
+      spyOn(component.selectedLink, 'emit');
+
+      component['emitSelectionCommands']();
+
+      expect(component.selectedLink.emit).toHaveBeenCalled();
+    });
+
+    it(`emitSelectionCommands: the object property 'commands'
+    should contain 'Createlink' if 'isCursorPositionedInALink' returns 'true'`, () => {
+
+      spyOn(component, <any>'isCursorPositionedInALink').and.returnValue(true);
+      spyOn(document, 'queryCommandState').and.returnValue(false);
+      spyOn(document, 'queryCommandValue').and.returnValue('rgb');
+      spyOn(component, <any>'rgbToHex').and.returnValue('hex');
+      spyOn(component.commands, 'emit');
+
+      component['emitSelectionCommands']();
+
+      expect(component.commands.emit).toHaveBeenCalledWith({commands: ['Createlink'], hexColor: 'hex'});
+    });
+
+    it(`emitSelectionCommands: the object property 'commands'
+    should contain 'Createlink' if 'isCursorPositionedInALink' returns 'true'`, () => {
+
+      spyOn(component, <any>'isCursorPositionedInALink').and.returnValue(true);
+      spyOn(document, 'queryCommandState').and.returnValue(false);
+      spyOn(document, 'queryCommandValue').and.returnValue('rgb');
+      spyOn(component, <any>'rgbToHex').and.returnValue('hex');
+      spyOn(UtilsFunction, 'isIE').and.returnValue(false);
+      spyOn(component.commands, 'emit');
+
+      component['emitSelectionCommands']();
+
+      expect(component.commands.emit).toHaveBeenCalledWith({commands: ['Createlink'], hexColor: 'hex'});
+    });
+
+    it(`emitSelectionCommands: should call 'commands.emit' with 'hexColor' undefined if browser is IE`, () => {
+
+      spyOn(component, <any>'isCursorPositionedInALink').and.returnValue(true);
+      spyOn(document, 'queryCommandState').and.returnValue(false);
+      spyOn(document, 'queryCommandValue').and.returnValue('rgb');
+      spyOn(UtilsFunction, 'isIE').and.returnValue(true);
+      spyOn(component.commands, 'emit');
+
+      component['emitSelectionCommands']();
+
+      expect(component.commands.emit).toHaveBeenCalledWith({commands: ['Createlink'], hexColor: undefined });
+    });
+
+    it(`emitSelectionCommands: the object property 'commands'
+    shouldn't contain 'Createlink' if 'isCursorPositionedInALink' returns 'false'`, () => {
+
+      spyOn(component, <any>'isCursorPositionedInALink').and.returnValue(false);
+      spyOn(document, 'queryCommandState').and.returnValue(false);
+      spyOn(document, 'queryCommandValue').and.returnValue('rgb');
+      spyOn(component, <any>'rgbToHex').and.returnValue('hex');
+      spyOn(component.commands, 'emit');
+
+      component['emitSelectionCommands']();
+
+      expect(component.commands.emit).toHaveBeenCalledWith({commands: [], hexColor: 'hex'});
+    });
+
+    it('handleCommandLink: should call `insertHtmlLinkElement` if isIE returns `true`', () => {
+      const fakeValue = {
+        command: 'InsertHTML',
+        urlLink: 'urlLink',
+        urlLinkText: 'url link text'
+      };
+
+      spyOn(UtilsFunction, 'isIE').and.returnValue(true);
+      spyOn(component, <any>'insertHtmlLinkElement');
+      spyOn(document, <any>'execCommand');
+
+      component['handleCommandLink'](fakeValue.command, fakeValue.urlLink, fakeValue.urlLinkText);
+
+      expect(document.execCommand).not.toHaveBeenCalled();
+      expect(UtilsFunction.isIE).toHaveBeenCalled();
+      expect(component['insertHtmlLinkElement']).toHaveBeenCalledWith(fakeValue.urlLink, fakeValue.urlLinkText);
+    });
+
+    it('handleCommandLink: should call `makeLinkTag` if isIE returns `false`', () => {
+      const fakeValue = {
+        command: 'InsertHTML',
+        urlLink: 'urlLink',
+        urlLinkText: 'url link text'
+      };
+
+      spyOn(UtilsFunction, 'isIE').and.returnValue(false);
+      spyOn(component, <any>'insertHtmlLinkElement');
+      spyOn(document, <any>'execCommand');
+      spyOn(component, <any>'makeLinkTag');
+
+      component['handleCommandLink'](fakeValue.command, fakeValue.urlLink, fakeValue.urlLinkText);
+
+      expect(document.execCommand).toHaveBeenCalled();
+      expect(UtilsFunction.isIE).toHaveBeenCalled();
+      expect(component['insertHtmlLinkElement']).not.toHaveBeenCalledWith(fakeValue.urlLink, fakeValue.urlLinkText);
+      expect(component['makeLinkTag']).toHaveBeenCalledWith(fakeValue.urlLink, fakeValue.urlLinkText);
+    });
+
+    it('handleCommandLink: should call `document.execCommand` with `command`, `false` and linkValue as params if isIE is `false`', () => {
+      const linkValue = `<a class="po-rich-text-link" href="urlLink" target="_blank">url link text</a>`;
+      const fakeValue = {
+        command: 'InsertHTML',
+        urlLink: 'urlLink',
+        urlLinkText: 'url link text'
+      };
+
+      spyOn(UtilsFunction, 'isIE').and.returnValue(false);
+      spyOn(component, <any>'insertHtmlLinkElement');
+      spyOn(document, <any>'execCommand');
+
+      component['handleCommandLink'](fakeValue.command, fakeValue.urlLink, fakeValue.urlLinkText);
+
+      expect(document.execCommand).toHaveBeenCalledWith(fakeValue.command, false, linkValue);
+      expect(component['insertHtmlLinkElement']).not.toHaveBeenCalled();
+    });
+
+    it(`handleCommandLink: the parameter 'linkvalue' should be concatenated with 'urlLink' if 'urlLinkText' is undefined`, () => {
+      const linkValue = `<a class="po-rich-text-link" href="urlLink" target="_blank">urlLink</a>`;
+      const fakeValue = {
+        command: 'InsertHTML',
+        urlLink: 'urlLink',
+        urlLinkText: undefined
+      };
+
+      spyOn(UtilsFunction, 'isIE').and.returnValue(false);
+      spyOn(document, <any>'execCommand');
+
+      component['handleCommandLink'](fakeValue.command, fakeValue.urlLink, fakeValue.urlLinkText);
+
+      expect(document.execCommand).toHaveBeenCalledWith(fakeValue.command, false, linkValue);
+    });
+
+    it(`handleCommandLink: should add '&nbsp;' at beginning and end of 'linkValue' if 'isFirefox'`, () => {
+      const expectedLinkValue = `&nbsp;<a class="po-rich-text-link" href="urlLink" target="_blank">urlLink</a>&nbsp;`;
+      const fakeValue = {
+        command: 'InsertHTML',
+        urlLink: 'urlLink',
+        urlLinkText: undefined
+      };
+
+      spyOn(UtilsFunction, 'isIE').and.returnValue(false);
+      spyOn(UtilsFunction, 'isFirefox').and.returnValue(true);
+      spyOn(document, <any>'execCommand');
+
+      component['handleCommandLink'](fakeValue.command, fakeValue.urlLink, fakeValue.urlLinkText);
+
+      expect(document.execCommand).toHaveBeenCalledWith(fakeValue.command, false, expectedLinkValue);
+    });
+
+    it('handleCommandLink: should call `addClickListenerOnAnchorElements`', () => {
+      spyOn(component, <any>'addClickListenerOnAnchorElements');
+
+      component['handleCommandLink']('CreateLink', 'link text', 'link url');
+
+      expect(component['addClickListenerOnAnchorElements']).toHaveBeenCalled();
+    });
+
     it('insertHtmlLinkElement: should contain `po-rich-text-link`', () => {
       const urlLink = 'urlLink';
       const urlLinkText = 'url link text';
@@ -451,6 +535,605 @@ describe('PoRichTextBodyComponent:', () => {
       fixture.detectChanges();
 
       expect(nativeElement.querySelector('.po-rich-text-link')).toBeTruthy();
+    });
+
+    it('getTextSelection: should call `document.getSelection`', () => {
+      spyOn(document, <any> 'getSelection');
+
+      component['getTextSelection']();
+
+      expect(document['getSelection']).toHaveBeenCalled();
+    });
+
+    it('getTextSelection: should return `node` and `tagName`', () => {
+      const fakeSelection = { anchorNode: { parentNode: { nodeName: 'A' } } };
+      const expectedReturn = { node: { nodeName: 'A' }, tagName: 'A'};
+
+      spyOn(document, <any> 'getSelection').and.returnValue(<any>fakeSelection);
+
+      const expectedValue = component['getTextSelection']();
+
+      expect(expectedValue).toEqual(<any>expectedReturn);
+    });
+
+    it('getTextSelection: should return `node` and `tagName`', () => {
+      const fakeSelection = {};
+      const expectedReturn = undefined;
+
+      spyOn(document, <any> 'getSelection').and.returnValue(<any>fakeSelection);
+
+      const expectedValue = component['getTextSelection']();
+
+      expect(expectedValue).toEqual(expectedReturn);
+    });
+
+    it('isCursorPositionedInALink: should return true if `focusNode.parentElement` is a link', () => {
+      const fakeSelection = { node: { nodeName: 'A' }, tagName: 'A'};
+
+      spyOn(component, <any> 'getTextSelection').and.returnValue(<any>fakeSelection);
+
+      const expectedValue = component['isCursorPositionedInALink']();
+
+      expect(expectedValue).toBe(true);
+    });
+
+    it('isCursorPositionedInALink: should return true if `anchorNode.parentNode` is a link', () => {
+      const fakeSelection = { anchorNode: { parentNode: { nodeName: 'A' } } };
+
+      spyOn(document, 'getSelection').and.returnValue(<any>fakeSelection);
+
+      const expectedValue = component['isCursorPositionedInALink']();
+
+      expect(expectedValue).toBe(true);
+    });
+
+    it(`isCursorPositionedInALink: should return true if browser is firefox and 'verifyCursorPositionInFirefoxIEEdge' return true`, () => {
+      const fakeSelection = { focusNode: { parentElement: { tagName: 'B' } } };
+
+      spyOn(document, 'getSelection').and.returnValue(<any>fakeSelection);
+      spyOn(UtilsFunction, 'isFirefox').and.returnValue(true);
+      spyOn(component, <any>'verifyCursorPositionInFirefoxIEEdge').and.returnValue(true);
+
+      const expectedValue = component['isCursorPositionedInALink']();
+
+      expect(expectedValue).toBe(true);
+    });
+
+    it(`isCursorPositionedInALink: should return true if browser is IE and 'verifyCursorPositionInFirefoxIEEdge' return true`, () => {
+      const fakeSelection = { focusNode: { parentElement: { tagName: 'B' } } };
+
+      spyOn(document, 'getSelection').and.returnValue(<any>fakeSelection);
+      spyOn(UtilsFunction, 'isIEOrEdge').and.returnValue(true);
+      spyOn(component, <any>'verifyCursorPositionInFirefoxIEEdge').and.returnValue(true);
+
+      const expectedValue = component['isCursorPositionedInALink']();
+
+      expect(expectedValue).toBe(true);
+    });
+
+    it(`isCursorPositionedInALink: should return true if not tag A, firefox and IE, but 'isParentNodeAnchor' return true`, () => {
+      const fakeSelection = { focusNode: { parentElement: { tagName: 'B' } } };
+
+      spyOn(document, 'getSelection').and.returnValue(<any>fakeSelection);
+      spyOn(UtilsFunction, 'isIEOrEdge').and.returnValue(false);
+      spyOn(UtilsFunction, 'isFirefox').and.returnValue(false);
+      spyOn(component, <any>'isParentNodeAnchor').and.returnValue(true);
+
+      const expectedValue = component['isCursorPositionedInALink']();
+
+      expect(expectedValue).toBe(true);
+    });
+
+    it(`isCursorPositionedInALink: should return false if not tag A, firefox, IE  and 'isParentNodeAnchor' return false`, () => {
+      const fakeSelection = { focusNode: { parentElement: { tagName: 'B' } } };
+
+      spyOn(document, 'getSelection').and.returnValue(<any>fakeSelection);
+      spyOn(UtilsFunction, 'isIEOrEdge').and.returnValue(false);
+      spyOn(UtilsFunction, 'isFirefox').and.returnValue(false);
+      spyOn(component, <any>'isParentNodeAnchor').and.returnValue(false);
+
+      const expectedValue = component['isCursorPositionedInALink']();
+
+      expect(expectedValue).toBe(false);
+    });
+
+    it(`isCursorPositionedInALink: should return false if browser is firefox and 'verifyCursorPositionInFirefoxIEEdge'
+      return false`, () => {
+
+      const fakeSelection = { focusNode: { parentElement: { tagName: 'B' } } };
+
+      spyOn(document, 'getSelection').and.returnValue(<any>fakeSelection);
+      spyOn(UtilsFunction, 'isFirefox').and.returnValue(true);
+      spyOn(component, <any>'verifyCursorPositionInFirefoxIEEdge').and.returnValue(false);
+
+      const expectedValue = component['isCursorPositionedInALink']();
+
+      expect(expectedValue).toBe(false);
+    });
+
+    it(`isCursorPositionedInALink: should return false if browser is IE and 'verifyCursorPositionInFirefoxIEEdge'
+      return false`, () => {
+
+      const fakeSelection = { focusNode: { parentElement: { tagName: 'B' } } };
+
+      spyOn(document, 'getSelection').and.returnValue(<any>fakeSelection);
+      spyOn(UtilsFunction, 'isIEOrEdge').and.returnValue(true);
+      spyOn(component, <any>'verifyCursorPositionInFirefoxIEEdge').and.returnValue(false);
+
+      const expectedValue = component['isCursorPositionedInALink']();
+
+      expect(expectedValue).toBe(false);
+    });
+
+    it('isParentNodeAnchor: should return true if focusNode.parentElement if anchor element', () => {
+      const textSelection = { node: { nodeName: 'A' }, tagName: 'A'};
+
+      const isParentNodeAnchor = component['isParentNodeAnchor'](<any> textSelection);
+
+      expect(isParentNodeAnchor).toBe(true);
+      expect(component['linkElement']).toEqual(textSelection.node);
+    });
+
+    it('isParentNodeAnchor: should return true if parentElement of focusNode.parentElement if anchor element', () => {
+      const parentElement = {
+        tagName : 'A'
+      };
+
+      const textSelection = { node: { parentElement: { nodeName: 'DIV', parentElement} }, tagName: 'DIV'};
+
+      const isParentNodeAnchor = component['isParentNodeAnchor'](<any> textSelection);
+
+      expect(isParentNodeAnchor).toBe(true);
+      expect(component['linkElement']).toEqual(textSelection.node.parentElement.parentElement);
+    });
+
+    it('isParentNodeAnchor: should return false and set linkElement with undefined', () => {
+      const textSelection = { node: { parentElement: { nodeName: '' } }, tagName: 'DIV'};
+
+      const isParentNodeAnchor = component['isParentNodeAnchor'](<any> textSelection);
+
+      expect(isParentNodeAnchor).toBe(false);
+      expect(component['linkElement']).toBeUndefined();
+    });
+
+    it('isParentNodeAnchor: should return falsy if textSelection is undefined', () => {
+      const textSelection = {};
+
+      const isParentNodeAnchor = component['isParentNodeAnchor'](textSelection);
+
+      expect(isParentNodeAnchor).toBeFalsy();
+    });
+
+    it('isParentNodeAnchor: should return false and set linkElement with undefined', () => {
+      const textSelection = {
+        node: {
+          nodeName: 'DIV',
+          parentNode: { nodeName: 'DIV' },
+          tagName: null
+        },
+        tagName: 'DIV'
+      };
+
+      const isParentNodeAnchor = component['isParentNodeAnchor'](<any> textSelection);
+
+      expect(isParentNodeAnchor).toBe(false);
+      expect(component['linkElement']).toBeUndefined();
+    });
+
+    it('onAnchorClick: should `openExternalLink` with url if key is `ctrlKey`', () => {
+      const url = 'http://test.com';
+
+      const event = {
+        ctrlKey: 'true',
+        target: {
+          attributes: { href: { value: url } },
+          classList: { remove: () => {} }
+        }
+      };
+
+      spyOn(UtilsFunction, 'openExternalLink');
+
+      component['onAnchorClick'](event);
+
+      expect(UtilsFunction.openExternalLink).toHaveBeenCalledWith(url);
+    });
+
+    it('onAnchorClick: should remove `po-clickable` if key is `ctrlKey`', () => {
+      const url = 'http://test.com';
+
+      const event = {
+        ctrlKey: 'true',
+        target: {
+          attributes: { href: { value: url } },
+          classList: { remove: () => {} }
+        }
+      };
+
+      spyOn(UtilsFunction, 'openExternalLink');
+      spyOn(event.target.classList, 'remove');
+
+      component['onAnchorClick'](event);
+
+      expect(event.target.classList.remove).toHaveBeenCalledWith('po-clickable');
+    });
+
+    it('onAnchorClick: should `openExternalLink` with url if key is `metaKey`', () => {
+      const url = 'http://test.com';
+
+      const event = {
+        metaKey: 'true',
+        target: {
+          attributes: { href: { value: url } },
+          classList: { remove: () => {} }
+        }
+      };
+
+      spyOn(UtilsFunction, 'openExternalLink');
+
+      component['onAnchorClick'](event);
+
+      expect(UtilsFunction.openExternalLink).toHaveBeenCalledWith(url);
+    });
+
+    it('onAnchorClick: shouldn`t `openExternalLink` if key not is ctrlKey or metaKey', () => {
+      const url = 'http://test.com';
+
+      const event = {
+        enter: 'true',
+        target: {
+          attributes: { href: { value: url } }
+        }
+      };
+
+      spyOn(UtilsFunction, 'openExternalLink');
+
+      component['onAnchorClick'](event);
+
+      expect(UtilsFunction.openExternalLink).not.toHaveBeenCalled();
+    });
+
+    it('onAnchorClick: should get `href` of `event.path`', () => {
+      const url = 'http://test2.com';
+      const espectedValue = 'http://test.com';
+
+      const event = {
+        ctrlKey: 'true',
+        path: [
+          { nodeName: 'A',
+            href: espectedValue,
+            classList: { remove: () => {} }
+          },
+          { nodeName: 'DIV' }],
+        target: {
+          attributes: { href: { value: url } },
+          classList: { remove: () => {} }
+        }
+      };
+
+      spyOn(UtilsFunction, 'openExternalLink');
+
+      component['onAnchorClick'](event);
+
+      expect(UtilsFunction.openExternalLink).toHaveBeenCalledWith(espectedValue);
+    });
+
+    it('removeBrElement: should remove tag `br`', () => {
+      const element = document.createElement('br');
+      element.classList.add('teste');
+
+      component.bodyElement.nativeElement.appendChild(element);
+
+      component['removeBrElement']();
+
+      expect(nativeElement.querySelector('.teste')).toBeFalsy();
+    });
+
+    it('removeBrElement: should`t remove tag `br`', () => {
+      const div = document.createElement('div');
+      const br = document.createElement('br');
+
+      br.classList.add('teste-br');
+      div.classList.add('teste-div');
+
+      component.bodyElement.nativeElement.appendChild(div);
+      component.bodyElement.nativeElement.appendChild(br);
+
+      component['removeBrElement']();
+
+      expect(nativeElement.querySelector('.teste-br')).toBeTruthy();
+      expect(nativeElement.querySelector('.teste-div')).toBeTruthy();
+    });
+
+    it('rgbToHex: should return the hexadecimal value`', () => {
+      const rbg = 'rgb(0, 128, 255)';
+      const hex = '#0080ff';
+      const result = component['rgbToHex'](rbg);
+
+      expect(result).toBe(hex);
+    });
+
+    it('toggleCursorOnLink: shouldn`t call remove if focusNode is undefined', () => {
+      const event = { key: 'Control' };
+
+      const removeSpy = jasmine.createSpy('remove');
+
+      spyOn(document , 'getSelection').and.returnValue(<any>{
+        focusNode: undefined
+      });
+
+      component['toggleCursorOnLink'](event, 'remove');
+
+      expect(removeSpy).not.toHaveBeenCalled();
+    });
+
+    it('toggleCursorOnLink: should call remove of classList if `action` is remove, `element` is `anchor` and `key` is `Control`', () => {
+      const event = { key: 'Control' };
+
+      const removeSpy = jasmine.createSpy('remove');
+      const containsSpy = jasmine.createSpy('contains').and.returnValue(true);
+
+      spyOn(document , 'getSelection').and.returnValue(<any>{
+        focusNode: {
+          parentNode: {
+            nodeName: 'A',
+            classList: {
+              remove: removeSpy,
+              contains: containsSpy
+            }
+          }
+        }
+      });
+
+      component['toggleCursorOnLink'](event, 'remove');
+
+      expect(removeSpy).toHaveBeenCalledWith('po-clickable');
+    });
+
+    it('toggleCursorOnLink: should call add of classList if `action` is add, `element` is `anchor` and `key` is `Control`', () => {
+      const event = { key: 'Control' };
+
+      const addSpy = jasmine.createSpy('add');
+      const isCursorPositionedInALinkSpy = spyOn(component, <any> 'isCursorPositionedInALink').and.returnValue(true);
+
+      spyOn(document , 'getSelection').and.returnValue(<any>{
+        focusNode : {
+          parentNode: {
+            nodeName: 'A',
+            classList: {
+              add: addSpy
+            }
+          }
+        }
+      });
+
+      component['toggleCursorOnLink'](event, 'add');
+
+      expect(addSpy).toHaveBeenCalledWith('po-clickable');
+      expect(isCursorPositionedInALinkSpy).toHaveBeenCalled();
+    });
+
+    it('toggleCursorOnLink: should call add of classList if `action` is add, `element` is `anchor` and `key` is `Meta`', () => {
+      const event = { key: 'Meta' };
+
+      const addSpy = jasmine.createSpy('add');
+      const isCursorPositionedInALinkSpy = spyOn(component, <any> 'isCursorPositionedInALink').and.returnValue(true);
+
+      spyOn(document , 'getSelection').and.returnValue(<any>{
+        focusNode : {
+          parentNode: {
+            nodeName: 'A',
+            classList: {
+              add: addSpy
+            }
+          }
+        }
+      });
+
+      component['toggleCursorOnLink'](event, 'add');
+
+      expect(addSpy).toHaveBeenCalledWith('po-clickable');
+      expect(isCursorPositionedInALinkSpy).toHaveBeenCalled();
+    });
+
+    it('toggleCursorOnLink: should call add of classList if `action` is add, `element` is `anchor` and `key` is `Control`', () => {
+      const event = { key: 'Control' };
+
+      const addSpy = jasmine.createSpy('add');
+      const isCursorPositionedInALinkSpy = spyOn(component, <any> 'isCursorPositionedInALink').and.returnValue(true);
+
+      spyOn(document , 'getSelection').and.returnValue(<any>{
+        focusNode : {
+          parentNode: {
+            nodeName: 'A',
+            classList: {
+              add: addSpy
+            }
+          }
+        }
+      });
+
+      component['toggleCursorOnLink'](event, 'add');
+
+      expect(addSpy).toHaveBeenCalledWith('po-clickable');
+      expect(isCursorPositionedInALinkSpy).toHaveBeenCalled();
+    });
+
+    it(`toggleCursorOnLink: shouldn't call add and call remove of classList if 'element' not is 'anchor'`, () => {
+      const event = { key: 'Control' };
+
+      const addSpy = jasmine.createSpy('add');
+      const isCursorPositionedInALinkSpy = spyOn(component, <any> 'isCursorPositionedInALink').and.returnValue(false);
+      const removeSpy = jasmine.createSpy('remove');
+      const containsSpy = jasmine.createSpy('contains').and.returnValue(true);
+
+      spyOn(document , 'getSelection').and.returnValue(<any>{
+        focusNode : {
+          parentNode: {
+            nodeName: 'DIV',
+            classList: {
+              add: addSpy,
+              remove: removeSpy,
+              contains: containsSpy
+            }
+          }
+        }
+      });
+
+      component['toggleCursorOnLink'](event, 'add');
+
+      expect(removeSpy).toHaveBeenCalled();
+      expect(isCursorPositionedInALinkSpy).toHaveBeenCalled();
+      expect(addSpy).not.toHaveBeenCalled();
+    });
+
+    it(`toggleCursorOnLink: shouldn't call add and call remove of classList if 'isClickable'`, () => {
+      const event = { key: 'Control' };
+
+      const addSpy = jasmine.createSpy('add');
+      const isCursorPositionedInALinkSpy = spyOn(component, <any> 'isCursorPositionedInALink').and.returnValue(false);
+      const removeSpy = jasmine.createSpy('remove');
+      const containsSpy = jasmine.createSpy('contains').and.returnValue(false);
+
+      spyOn(document , 'getSelection').and.returnValue(<any>{
+        focusNode : {
+          parentNode: {
+            nodeName: 'DIV',
+            classList: {
+              add: addSpy,
+              remove: removeSpy,
+              contains: containsSpy
+            }
+          }
+        }
+      });
+
+      component['toggleCursorOnLink'](event, 'add');
+
+      expect(removeSpy).not.toHaveBeenCalled();
+      expect(isCursorPositionedInALinkSpy).toHaveBeenCalled();
+      expect(addSpy).not.toHaveBeenCalled();
+    });
+
+    it('updateModel: should update `modelValue`', () => {
+      component.bodyElement.nativeElement.innerHTML = 'teste';
+      component['updateModel']();
+      fixture.detectChanges();
+      expect(component.modelValue).toContain('teste');
+    });
+
+    it('updateModel: should call `value.emit` with `modelValue`', () => {
+      component.modelValue = 'teste';
+
+      spyOn(component.value, 'emit');
+      component['updateModel']();
+
+      expect(component.value.emit).toHaveBeenCalledWith(component.modelValue);
+    });
+
+    it('updateValueWithModelValue: should call `bodyElement.nativeElement.insertAdjacentHTML`', () => {
+      component.modelValue = 'teste';
+
+      spyOn(component.bodyElement.nativeElement, 'insertAdjacentHTML');
+      component['updateValueWithModelValue']();
+
+      expect(component.bodyElement.nativeElement.insertAdjacentHTML).toHaveBeenCalledWith('afterbegin', component.modelValue);
+    });
+
+    it('verifyCursorPositionInFirefoxIEEdge: should return true if nodeName is an A tag', () => {
+      const element = { nodeName: 'A' };
+      const textSelection = {
+        focusNode: { nodeName: 'A' }
+      };
+
+      spyOn(document, 'getSelection').and.returnValue(<any>textSelection);
+
+      expect(component['verifyCursorPositionInFirefoxIEEdge']()).toBe(true);
+      expect(component['linkElement']).toEqual(element);
+    });
+
+    it('verifyCursorPositionInFirefoxIEEdge: should return true if childNodes of fragmentDocument is an A tag', () => {
+      const element = { element: 'test', nodeName: 'A' };
+      const textSelection = {
+        getRangeAt: () => {
+          return {
+            cloneContents: () => {
+              return { childNodes:
+                [{ element: 'test', nodeName: 'A' }]
+              };
+            }
+          };
+        }
+      };
+
+      spyOn(document, 'getSelection').and.returnValue(<any>textSelection);
+
+      expect(component['verifyCursorPositionInFirefoxIEEdge']()).toBe(true);
+      expect(component['linkElement']).toEqual(element);
+    });
+
+    it('verifyCursorPositionInFirefoxIEEdge: should return true if firstElementChild of fragmentDocument is an A tag', () => {
+      const element = { element: 'test', nodeName: 'A' };
+      const textSelection = {
+        getRangeAt: () => {
+          return {
+            cloneContents: () => {
+              return {
+                firstElementChild: { element: 'test', nodeName: 'A' },
+                childNodes: []
+              };
+            }
+          };
+        }
+      };
+
+      spyOn(document, 'getSelection').and.returnValue(<any>textSelection);
+
+      expect(component['verifyCursorPositionInFirefoxIEEdge']()).toBe(true);
+      expect(component['linkElement']).toEqual(element);
+    });
+
+    it(`verifyCursorPositionInFirefoxIEEdge: should return false if focusNode and firstElementChild of fragmentDocument
+      are not an A tag and childNodes is undefined `, () => {
+
+      const textSelection = {
+        getRangeAt: () => {
+          return {
+            cloneContents: () => {
+              return {
+                firstElementChild: { element: 'test', nodeName: 'DIV' },
+                childNodes: []
+              };
+            }
+          };
+        }
+      };
+
+      spyOn(document, 'getSelection').and.returnValue(<any>textSelection);
+
+      expect(component['verifyCursorPositionInFirefoxIEEdge']()).toBe(false);
+      expect(component['linkElement']).toBe(undefined);
+    });
+
+    it(`verifyCursorPositionInFirefoxIEEdge: should return false if focusNode and childNodes of fragmentDocument
+      are not an A tag and firstElementChild is undefined`, () => {
+
+      const textSelection = {
+        getRangeAt: () => {
+          return {
+            cloneContents: () => {
+              return {
+                firstElementChild: undefined,
+                childNodes: [{ element: 'test', nodeName: 'DIV' }]
+              };
+            }
+          };
+        }
+      };
+
+      spyOn(document, 'getSelection').and.returnValue(<any>textSelection);
+
+      expect(component['verifyCursorPositionInFirefoxIEEdge']()).toBe(false);
+      expect(component['linkElement']).toBe(undefined);
     });
 
   });

--- a/projects/ui/src/lib/components/po-field/po-rich-text/po-rich-text-literals.ts
+++ b/projects/ui/src/lib/components/po-field/po-rich-text/po-rich-text-literals.ts
@@ -14,6 +14,7 @@ export const poRichTextLiteralsDefault = {
     linkUrlTextHelper: 'Paste in the text box below the copied browser link',
     linkUrlTextPlaceholder: 'Enter the link address that will be attached to the text.',
     cancel: 'Cancel',
+    editLink: 'Edit link',
     insert: 'Insert',
     insertImage: 'Insert image',
     urlImage: 'URL image'
@@ -33,6 +34,7 @@ export const poRichTextLiteralsDefault = {
     linkUrlTextHelper: 'Pegue en el cuadro de texto debajo del enlace del navegador copiado',
     linkUrlTextPlaceholder: 'Ingrese la dirección del enlace que se adjuntará al texto.',
     cancel: 'Cancelar',
+    editLink: 'Editar enlace',
     insert: 'Insertar',
     insertImage: 'Insertar imagen',
     urlImage: 'Imagen URL'
@@ -52,6 +54,7 @@ export const poRichTextLiteralsDefault = {
     linkUrlTextHelper: 'Cole na caixa de texto abaixo o link copiado do navegador',
     linkUrlTextPlaceholder: 'Insira o endereço do link que será anexado ao texto',
     cancel: 'Cancelar',
+    editLink: 'Editar link',
     insert: 'Inserir',
     insertImage: 'Inserir imagem',
     urlImage: 'Imagem em URL'

--- a/projects/ui/src/lib/components/po-field/po-rich-text/po-rich-text-toolbar/po-rich-text-toolbar.component.ts
+++ b/projects/ui/src/lib/components/po-field/po-rich-text/po-rich-text-toolbar/po-rich-text-toolbar.component.ts
@@ -17,7 +17,6 @@ const poRichTextDefaultColor = '#000000';
 export class PoRichTextToolbarComponent implements AfterViewInit {
 
   private _readonly: boolean;
-  private selection = document.getSelection();
 
   readonly literals = {
     ...poRichTextLiteralsDefault[this.languageService.getShortLanguage()]
@@ -85,7 +84,7 @@ export class PoRichTextToolbarComponent implements AfterViewInit {
     {
       command: 'Createlink',
       icon: 'po-icon-link',
-      tooltip: `${this.literals.insertLink} (Ctrl + L)`,
+      tooltip: `${this.literals.insertLink} (Ctrl + K)`,
       action: () => this.modal.emit(PoRichTextModalType.Link)
     }
   ];

--- a/projects/ui/src/lib/components/po-field/po-rich-text/po-rich-text.component.html
+++ b/projects/ui/src/lib/components/po-field/po-rich-text/po-rich-text.component.html
@@ -12,6 +12,7 @@
       [p-readonly]="readonly"
       (p-change)="onChangeValue($event)"
       (p-commands)="richTextToolbar.setButtonsStates($event)"
+      (p-selected-link)="richTextModal.selectedLink($event)"
       (p-shortcut-command)="richTextToolbar.shortcutTrigger()"
       (p-value)="updateValue($event)">
     </po-rich-text-body>
@@ -23,7 +24,8 @@
     </po-rich-text-toolbar>
 
     <po-rich-text-modal #richTextModal
-      (p-command)="richTextBody.executeCommand($event)">
+      (p-command)="richTextBody.executeCommand($event)"
+      (p-link-editing)="richTextBody.linkEditing($event)">
     </po-rich-text-modal>
 
   </div>

--- a/projects/ui/src/lib/components/po-field/po-rich-text/samples/sample-po-rich-text-recipe/sample-po-rich-text-recipe.component.ts
+++ b/projects/ui/src/lib/components/po-field/po-rich-text/samples/sample-po-rich-text-recipe/sample-po-rich-text-recipe.component.ts
@@ -14,7 +14,7 @@ export class SamplePoRichTextRecipeComponent {
     <div><b><u>Preparation Time:</u></b>&nbsp;less than 30 mins</div>
     <div><b><u>Serves</u></b>: 3 people</div>
     <div><b><u>Reference</u></b>:
-      <a class="po-rich-text-link" href="en.wikipedia.org/wiki/hummus" target="_blank">Hummus Delicious Recipe</a>
+      <a class="po-rich-text-link" href="http://en.wikipedia.org/wiki/hummus" target="_blank">Hummus Delicious Recipe</a>
     </div>
     </div>
     <div><br></div>

--- a/projects/ui/src/lib/enums/po-key-code.enum.ts
+++ b/projects/ui/src/lib/enums/po-key-code.enum.ts
@@ -25,6 +25,9 @@ export enum PoKeyCodeEnum {
     /** Esc */
     esc = 27,
 
+    /** Tecla K */
+    keyK = 75,
+
     /** Tecla L */
     keyL = 76,
 

--- a/projects/ui/src/lib/utils/util.ts
+++ b/projects/ui/src/lib/utils/util.ts
@@ -221,6 +221,13 @@ export function isIE() {
   return /msie\s|trident/i.test(userAgent);
 }
 
+// Verifica se o navegador em que está sendo usado é Firefox
+export function isFirefox() {
+  const userAgent = window.navigator.userAgent;
+
+  return userAgent.toLowerCase().indexOf('firefox') > -1;
+}
+
 // Verifica qual o dispositivo que está sendo usado
 export function isMobile() {
   const userAgent = window.navigator.userAgent;


### PR DESCRIPTION
**PO RICH TEXT**

**DTHFUI-2141**
_____________________________________________________________________________

**PR Checklist**

- [x] Código
- [x] Testes unitários
- [ ] Documentação
- [ ] Samples

**Qual o comportamento atual?**
Atualmente o usuário depois de criar um link, ele não consegue editá-lo no rich-text.

**Qual o novo comportamento?**
Ao utilizar a função de criar um link, o usuário pode selecionar a palavra
e editar este link que foi criado.

- Ao selecionar um texto com um link e clicar no botão 'link', a modal deve abrir com os dados relacionados ao link;
- deve permitir alterar tanto o link como o texto de exibição;
- mesmo que o usuário selecione parte do texto que contém o link, deve ser levado em consideração todo o texto usado para a exibição do link;
- a regra relacionada ao texto de link prevalece a mesma, ou seja, se o usuário não especificar um valor de exibição, o valor de link deve ser o exibido na tela de edição;
- permitir alterar o estilo dos links sem comprometer a identificação do link no toolbar do rich text;
- links sem definição de estilo, devem sempre seguir o padrão definido para o componente;
- permitir que o usuário use o CTRL/CMD + Click para abrir o link em uma nova aba.

**Simulação**
Pode ser simulado nos samples do portal.