### PR TITLE
feat(combo): permite customizar a lista de opções

### DIFF
--- a/projects/ui/src/lib/components/po-field/po-combo/po-combo-option-template/po-combo-option-template.directive.spec.ts
+++ b/projects/ui/src/lib/components/po-field/po-combo/po-combo-option-template/po-combo-option-template.directive.spec.ts
@@ -1,0 +1,10 @@
+import { PoComboOptionTemplateDirective } from './po-combo-option-template.directive';
+
+describe('PoComboOptionTemplateDirective:', () => {
+  const component = new PoComboOptionTemplateDirective(null);
+
+  it('should be created', () => {
+    expect(component).toBeTruthy();
+  });
+
+});

--- a/projects/ui/src/lib/components/po-field/po-combo/po-combo-option-template/po-combo-option-template.directive.ts
+++ b/projects/ui/src/lib/components/po-field/po-combo/po-combo-option-template/po-combo-option-template.directive.ts
@@ -1,0 +1,54 @@
+import { Directive, TemplateRef } from '@angular/core';
+
+/**
+ * @usedBy PoComboComponent
+ *
+ * @description
+ *
+ * Esta diretiva permite personalizar o conteúdo dos itens exibidos na lista de opções do componente.
+ *
+ * > Quando utilizada em dispositivos *mobile* será exibido o componente nativo.
+ *
+ * Para personalizar o conteúdo de cada item da lista deve-se utilizar a diretiva `p-combo-option-template` com `ng-template`
+ * dentro da *tag* `po-combo`.
+ *
+ * Para obter a referência do item atual utilize `let-option`, com isso você terá acesso aos valores e poderá personalizar sua exibição.
+ *
+ * Esta diretiva compõe-se de dois meios para uso, de forma explícita tal como em *syntax sugar*. Veja a seguir ambos, respectivamente:
+ *
+ * ```
+ * ...
+ * <po-combo
+ *   name="combo"
+ *   [(ngModel)]="combo"
+ *   [p-options]="options">
+ *     <ng-template p-combo-option-template let-option>
+ *       <option-template [option]="option"></option-template>
+ *     </ng-template>
+ * </po-combo>
+ * ...
+ * ```
+ *
+ * ```
+ * ...
+ * <po-combo
+ *   name="combo"
+ *   [(ngModel)]="combo"
+ *   [p-options]="options">
+ *     <div *p-combo-option-template="let option">
+ *       <option-template [option]="option"></option-template>
+ *     </div>
+ * </po-combo>
+ * ...
+ *
+ * ```
+ */
+@Directive({
+  selector: '[p-combo-option-template]'
+})
+export class PoComboOptionTemplateDirective {
+
+  // Necessário manter templateRef para o funcionamento do row template.
+  constructor(public templateRef: TemplateRef<any>) { }
+
+}

--- a/projects/ui/src/lib/components/po-field/po-combo/po-combo.component.html
+++ b/projects/ui/src/lib/components/po-field/po-combo/po-combo.component.html
@@ -59,7 +59,20 @@
     <li *ngFor="let option of visibleOptions"
       [class.po-combo-item-selected]="compareObjects(selectedView, option)"
       (click)="onOptionClick(option, $event)">
-      <a class="po-combo-item" [innerHTML]="getLabelFormatted(option?.label)"></a>
+      <a class="po-combo-item">
+
+        <ng-container *ngIf="comboOptionTemplate; then optionTemplate; else defaultOptionTemplate"></ng-container>
+        
+        <ng-template #defaultOptionTemplate>
+          <span [innerHTML]="getLabelFormatted(option?.label)"></span>
+        </ng-template>
+
+        <ng-template #optionTemplate
+          [ngTemplateOutlet]="comboOptionTemplate?.templateRef"
+          [ngTemplateOutletContext]="{$implicit: option}">
+        </ng-template>
+
+      </a>
     </li>
   </ul>
 </ng-template>

--- a/projects/ui/src/lib/components/po-field/po-combo/po-combo.component.spec.ts
+++ b/projects/ui/src/lib/components/po-field/po-combo/po-combo.component.spec.ts
@@ -1403,6 +1403,28 @@ describe('PoComboComponent:', () => {
       expect(nativeElement.querySelector('.po-combo-content')).toBeNull();
     });
 
