### PR TITLE
fix(table): corrige exibição dos ícones de acordo com o valor da coluna

### DIFF
--- a/projects/ui/src/lib/components/po-table/po-table-column-icon/po-table-column-icon.component.spec.ts
+++ b/projects/ui/src/lib/components/po-table/po-table-column-icon/po-table-column-icon.component.spec.ts
@@ -2,6 +2,7 @@ import { ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { configureTestSuite } from './../../../util-test/util-expect.spec';
 
+import { PoTableColumnIcon } from './po-table-column-icon.interface';
 import { PoTableColumnIconComponent } from './po-table-column-icon.component';
 import { PoTableModule } from '../po-table.module';
 import { PoTooltipModule } from '../../../directives/po-tooltip';
@@ -170,20 +171,63 @@ describe('PoTableColumnIconComponent:', () => {
       expect(expectedValue).toBe(expectedIcon);
     });
 
-    it('click: should call column.action', () => {
+    it('click: shouldn`t call columnIcon.action or column.action if columnIcon.disabled is true', () => {
       const fakeRow = component.row = {};
-      const fakeColumn = {
+      const fakeColumnIcon = {
         color: 'color-08',
         value: 'po-icon-copy',
         action: () => true,
         disabled: () => true
       };
+      component.column = { property: 'columnIcon', type: 'icon', action: () => true };
 
-      spyOn(fakeColumn, 'action');
+      spyOn(component, 'isDisabled').and.callThrough();
+      spyOn(fakeColumnIcon, 'action');
+      spyOn(component.column, 'action');
 
-      component.click(fakeColumn);
+      component.click(fakeColumnIcon);
 
-      expect(fakeColumn.action).toHaveBeenCalledWith(fakeRow, fakeColumn);
+      expect(component.column.action).not.toHaveBeenCalledWith(fakeColumnIcon);
+      expect(fakeColumnIcon.action).not.toHaveBeenCalledWith(fakeRow, fakeColumnIcon);
+      expect(component['isDisabled']).toHaveBeenCalledWith(fakeColumnIcon);
+    });
+
+    it('click: should call columnIcon.action if isDisabled is false', () => {
+      const fakeRow = component.row = {};
+      const fakeColumnIcon = {
+        color: 'color-08',
+        value: 'po-icon-copy',
+        action: () => true,
+        disabled: () => false
+      };
+      component.column = { property: 'columnIcon', type: 'icon', action: () => {} };
+
+      spyOn(component, 'isDisabled').and.callThrough();
+      spyOn(component.column, 'action');
+      spyOn(fakeColumnIcon, 'action');
+
+      component.click(fakeColumnIcon);
+
+      expect(fakeColumnIcon.action).toHaveBeenCalledWith(fakeRow, fakeColumnIcon);
+      expect(component.column.action).not.toHaveBeenCalledWith(fakeColumnIcon);
+      expect(component['isDisabled']).toHaveBeenCalledWith(fakeColumnIcon);
+    });
+
+    it('click: should call column.action with columnIcon if isDisabled is falsy and columnIcon.action is undefined', () => {
+      const fakeRow = component.row = {};
+      const fakeColumnIcon = {
+        color: 'color-08',
+        value: 'po-icon-copy'
+      };
+      component.column = { property: 'columnIcon', type: 'icon', action: () => {} };
+
+      spyOn(component, 'isDisabled').and.callThrough();
+      spyOn(component.column, 'action');
+
+      component.click(fakeColumnIcon);
+
+      expect(component.column.action).toHaveBeenCalledWith(fakeRow, fakeColumnIcon);
+      expect(component['isDisabled']).toHaveBeenCalledWith(fakeColumnIcon);
     });
 
     it('trackByFunction: should return index', () => {
@@ -191,6 +235,26 @@ describe('PoTableColumnIconComponent:', () => {
       const trackBy = component.trackByFunction(fakeIndex);
 
       expect(trackBy).toBe(fakeIndex);
+    });
+
+    it('convertToColumnIcon: should convert to columnIcon pattern if pass string', () => {
+      const icon = 'po-icon-copy';
+      const columnIcons: Array<PoTableColumnIcon> = [{ value: icon }];
+
+      expect(component['convertToColumnIcon'](icon)).toEqual(columnIcons);
+    });
+
+    it('convertToColumnIcon: should convert to columnIcon pattern if pass array of string', () => {
+      const icons = ['po-icon-copy', 'po-icon-edit'];
+      const columnIcons: Array<PoTableColumnIcon> = [{ value: 'po-icon-copy' }, { value: 'po-icon-edit' }];
+
+      expect(component['convertToColumnIcon'](icons)).toEqual(columnIcons);
+    });
+
+    it('convertToColumnIcon: should return `icons` if is correct pattern', () => {
+      const columnIcons: Array<PoTableColumnIcon> = [{ value: 'po-icon-copy' }, { value: 'po-icon-edit' }];
+
+      expect(component['convertToColumnIcon'](columnIcons)).toEqual(columnIcons);
     });
 
   });

--- a/projects/ui/src/lib/components/po-table/po-table-column-icon/po-table-column-icon.interface.ts
+++ b/projects/ui/src/lib/components/po-table/po-table-column-icon/po-table-column-icon.interface.ts
@@ -40,9 +40,9 @@ export interface PoTableColumnIcon {
   disabled?: Function;
 
   /**
-   * Ícone a ser exibido.
+   * Ícone que será exibido, veja os valores válidos na [biblioteca de ícones](/guides/icons).
    *
-   * > Veja os valores válidos na [Biblioteca de ícones](/guides/icons).
+   * > Caso esta propriedade não seja definida, a mesma receberá o valor contido em `value`.
    */
   icon?: string;
 
@@ -50,9 +50,7 @@ export interface PoTableColumnIcon {
   tooltip?: string;
 
   /**
-   * Define o valor do respectivo ícone que será exibido, o qual se refere a propriedade `icon`.
-   *
-   * > Caso propriedade `icon` não for informada, o componente utilizará o próprio `value` como valor.
+   * Define o valor do ícone que será exibido.
    */
   value: string;
 

--- a/projects/ui/src/lib/components/po-table/po-table-icon/po-table-icon.component.html
+++ b/projects/ui/src/lib/components/po-table/po-table-icon/po-table-icon.component.html
@@ -1,5 +1,5 @@
 <span
-  class="po-icon {{ icon }} {{ color }}"
+  class="po-icon {{ icon }} {{ disabled ? '' : color }}"
   [ngClass]="{'po-clickable': clickable, 'po-table-icon-disabled': disabled}"
   [p-tooltip]="tooltip"
   (click)="onClick()"

--- a/projects/ui/src/lib/components/po-table/po-table.component.html
+++ b/projects/ui/src/lib/components/po-table/po-table.component.html
@@ -189,6 +189,7 @@
               </po-table-column-link>
 
               <po-table-column-icon *ngSwitchCase="'icon'"
+                [p-column]="column"
                 [p-icons]="getColumnIcons(row, column)"
                 [p-row]="row">
               </po-table-column-icon>

--- a/projects/ui/src/lib/components/po-table/po-table.component.ts
+++ b/projects/ui/src/lib/components/po-table/po-table.component.ts
@@ -256,15 +256,17 @@ export class PoTableComponent extends PoTableBaseComponent implements AfterViewI
   }
 
   getColumnIcons(row: any, column: PoTableColumn) {
-    if (column.icons && column.icons.length) {
-      return column.icons;
-    }
-
     const rowIcons = row[column.property];
 
-    if (rowIcons && rowIcons.length) {
-      return this.getColumnIconsFromProperty(rowIcons, column);
+    if (column.icons) {
+      if (Array.isArray(rowIcons)) {
+        return this.mergeCustomIcons(rowIcons, column.icons);
+      } else {
+        return this.findCustomIcon(rowIcons, column);
+      }
     }
+
+    return rowIcons;
   }
 
   getColumnLabel(row: any, columnLabel: PoTableColumn): PoTableColumnLabel {
@@ -402,6 +404,11 @@ export class PoTableComponent extends PoTableBaseComponent implements AfterViewI
     }
   }
 
+  private findCustomIcon(rowIcons, column: PoTableColumn) {
+    const customIcon = column.icons.find(icon => rowIcons === icon.value);
+    return customIcon ? [ customIcon ] : undefined;
+  }
+
   private getHeightTableFooter() {
     return this.tableFooterElement ? this.tableFooterElement.nativeElement.offsetHeight : 0;
   }
@@ -421,16 +428,15 @@ export class PoTableComponent extends PoTableBaseComponent implements AfterViewI
     });
   }
 
-  private getColumnIconsFromProperty(rowIcons: Array<string>, column: PoTableColumn) {
+  private mergeCustomIcons(rowIcons: Array<string>, customIcons: Array<any>) {
+    const mergedIcons = [];
 
-    const icons = [];
-    const { action, color, disabled } = column;
+    rowIcons.forEach(columnValue => {
+      const foundCustomIcon = customIcons.find(customIcon => columnValue === customIcon.icon || columnValue === customIcon.value);
+      foundCustomIcon ? mergedIcons.push(foundCustomIcon) : mergedIcons.push(columnValue);
+    });
 
-    const icon = { action, color, disabled };
-
-    rowIcons.forEach(value => icons.push( typeof value === 'string' ? { ...icon, value } : value));
-
-    return icons;
+    return mergedIcons;
   }
 
   private removeListeners() {


### PR DESCRIPTION
**PO-TABLE**

**DTHFUI-2398**

***

**PR Checklist**

- [x] Código
- [x] Testes unitários
- [x] Documentação
- [ ] Samples

***

**Qual o comportamento atual?**
Os ícones estão sempre sendo exibidos independente dos valores.

**Qual o novo comportamento?**
Exibir só os ícones que estão sendo listados no registro.

**Simulação**
No sample de componentes, remover a definição do array na propriedade *favorite* da coluna e manter apenas uma string.