### PR TITLE
feat(datepicker): permite definir saída do model

### DIFF
--- a/projects/ui/src/lib/components/po-field/index.ts
+++ b/projects/ui/src/lib/components/po-field/index.ts
@@ -5,6 +5,7 @@ export * from './po-combo/interfaces/po-combo-filter.interface';
 export * from './po-combo/interfaces/po-combo-literals.interface';
 export * from './po-combo/interfaces/po-combo-option.interface';
 export * from './po-combo/po-combo.component';
+export * from './po-datepicker/enums/po-datepicker-iso-format.enum';
 export * from './po-datepicker/po-datepicker.component';
 export * from './po-datepicker-range/interfaces/po-datepicker-range.interface';
 export * from './po-datepicker-range/interfaces/po-datepicker-range-literals.interface';

--- a/projects/ui/src/lib/components/po-field/po-datepicker/enums/po-datepicker-iso-format.enum.ts
+++ b/projects/ui/src/lib/components/po-field/po-datepicker/enums/po-datepicker-iso-format.enum.ts
@@ -1,0 +1,18 @@
+/**
+ * @usedBy PoDatepickerComponent
+ *
+ * @description
+ *
+ * *Enum* que define o padrão de formatação das datas.
+ *
+ * > Caso um formato padrão seja definido, o mesmo não será mais alterado de acordo com o formato de entrada.
+ */
+export enum PoDatepickerIsoFormat {
+
+  /** Padrão **E8601DAw** (*yyyy-mm-dd*). */
+  Basic = 'basic',
+
+  /** Padrão **E8601DZw** (*yyyy-mm-ddThh:mm:ss+|-hh:mm*). */
+  Extended = 'extended'
+
+}

--- a/projects/ui/src/lib/components/po-field/po-datepicker/po-datepicker-base.component.spec.ts
+++ b/projects/ui/src/lib/components/po-field/po-datepicker/po-datepicker-base.component.spec.ts
@@ -7,6 +7,7 @@ import { convertDateToISOExtended, formatYear, getShortBrowserLanguage, setYearF
 import { expectSettersMethod, expectPropertiesValues } from '../../../util-test/util-expect.spec';
 
 import { PoDatepickerBaseComponent } from './po-datepicker-base.component';
+import { PoDatepickerIsoFormat } from './enums/po-datepicker-iso-format.enum';
 import { PoMask } from '../po-input/po-mask';
 
 class PoDatepickerComponent extends PoDatepickerBaseComponent {
@@ -580,6 +581,31 @@ describe('PoDatepickerBaseComponent:', () => {
 
       expect(setYearFrom0To100).toHaveBeenCalled();
     });
+
+    it('p-iso-format: should update with valid value', () => {
+      const validValue = [PoDatepickerIsoFormat.Basic, PoDatepickerIsoFormat.Extended, 'basic', 'extended'];
+
+      expectPropertiesValues(component, 'isoFormat', validValue , validValue);
+    });
+
+    it('p-iso-format: should set isExtendedISO with `false` if isoFormat value is `PoDatepickerIsoFormat.Basic`', () => {
+      component.isoFormat = PoDatepickerIsoFormat.Basic;
+
+      expect(component['isExtendedISO']).toBe(false);
+    });
+
+    it('p-iso-format: should set isExtendedISO with `true` if isoFormat value is `PoDatepickerIsoFormat.Extended`', () => {
+      component.isoFormat = PoDatepickerIsoFormat.Extended;
+
+      expect(component['isExtendedISO']).toBe(true);
+    });
+
+    it('p-iso-format: should be set with `undefined` if it receives an invalid value', () => {
+      const invalidValues = [ undefined, 0, 1, 3, 'valor', [], true, false ];
+
+      expectPropertiesValues(component, 'isoFormat', invalidValues, undefined);
+    });
+
   });
 
 });