+    it('shouldn`t have a child span tag inside `po-combo-item` if `comboOptionTemplate` is true', () => {
+      component.comboOptionTemplate = <any> { templateRef: null };
+      component.options = [{ label: '1', value: '1' }];
+
+      fixture.detectChanges();
+
+      const defaultSpan = nativeElement.querySelector('.po-combo-item > span');
+
+      expect(defaultSpan).toBeNull();
+    });
+
+    it('should contain a child span tag inside `po-combo-item` if `comboOptionTemplate` is false', () => {
+      component.comboOptionTemplate = undefined;
+      component.options = [{ label: '1', value: '1' }];
+
+      fixture.detectChanges();
+
+      const defaultSpan = nativeElement.querySelector('.po-combo-item > span');
+
+      expect(defaultSpan).toBeTruthy();
+    });
+
   });
 
   describe('Integration:', () => {

--- a/projects/ui/src/lib/components/po-field/po-combo/po-combo.component.ts
+++ b/projects/ui/src/lib/components/po-field/po-combo/po-combo.component.ts
@@ -1,4 +1,4 @@
-import { ChangeDetectorRef, Component, DoCheck, ElementRef, forwardRef,
+import { ChangeDetectorRef, Component, ContentChild, DoCheck, ElementRef, forwardRef,
   IterableDiffers, OnDestroy, Renderer2, ViewChild } from '@angular/core';
 import { DomSanitizer, SafeHtml } from '@angular/platform-browser';
 import { NG_VALIDATORS, NG_VALUE_ACCESSOR } from '@angular/forms';
@@ -14,6 +14,7 @@ import { PoComboBaseComponent } from './po-combo-base.component';
 import { PoComboFilterMode } from './po-combo-filter-mode.enum';
 import { PoComboFilterService } from './po-combo-filter.service';
 import { PoComboOption } from './interfaces/po-combo-option.interface';
+import { PoComboOptionTemplateDirective } from './po-combo-option-template/po-combo-option-template.directive';
 
 const poComboContainerOffset = 8;
 const poComboContainerPositionDefault = 'bottom';
@@ -99,6 +100,8 @@ export class PoComboComponent extends PoComboBaseComponent implements DoCheck, O
 
   private filterSubscription: Subscription;
   private getSubscription: Subscription;
+
+  @ContentChild(PoComboOptionTemplateDirective, { static: true }) comboOptionTemplate: PoComboOptionTemplateDirective;
 
   @ViewChild('containerElement', { read: ElementRef, static: false }) containerElement: ElementRef;
   @ViewChild('contentElement', { read: ElementRef, static: false }) contentElement: ElementRef;

--- a/projects/ui/src/lib/components/po-field/po-combo/samples/sample-po-combo-transfer/sample-po-combo-transfer.component.html
+++ b/projects/ui/src/lib/components/po-field/po-combo/samples/sample-po-combo-transfer/sample-po-combo-transfer.component.html
@@ -22,6 +22,17 @@
       p-label="To contact"
       p-placeholder="Select a contact"
       p-required>
+
+      <ng-template p-combo-option-template let-option>
+        <div class="po-row">
+          <po-avatar class="po-sm-2 po-md-3 po-lg-1" p-size="sm"></po-avatar>
+
+          <div class="po-sm-10 po-md-9 po-lg-11">
+            <div class="po-font-text-large-bold"> {{ option.label }} </div>
+            <div class="po-font-text-smaller"> Account: {{ option.value }} </div>
+          </div>
+        </div>
+      </ng-template>
     </po-combo>
   </div>
 
@@ -76,7 +87,7 @@
     </po-info>
   </div>
 
-  <hr>
+  <po-divider></po-divider>
 
   <div class="po-row">
     <po-info

--- a/projects/ui/src/lib/components/po-field/po-field.module.ts
+++ b/projects/ui/src/lib/components/po-field/po-field.module.ts
@@ -19,6 +19,7 @@ import { PoTooltipModule } from './../../directives/po-tooltip/po-tooltip.module
 import { PoCalendarComponent } from './po-datepicker/po-calendar/po-calendar.component';
 import { PoCleanComponent } from './po-clean/po-clean.component';
 import { PoComboComponent } from './po-combo/po-combo.component';
+import { PoComboOptionTemplateDirective } from './po-combo/po-combo-option-template/po-combo-option-template.directive';
 import { PoDatepickerComponent } from './po-datepicker/po-datepicker.component';
 import { PoDatepickerRangeComponent } from './po-datepicker-range/po-datepicker-range.component';
 import { PoDecimalComponent } from './po-decimal/po-decimal.component';
@@ -80,6 +81,7 @@ import { PoUrlComponent } from './po-url/po-url.component';
     PoCheckboxGroupModule,
     PoCleanComponent,
     PoComboComponent,
+    PoComboOptionTemplateDirective,
     PoDecimalComponent,
     PoDatepickerComponent,
     PoDatepickerRangeComponent,
@@ -104,6 +106,7 @@ import { PoUrlComponent } from './po-url/po-url.component';
     PoCalendarComponent,
     PoCleanComponent,
     PoComboComponent,
+    PoComboOptionTemplateDirective,
     PoDecimalComponent,
     PoDatepickerComponent,
     PoDatepickerRangeComponent,


### PR DESCRIPTION
**COMBO**

**DTHFUI-1893**
_____________________________________________________________________________

**PR Checklist**

- [x] Código
- [x] Testes unitários
- [x] Documentação
- [x] Samples

**Qual o comportamento atual?**
A lista de opções do combo segue o guideline proposto pelo UX.

**Qual o novo comportamento?**
Agora é possível definir um template customizado através da diretiva `po-combo-option-template`.

**Simulação**
O Sample Banking Transfer contempla a nova funcionalidade.