--- a/projects/ui/src/lib/components/po-field/po-datepicker/po-datepicker-base.component.ts
+++ b/projects/ui/src/lib/components/po-field/po-datepicker/po-datepicker-base.component.ts
@@ -6,6 +6,8 @@ import { convertDateToISODate, convertDateToISOExtended, convertIsoToDate, conve
 import { dateFailed, requiredFailed } from './../validators';
 import { PoMask } from '../po-input/po-mask';
 
+import { PoDatepickerIsoFormat } from './enums/po-datepicker-iso-format.enum';
+
 const poDatepickerFormatDefault: string = 'dd/mm/yyyy';
 
 /**
@@ -22,7 +24,8 @@ const poDatepickerFormatDefault: string = 'dd/mm/yyyy';
  * O datepicker aceita três formatos de data: o E8601DZw (yyyy-mm-ddThh:mm:ss+|-hh:mm), o E8601DAw (yyyy-mm-dd) e o
  * Date padrão do Javascript.
  *
- * > O formato de saída do *model* se ajusta conforme o formato de entrada, veja abaixo:
+ * > Por padrão, o formato de saída do *model* se ajustará conforme o formato de entrada. Se por acaso precisar controlar o valor de saída,
+ * a propriedade `p-iso-format` provê esse controle independentemente do formato de entrada. Veja abaixo os formatos disponíveis:
  *
  * - Formato de entrada e saída (E8601DZw) - `'2017-11-28T00:00:00-02:00'`;
  *
@@ -53,6 +56,7 @@ export abstract class PoDatepickerBaseComponent implements ControlValueAccessor,
 
   private _autofocus?: boolean;
   private _format?: string = poDatepickerFormatDefault;
+  private _isoFormat: PoDatepickerIsoFormat;
   private _maxDate: Date;
   private _minDate: Date;
   private _noAutocomplete?: boolean = false;
@@ -251,6 +255,26 @@ export abstract class PoDatepickerBaseComponent implements ControlValueAccessor,
 
   get format() {
     return this._format;
+  }
+
+  /**
+   * @optional
+   *
+   * @description
+   *
+   * Padrão de formatação para saída do *model*, independentemente do formato de entrada.
+   *
+   * > Veja os valores válidos no *enum* `PoDatepickerIsoFormat`.
+   */
+  @Input('p-iso-format') set isoFormat(value: PoDatepickerIsoFormat) {
+    if (Object.values(PoDatepickerIsoFormat).includes(value)) {
+      this._isoFormat = value;
+      this.isExtendedISO = value === PoDatepickerIsoFormat.Extended;
+    }
+  }
+
+  get isoFormat() {
+    return this._isoFormat;
   }
 
   /**

--- a/projects/ui/src/lib/components/po-field/po-datepicker/po-datepicker.component.spec.ts
+++ b/projects/ui/src/lib/components/po-field/po-datepicker/po-datepicker.component.spec.ts
@@ -13,6 +13,7 @@ import { PoCalendarService } from './po-calendar/po-calendar.service';
 import { PoCalendarComponent } from './po-calendar/po-calendar.component';
 import { PoCleanComponent } from '../po-clean/po-clean.component';
 import { PoDatepickerComponent } from './po-datepicker.component';
+import { PoDatepickerIsoFormat } from './enums/po-datepicker-iso-format.enum';
 import { PoFieldContainerBottomComponent } from './../po-field-container/po-field-container-bottom/po-field-container-bottom.component';
 import { PoFieldContainerComponent } from '../po-field-container/po-field-container.component';
 
@@ -836,15 +837,6 @@ describe('PoDatepickerComponent:', () => {
       expect(setYearFrom0To100).toHaveBeenCalled();
     });
 
-    it('writeValue: should set `isExtendedISO` to `false` if `isValidDateIso` is `true`', () => {
-      component['isExtendedISO'] = true;
-      const date = '2017-08-05';
-
-      component.writeValue(date);
-
-      expect(component['isExtendedISO']).toBe(false);
-    });
-
     it(`writeValue: should update 'valueBeforeChange' with 'formatToDate' return and call 'formatToDate'
       with 'this.date'`, () => {
 
@@ -1109,6 +1101,45 @@ describe('PoDatepickerComponent:', () => {
 
       component['setDialogPickerStyleDisplay']('block');
       expect(component.dialogPicker.nativeElement.style.display).toBe('block');
+    });
+
+    it('writeValue: should set `isExtendedISO` with `false` if `isoFormat` is `undefined` and `isValidExtendedIso` is `false`', () => {
+      component['isExtendedISO'] = false;
+      const date = '2019-11-21';
+
+      component.writeValue(date);
+
+      expect(component['isExtendedISO']).toBeFalsy();
+    });
+
+    it('writeValue: should set `isExtendedISO` with `true` if `isoFormat` is `undefined` and `isValidExtendedIso` is `true`', () => {
+      component['isExtendedISO'] = false;
+      const date = '2019-11-21T16:26:05-03:00';
+
+      component.writeValue(date);
+
+      expect(component['isExtendedISO']).toBeTruthy();
+    });
+
+    it('writeValue: shouldn`t change `isExtendedISO` value if `isoFormat` has a valid value', () => {
+      component.isoFormat = PoDatepickerIsoFormat.Basic;
+      const date = '2019-11-21';
+
+      component.writeValue(date);
+
+      expect(component['isExtendedISO']).toBeFalsy();
+    });
+
+    it('writeValue: should set `hour` value if date is an extended iso format', () => {
+      component.writeValue('2019-11-21T00:00:00-03:00');
+
+      expect(component.hour).toBe('T00:00:00-03:00');
+    });
+
+    it('writeValue: should keep `hour` with it`s default value if date isn`t an extended iso format', () => {
+      component.writeValue('2019-11-21');
+
+      expect(component.hour).toBe('T00:00:01-00:00');
     });
 
   });

--- a/projects/ui/src/lib/components/po-field/po-datepicker/po-datepicker.component.ts
+++ b/projects/ui/src/lib/components/po-field/po-datepicker/po-datepicker.component.ts
@@ -286,12 +286,14 @@ export class PoDatepickerComponent extends PoDatepickerBaseComponent implements 
 
       } else if (this.isValidDateIso(value) || this.isValidExtendedIso(value)) {
 
-        if (this.isValidDateIso(value)) {
-          this.isExtendedISO = false;
-        } else {
+        if (this.isValidExtendedIso(value)) {
           this.hour = value.substring(10, 25);
-          this.isExtendedISO = true;
         }
+
+        if (this.isoFormat === undefined) {
+          this.isExtendedISO = this.isValidExtendedIso(value);
+        }
+
         const day = parseInt(value.substring(8, 10), 10);
         const month = parseInt(value.substring(5, 7), 10) - 1;
         const year = parseInt(value.substring(0, 4), 10);

--- a/projects/ui/src/lib/components/po-field/po-datepicker/samples/sample-po-datepicker-labs/sample-po-datepicker-labs.component.html
+++ b/projects/ui/src/lib/components/po-field/po-datepicker/samples/sample-po-datepicker-labs/sample-po-datepicker-labs.component.html
@@ -8,6 +8,7 @@
   [p-error-pattern]="errorPattern"
   [p-format]="format"
   [p-help]="help"
+  [p-iso-format]="isoFormat"
   [p-label]="label"
   [p-locale]="locale"
   [p-min-date]="minDate"
@@ -98,17 +99,6 @@
   </div>
 
   <div class="po-row">
-    <po-checkbox-group
-      class="po-sm-12"
-      name="properties"
-      [(ngModel)]="properties"
-      p-columns="4"
-      p-label="Properties"
-      [p-options]="propertiesOptions">
-    </po-checkbox-group>
-  </div>
-
-  <div class="po-row">
     <po-radio-group
       class="po-md-6"
       name="format"
@@ -126,6 +116,26 @@
       p-label="Locale"
       [p-options]="localeOptions">
     </po-radio-group>
+  </div>
+
+  <div class="po-row">
+    <po-radio-group
+      class="po-md-4"
+      name="isoFormat"
+      [(ngModel)]="isoFormat"
+      p-columns="1"
+      p-label="Iso Format"
+      [p-options]="isoFormatOptions">
+    </po-radio-group>
+
+    <po-checkbox-group
+      class="po-sm-8"
+      name="properties"
+      [(ngModel)]="properties"
+      p-columns="3"
+      p-label="Properties"
+      [p-options]="propertiesOptions">
+    </po-checkbox-group>
   </div>
 
   <div class="po-row">

--- a/projects/ui/src/lib/components/po-field/po-datepicker/samples/sample-po-datepicker-labs/sample-po-datepicker-labs.component.ts
+++ b/projects/ui/src/lib/components/po-field/po-datepicker/samples/sample-po-datepicker-labs/sample-po-datepicker-labs.component.ts
@@ -1,6 +1,6 @@
 import { Component, OnInit } from '@angular/core';
 
-import { PoCheckboxGroupOption, PoRadioGroupOption } from '@portinari/portinari-ui';
+import { PoCheckboxGroupOption, PoDatepickerIsoFormat, PoRadioGroupOption } from '@portinari/portinari-ui';
 
 @Component({
   selector: 'sample-po-datepicker-labs',
@@ -14,11 +14,17 @@ export class SamplePoDatepickerLabsComponent implements OnInit {
   event: string;
   format: string;
   help: string;
+  isoFormat: PoDatepickerIsoFormat;
   label: string;
   locale: string;
   placeholder: string;
   properties: Array<string>;
   minDate: string | Date;
+
+  public readonly isoFormatOptions: Array<PoRadioGroupOption> = [
+    { label: 'Basic', value: PoDatepickerIsoFormat.Basic },
+    { label: 'Extended', value: PoDatepickerIsoFormat.Extended }
+  ];
 
   public readonly propertiesOptions: Array<PoCheckboxGroupOption> = [
     { value: 'clean', label: 'Clean' },
@@ -56,6 +62,7 @@ export class SamplePoDatepickerLabsComponent implements OnInit {
     this.errorPattern = undefined;
     this.format = undefined;
     this.help = undefined;
+    this.isoFormat = undefined;
     this.label = undefined;
     this.locale = undefined;
     this.placeholder = undefined;


### PR DESCRIPTION
**DATEPICKER**

**DTHFUI-2017**
_____________________________________________________________________________

**PR Checklist**

- [X] Código
- [X] Testes unitários
- [X] Documentação
- [X] Samples

**Qual o comportamento atual?**
Atualmente o formato de saída do model se ajusta conforme o formato de entrada.

**Qual o novo comportamento?**
- Definida nova propriedade `p-iso-format` para controle de formato de saída do model independentemente do valor de entrada recebido;
- Definido enum `PoDatepickerIsoFormat` para set de valor para a propriedade `p-iso-format`.

Obs.: Definido com o time que `PoDatepickerIsoFormat` seria mais apropriado e intuitivo do que definição `boolean` para `p-iso-format`.

**Simulação**
Sample Labs contém radio group para definição de saída do model.