### PR TITLE
feat(dynamic-form): permite atribuir foco nos campos

### DIFF
--- a/projects/ui/src/lib/components/po-dynamic/po-dynamic-form/po-dynamic-form-base.component.ts
+++ b/projects/ui/src/lib/components/po-dynamic/po-dynamic-form/po-dynamic-form-base.component.ts
@@ -21,6 +21,22 @@ export class PoDynamicFormBaseComponent {
   private _groupForm?: boolean = false;
 
   /**
+   * @optional
+   *
+   * @description
+   *
+   * Nome da propriedade, atribuída ao `PoDynamicFormField.property`, que iniciará o campo com foco.
+   *
+   * > Não é possivel iniciar os componentes abaixo com foco:
+   *  - `po-checkbox-group`
+   *  - `po-combo`
+   *  - `po-radio-group`
+   *  - `po-select`
+   *  - `po-switch`
+   */
+  @Input('p-auto-focus') autoFocus?: string;
+
+  /**
    * @description
    *
    * Coleção de objetos que implementam a interface `PoDynamicFormField`, para definição dos campos que serão criados

--- a/projects/ui/src/lib/components/po-dynamic/po-dynamic-form/po-dynamic-form-field.interface.ts
+++ b/projects/ui/src/lib/components/po-dynamic/po-dynamic-form/po-dynamic-form-field.interface.ts
@@ -80,7 +80,7 @@ export interface PoDynamicFormField extends PoDynamicField {
   /** Valor mínimo a ser informado no componente, podendo ser utilizado quando o tipo de dado por *number*, *date* ou *dateTime*. */
   minValue?: string | number;
 
-  /** Quantidade de linhas exibidas no po-textarea */
+  /** Quantidade de linhas exibidas no `po-textarea`. */
   rows?: number;
 
   /** Esconde a informação estilo *password*, pode ser utilizado quando o tipo de dado for *string*. */

--- a/projects/ui/src/lib/components/po-dynamic/po-dynamic-form/po-dynamic-form-fields/po-dynamic-form-field-internal.interface.ts
+++ b/projects/ui/src/lib/components/po-dynamic/po-dynamic-form/po-dynamic-form-fields/po-dynamic-form-field-internal.interface.ts
@@ -15,4 +15,16 @@ export interface PoDynamicFormFieldInternal extends PoDynamicFormField {
   // camponente a ser utilizado.
   control?: string;
 
+  /**
+   * Aplica foco no campo quando o componente for iniciado.
+   *
+   * > Os seguintes componentes ainda não contemplam esta propriedade:
+   *  - `po-checkbox-group`
+   *  - `po-combo`
+   *  - `po-radio-group`
+   *  - `po-select`
+   *  - `po-switch`
+   */
+  focus?: boolean;
+
 }

--- a/projects/ui/src/lib/components/po-dynamic/po-dynamic-form/po-dynamic-form-fields/po-dynamic-form-fields-base.component.spec.ts
+++ b/projects/ui/src/lib/components/po-dynamic/po-dynamic-form/po-dynamic-form-fields/po-dynamic-form-fields-base.component.spec.ts
@@ -28,7 +28,7 @@ describe('PoDynamicFormFieldsBaseComponent:', () => {
     expect(component).toBeTruthy();
   });
 
-  describe('Properties: ', () => {
+  describe('Properties:', () => {
     it('fields: should set `fields` to `[]` if not Array value' , () => {
       const invalidValues = [undefined, null, '', true, false, 0, 1, 'string', {}];
 
@@ -133,13 +133,14 @@ describe('PoDynamicFormFieldsBaseComponent:', () => {
       expect(convertedOptions.length).toBe(options.length);
     });
 
-    it(`createField: should call 'getGridColumnsClasses', and not call 'convertOptions' and return an
-      object that overrides the values of the same properties`, () => {
+    it(`createField: should call 'getGridColumnsClasses' and 'hasFocus', not call 'convertOptions' and return an
+      object that overrides the values of the same properties.`, () => {
       const field = { property: 'propertyName', label: 'labelName' };
 
       const spyTitleCasePipeTransform = spyOn(component['titleCasePipe'], 'transform').and.returnValue('propertyName');
       const spyGetGridColumnsClasses = spyOn(PoDynamicUtil, 'getGridColumnsClasses').and.callThrough();
       const spyConvertOptions = spyOn(component, <any> 'convertOptions').and.callThrough();
+      const spyHasFocus = spyOn(component, <any> 'hasFocus');
 
       const newField = component['createField'](field);
 
@@ -150,15 +151,17 @@ describe('PoDynamicFormFieldsBaseComponent:', () => {
       expect(spyTitleCasePipeTransform).toHaveBeenCalled();
       expect(spyGetGridColumnsClasses).toHaveBeenCalled();
       expect(spyConvertOptions).not.toHaveBeenCalled();
+      expect(spyHasFocus).toHaveBeenCalled();
     });
 
-    it(`createField: should call 'getGridColumnsClasses', 'convertOptions' and return an
+    it(`createField: should call 'getGridColumnsClasses', 'convertOptions', 'hasFocus' and return an
       object that overrides the values of the same properties`, () => {
       const field = { property: 'propertyName', label: 'labelName', options: ['Option 1', 'Option 2'] };
 
       const spyTitleCasePipeTransform = spyOn(component['titleCasePipe'], 'transform').and.returnValue('propertyName');
       const spyGetGridColumnsClasses = spyOn(PoDynamicUtil, 'getGridColumnsClasses').and.callThrough();
       const spyConvertOptions = spyOn(component, <any> 'convertOptions').and.callThrough();
+      const spyHasFocus = spyOn(component, <any> 'hasFocus');
 
       const newField = component['createField'](field);
 
@@ -169,6 +172,31 @@ describe('PoDynamicFormFieldsBaseComponent:', () => {
       expect(spyTitleCasePipeTransform).toHaveBeenCalled();
       expect(spyGetGridColumnsClasses).toHaveBeenCalled();
       expect(spyConvertOptions).toHaveBeenCalled();
+      expect(spyHasFocus).toHaveBeenCalled();
+    });
+
+    it(`hasFocus: should return true if 'autoFocus' is equal to 'field.property'`, () => {
+      const field = { property: 'field' };
+
+      component.autoFocus = 'field';
+
+      expect(component['hasFocus'](field)).toBe(true);
+    });
+
+    it(`hasFocus: should return undefined if 'autoFocus' is undefined`, () => {
+      const field = { property: 'field' };
+
+      component.autoFocus = undefined;
+
+      expect(component['hasFocus'](field)).toBe(false);
+    });
+
+    it(`hasFocus: should return undefined if 'autoFocus' isn't equal to 'field.property'`, () => {
+      const field = { property: 'field' };
+
+      component.autoFocus = 'otherField';
+
+      expect(component['hasFocus'](field)).toBe(false);
     });
 
     it('existsProperty: should return `true` if property exists in fields', () => {

--- a/projects/ui/src/lib/components/po-dynamic/po-dynamic-form/po-dynamic-form-fields/po-dynamic-form-fields-base.component.ts
+++ b/projects/ui/src/lib/components/po-dynamic/po-dynamic-form/po-dynamic-form-fields/po-dynamic-form-fields-base.component.ts
@@ -15,6 +15,8 @@ export class PoDynamicFormFieldsBaseComponent {
 
   visibleFields: Array<PoDynamicFormFieldInternal> = [];
 
+  @Input('p-auto-focus') autoFocus?: string;
+
   // array de objetos que implementam a interface PoDynamicFormField, que serão exibidos no componente.
   @Input('p-fields') set fields(value: Array<PoDynamicFormField>) {
     this._fields = Array.isArray(value) ? [...value] : [];
@@ -77,6 +79,7 @@ export class PoDynamicFormFieldsBaseComponent {
   private createField(field: PoDynamicFormField): PoDynamicFormFieldInternal {
     const control = this.getComponentControl(field);
     const options = !!field.options ? this.convertOptions(field.options) : undefined;
+    const focus = this.hasFocus(field);
 
     const componentClass = getGridColumnsClasses(field.gridSmColumns,
       field.gridMdColumns,
@@ -89,6 +92,7 @@ export class PoDynamicFormFieldsBaseComponent {
       ...field,
       componentClass,
       control,
+      focus,
       options
     };
   }
@@ -134,6 +138,10 @@ export class PoDynamicFormFieldsBaseComponent {
     }
 
     return 'input';
+  }
+
+  private hasFocus(field: PoDynamicFormField) {
+    return !!this.autoFocus && this.autoFocus === field.property;
   }
 
   private isCheckboxGroup(field: PoDynamicFormField) {

--- a/projects/ui/src/lib/components/po-dynamic/po-dynamic-form/po-dynamic-form-fields/po-dynamic-form-fields.component.html
+++ b/projects/ui/src/lib/components/po-dynamic/po-dynamic-form/po-dynamic-form-fields/po-dynamic-form-fields.component.html
@@ -4,12 +4,13 @@
     <po-divider *ngIf="field?.divider?.trim()" class="po-sm-12" [p-label]="field.divider">
     </po-divider>
 
-    <po-datepicker *ngIf="compareTo(field.control, 'datepicker')"
+    <po-datepicker #component *ngIf="compareTo(field.control, 'datepicker')"
       [name]="field.property"
       [(ngModel)]="value[field.property]"
       [ngClass]="field.componentClass"
       p-clean
       [p-disabled]="field.disabled"
+      [p-focus]="field.focus"
       [p-help]="field.help"
       [p-label]="field.label"
       [p-max-date]="field.maxValue"
@@ -17,12 +18,13 @@
       [p-required]="field.required">
     </po-datepicker>
 
-    <po-input *ngIf="compareTo(field.control, 'input')"
+    <po-input #component *ngIf="compareTo(field.control, 'input')"
       [name]="field.property"
       [(ngModel)]="value[field.property]"
       [ngClass]="field.componentClass"
       p-clean
       [p-disabled]="field.disabled"
+      [p-focus]="field.focus"
       [p-help]="field.help"
       [p-label]="field.label"
       [p-mask]="field.mask"
@@ -30,14 +32,15 @@
       [p-minlength]="field.minLength"
       [p-pattern]="field.pattern"
       [p-required]="field.required">
-      </po-input>
+    </po-input>
 
-    <po-number *ngIf="compareTo(field.control, 'number')"
+    <po-number #component *ngIf="compareTo(field.control, 'number')"
       [name]="field.property"
       [(ngModel)]="value[field.property]"
       [ngClass]="field.componentClass"
       p-clean
       [p-disabled]="field.disabled"
+      [p-focus]="field.focus"
       [p-help]="field.help"
       [p-label]="field.label"
       [p-min]="field.minValue"
@@ -47,18 +50,19 @@
       [p-required]="field.required">
     </po-number>
 
-    <po-decimal *ngIf="compareTo(field.control, 'decimal')"
+    <po-decimal #component *ngIf="compareTo(field.control, 'decimal')"
       [name]="field.property"
       [(ngModel)]="value[field.property]"
       [ngClass]="field.componentClass"
       p-clean
       [p-disabled]="field.disabled"
+      [p-focus]="field.focus"
       [p-help]="field.help"
       [p-label]="field.label"
       [p-required]="field.required">
     </po-decimal>
 
-    <po-select *ngIf="compareTo(field.control, 'select')"
+    <po-select #component *ngIf="compareTo(field.control, 'select')"
       [name]="field.property"
       [(ngModel)]="value[field.property]"
       [ngClass]="field.componentClass"
@@ -69,7 +73,7 @@
       [p-required]="field.required">
     </po-select>
 
-    <po-radio-group *ngIf="compareTo(field.control, 'radioGroup')"
+    <po-radio-group #component *ngIf="compareTo(field.control, 'radioGroup')"
       [name]="field.property"
       [(ngModel)]="value[field.property]"
       [ngClass]="field.componentClass"
@@ -81,7 +85,7 @@
       [p-required]="field.required">
     </po-radio-group>
 
-    <po-switch *ngIf="compareTo(field.control, 'switch')"
+    <po-switch #component *ngIf="compareTo(field.control, 'switch')"
       [name]="field.property"
       [(ngModel)]="value[field.property]"
       [ngClass]="field.componentClass"
@@ -92,7 +96,7 @@
       [p-label-on]="field.booleanTrue">
     </po-switch>
 
-    <po-combo *ngIf="compareTo(field.control, 'combo')"
+    <po-combo #component *ngIf="compareTo(field.control, 'combo')"
       [name]="field.property"
       [(ngModel)]="value[field.property]"
       [ngClass]="field.componentClass"
@@ -103,7 +107,7 @@
       [p-required]="field.required">
     </po-combo>
 
-    <po-lookup *ngIf="compareTo(field.control, 'lookup')"
+    <po-lookup #component *ngIf="compareTo(field.control, 'lookup')"
       [name]="field.property"
       [(ngModel)]="value[field.property]"
       p-field-label="label"
@@ -112,12 +116,13 @@
       [p-columns]="field.columns"
       [p-disabled]="field.disabled"
       [p-filter-service]="field.searchService"
+      [p-focus]="field.focus"
       [p-help]="field.help"
       [p-label]="field.label"
       [p-required]="field.required">
     </po-lookup>
 
-    <po-checkbox-group *ngIf="compareTo(field.control, 'checkboxGroup')"
+    <po-checkbox-group #component *ngIf="compareTo(field.control, 'checkboxGroup')"
       [name]="field.property"
       [(ngModel)]="value[field.property]"
       [ngClass]="field.componentClass"
@@ -129,22 +134,24 @@
       [p-required]="field.required">
     </po-checkbox-group>
 
-    <po-multiselect *ngIf="compareTo(field.control, 'multiselect')"
+    <po-multiselect #component *ngIf="compareTo(field.control, 'multiselect')"
       [name]="field.property"
       [(ngModel)]="value[field.property]"
       [ngClass]="field.componentClass"
       [p-disabled]="field.disabled"
+      [p-focus]="field.focus"
       [p-help]="field.help"
       [p-label]="field.label"
       [p-options]="field.options"
       [p-required]="field.required">
     </po-multiselect>
 
-    <po-textarea *ngIf="compareTo(field.control, 'textarea')"
+    <po-textarea #component *ngIf="compareTo(field.control, 'textarea')"
       [name]="field.property"
       [(ngModel)]="value[field.property]"
       [ngClass]="field.componentClass"
       [p-disabled]="field.disabled"
+      [p-focus]="field.focus"
       [p-help]="field.help"
       [p-label]="field.label"
       [p-maxlength]="field.maxLength"
@@ -153,18 +160,19 @@
       [p-rows]="field.rows">
     </po-textarea>
 
-    <po-password *ngIf="compareTo(field.control, 'password')"
+    <po-password #component *ngIf="compareTo(field.control, 'password')"
       [name]="field.property"
       [(ngModel)]="value[field.property]"
       [ngClass]="field.componentClass"
       p-clean
       [p-disabled]="field.disabled"
+      [p-focus]="field.focus"
       [p-help]="field.help"
       [p-label]="field.label"
       [p-maxlength]="field.maxLength"
       [p-minlength]="field.minLength"
       [p-required]="field.required">
-  </po-password>
+    </po-password>
 
   </ng-container>
 </div>

--- a/projects/ui/src/lib/components/po-dynamic/po-dynamic-form/po-dynamic-form-fields/po-dynamic-form-fields.component.spec.ts
+++ b/projects/ui/src/lib/components/po-dynamic/po-dynamic-form/po-dynamic-form-fields/po-dynamic-form-fields.component.spec.ts
@@ -67,6 +67,26 @@ describe('PoDynamicFormFieldsComponent: ', () => {
       expect(component.trackBy(index)).toBe(index);
     });
 
+    it('focus: should call `fieldComponent.focus` if find field by property param.', () => {
+      const fieldComponent = { focus: () => {}, name: 'newField' };
+      component.components = <any>[fieldComponent];
+
+      const spyOnFocus = spyOn(fieldComponent, 'focus');
+      component.focus('newField');
+
+      expect(spyOnFocus).toHaveBeenCalled();
+    });
+
+    it('focus: shouldn´t call `fieldsComponent.focus` if not find field by property param.', () => {
+      const fieldComponent = { focus: () => {}, name: 'newField' };
+      component.components = <any>[fieldComponent];
+
+      const spyOnFocus = spyOn(fieldComponent, 'focus');
+      component.focus('otherField');
+
+      expect(spyOnFocus).not.toHaveBeenCalled();
+    });
+
   });
 
   describe('Templates: ', () => {

--- a/projects/ui/src/lib/components/po-dynamic/po-dynamic-form/po-dynamic-form-fields/po-dynamic-form-fields.component.ts
+++ b/projects/ui/src/lib/components/po-dynamic/po-dynamic-form/po-dynamic-form-fields/po-dynamic-form-fields.component.ts
@@ -1,8 +1,8 @@
-import { Component, SimpleChanges, OnChanges } from '@angular/core';
+import { Component, OnChanges, QueryList, SimpleChanges, ViewChildren } from '@angular/core';
+import { ControlContainer, NgForm } from '@angular/forms';
+import { TitleCasePipe } from '@angular/common';
 
 import { PoDynamicFormFieldsBaseComponent } from './po-dynamic-form-fields-base.component';
-import { TitleCasePipe } from '@angular/common';
-import { ControlContainer, NgForm } from '@angular/forms';
 
 /**
  * @docsPrivate
@@ -18,6 +18,8 @@ import { ControlContainer, NgForm } from '@angular/forms';
 })
 export class PoDynamicFormFieldsComponent extends PoDynamicFormFieldsBaseComponent implements OnChanges {
 
+  @ViewChildren('component') components: QueryList<{ name: string, focus: () => void }>;
+
   constructor(titleCasePipe: TitleCasePipe) {
     super(titleCasePipe);
   }
@@ -25,6 +27,13 @@ export class PoDynamicFormFieldsComponent extends PoDynamicFormFieldsBaseCompone
   ngOnChanges(changes: SimpleChanges) {
     if (changes.fields) {
       this.visibleFields = this.getVisibleFields();
+    }
+  }
+
+  focus(property: string) {
+    const foundComponent = this.components.find(component => component.name === property);
+    if (foundComponent) {
+      foundComponent.focus();
     }
   }
 

--- a/projects/ui/src/lib/components/po-dynamic/po-dynamic-form/po-dynamic-form.component.html
+++ b/projects/ui/src/lib/components/po-dynamic/po-dynamic-form/po-dynamic-form.component.html
@@ -3,7 +3,11 @@
 
 <ng-template #reuseFormTemplate>
 
-  <po-dynamic-form-fields [p-fields]="fields" [p-value]="value"></po-dynamic-form-fields>
+  <po-dynamic-form-fields #fieldsComponent
+    [p-auto-focus]="autoFocus"
+    [p-fields]="fields"
+    [p-value]="value">
+  </po-dynamic-form-fields>
 
 </ng-template>
 
@@ -11,7 +15,11 @@
 
   <form #dynamicForm="ngForm">
 
-    <po-dynamic-form-fields [p-fields]="fields" [p-value]="value"></po-dynamic-form-fields>
+    <po-dynamic-form-fields #fieldsComponent
+      [p-auto-focus]="autoFocus"
+      [p-fields]="fields"
+      [p-value]="value">
+    </po-dynamic-form-fields>
 
   </form>
 

--- a/projects/ui/src/lib/components/po-dynamic/po-dynamic-form/po-dynamic-form.component.spec.ts
+++ b/projects/ui/src/lib/components/po-dynamic/po-dynamic-form/po-dynamic-form.component.spec.ts
@@ -7,7 +7,7 @@ import { PoDynamicFormBaseComponent } from './po-dynamic-form-base.component';
 import { PoDynamicFormComponent } from './po-dynamic-form.component';
 import { PoDynamicModule } from '../po-dynamic.module';
 
-describe('PoDynamicFormComponent: ', () => {
+describe('PoDynamicFormComponent:', () => {
   let component: PoDynamicFormComponent;
   let fixture: ComponentFixture<PoDynamicFormComponent>;
 
@@ -33,7 +33,7 @@ describe('PoDynamicFormComponent: ', () => {
     expect(component instanceof PoDynamicFormBaseComponent).toBeTruthy();
   });
 
-  describe('Properties: ', () => {
+  describe('Properties:', () => {
 
     it('form: should call `emitForm` and set property', fakeAsync(() => {
       spyOn(component, <any> 'emitForm');
@@ -52,7 +52,7 @@ describe('PoDynamicFormComponent: ', () => {
 
   });
 
-  describe('Methods: ', () => {
+  describe('Methods:', () => {
 
     it('emitForm: should call `formOutput.emit` if contains `formOutput.observers`', () => {
       const fakeThis = { formOutput: { observers: [{}], emit: () => {} } };
@@ -74,9 +74,17 @@ describe('PoDynamicFormComponent: ', () => {
       expect(fakeThis.formOutput.emit).not.toHaveBeenCalled();
     });
 
+    it('focus: should call `fieldsComponent.focus`.', () => {
+      const spyFieldsComponentFocus = spyOn(component.fieldsComponent, 'focus');
+
+      component.focus('field');
+
+      expect(spyFieldsComponentFocus).toHaveBeenCalled();
+    });
+
   });
 
-  describe('Templates: ', () => {
+  describe('Templates:', () => {
 
     it('should find `form` and `po-dynamic-form-fields` tags if `groupForm` is falsy', () => {
       component.fields = [];

--- a/projects/ui/src/lib/components/po-dynamic/po-dynamic-form/po-dynamic-form.component.ts
+++ b/projects/ui/src/lib/components/po-dynamic/po-dynamic-form/po-dynamic-form.component.ts
@@ -40,6 +40,40 @@ export class PoDynamicFormComponent extends PoDynamicFormBaseComponent {
     return this._form || <any> {};
   }
 
+  @ViewChild('fieldsComponent', { static: false }) fieldsComponent: {focus: (property: string) => void };
+
+  /**
+   * Função que atribui foco ao campo desejado.
+   *
+   * Para utilizá-la é necessário capturar a instância do `dynamic form`, como por exemplo:
+   *
+   * ``` html
+   * <po-dynamic-form #dynamicForm [p-fields]="fields"></po-dynamic-form>
+   * ```
+   *
+   * ``` javascript
+   * import { PoDynamicFormComponent, PoDynamicFormField } from '@portinari/portinari-ui';
+   *
+   * ...
+   *
+   * @ViewChild('dynamicForm', { static: true }) dynamicForm: PoDynamicFormComponent;
+   *
+   * fields: Array<PoDynamicFormField> = [
+   *   { property: 'fieldOne' },
+   *   { property: 'fieldTwo' }
+   * ];
+   *
+   * fieldFocus() {
+   *   this.dynamicForm.focus('fieldTwo');
+   * }
+   * ```
+   *
+   * @param {string} property Nome da propriedade atribuída ao `PoDynamicFormField.property`.
+   */
+  focus(property: string) {
+    this.fieldsComponent.focus(property);
+  }
+
   private emitForm() {
     if (!this.groupForm && this.formOutput.observers.length) {
       this.formOutput.emit(this.form);

--- a/projects/ui/src/lib/components/po-dynamic/po-dynamic-form/samples/sample-po-dynamic-form-register/sample-po-dynamic-form-register.component.html
+++ b/projects/ui/src/lib/components/po-dynamic/po-dynamic-form/samples/sample-po-dynamic-form-register/sample-po-dynamic-form-register.component.html
@@ -1,4 +1,5 @@
 <po-dynamic-form #dynamicForm
+  p-auto-focus="name"
   [p-fields]="fields"
   [p-value]="person">
 </po-dynamic-form>
@@ -6,7 +7,7 @@
 <div class="po-row">
   <po-button
     class="po-md-3"
-    p-label="Salvar"
+    p-label="Save"
     [p-disabled]="dynamicForm?.form.invalid"
     (p-click)="poNotification.success('Data saved successfully!'); dynamicForm.form.reset()">
   </po-button>

--- a/projects/ui/src/lib/components/po-field/po-combo/interfaces/po-combo-filter.interface.ts
+++ b/projects/ui/src/lib/components/po-field/po-combo/interfaces/po-combo-filter.interface.ts
@@ -15,8 +15,8 @@ export interface PoComboFilter {
    * Método responsável por retornar um Observable que contém uma coleção de objetos que seguem a interface PoComboOption,
    * será informado por parametro o campo, de acordo com o fieldLabel, e o valor a ser pesquisado.
    *
-   * @param params {any} Objeto contendo a propriedade e o valor responsável por realizar o filtro.
-   * @param filterParams {any} Valor informado através da propriedade `p-filter-params`.
+   * @param {any} params Objeto contendo a propriedade e o valor responsável por realizar o filtro.
+   * @param {any} filterParams Valor informado através da propriedade `p-filter-params`.
    */
   getFilteredData(params: any, filterParams?: any): Observable<Array<PoComboOption>>;
 
@@ -24,8 +24,8 @@ export interface PoComboFilter {
    * Método responsável por retornar um Observable que contém apenas o objeto filtrado que seguem a interface PoComboOption,
    * será informado por parametro valor a ser pesquisado.
    *
-   * @param value {string | number} Valor responsável por realizar a busca de um único objeto.
-   * @param filterParams {any} Valor informado através da propriedade `p-filter-params`.
+   * @param {string | number} value Valor responsável por realizar a busca de um único objeto.
+   * @param {any} filterParams Valor informado através da propriedade `p-filter-params`.
    */
   getObjectByValue(value: string | number, filterParams?: any): Observable<PoComboOption>;
 

--- a/projects/ui/src/lib/components/po-stepper/po-stepper.component.ts
+++ b/projects/ui/src/lib/components/po-stepper/po-stepper.component.ts
@@ -65,7 +65,7 @@ export class PoStepperComponent extends PoStepperBaseComponent implements AfterC
    *
    * > Este método é valido apenas para as implementações que utilizam o componente [**po-step**](/documentation/po-step).
    *
-   * @param index {number} Índice do `po-step` que se deseja ativar.
+   * @param {number} index Índice do `po-step` que se deseja ativar.
    */
   active(index: number): void {
     if (!this.usePoSteps) {

--- a/projects/ui/src/lib/services/po-i18n/po-i18n-base.service.ts
+++ b/projects/ui/src/lib/services/po-i18n/po-i18n-base.service.ts
@@ -177,9 +177,7 @@ export class PoI18nBaseService {
    *
    * > Caso o idioma do navegador não seja suportado pelo PO (`pt`, `en` ou `es`), será retornado valor `pt`.
    *
-   * **Retorno:**
-   *
-   * `string` com a sigla do idioma padrão.
+   * @returns {string} sigla do idioma padrão.
    */
   getLanguage(): string {
     return this.languageService.getLanguage();
@@ -191,9 +189,7 @@ export class PoI18nBaseService {
    *
    * A busca deste idioma é baseada no método [**getLanguage()**](/documentation/po-i18n#get-language).
    *
-   * **Retorno:**
-   *
-   * `string` com a sigla do idioma padrão.
+   * @returns {string} sigla do idioma padrão.
    */
   getShortLanguage(): string {
     return this.languageService.getShortLanguage();
@@ -206,14 +202,14 @@ export class PoI18nBaseService {
    * Ao utilizar este método, o idioma ficará gravado no armazenamento local do navegador, que será utilizado pelo
    * serviço do `i18n` para buscar as literais no idioma padrão.
    *
-   * @param language {string} Sigla do idioma.
+   * @param {string} language Sigla do idioma.
    *
    * Esta sigla deve ser composta por duas letras representando o idioma,
    * podendo ser adicionado outras duas letras representando o país, por exemplo: `pt`, `pt-BR`, `pt-br`, `en` ou `en-US`.
    *
    * > Caso seja informado um valor diferente deste padrão, o mesmo será ignorado.
    *
-   * @param reload {boolean} Indica se a página atual poderá ser recarregada após a alteração do idioma.
+   * @param {boolean} reload Indica se a página atual poderá ser recarregada após a alteração do idioma.
    *
    * Este recurso pode ser útil para os usuários que utilizam o método `getLiterals()` do serviço do i18n para poder
    * buscar novamente as literais no novo idioma configurado.

--- a/projects/ui/src/lib/services/po-notification/po-notification-base.service.ts
+++ b/projects/ui/src/lib/services/po-notification/po-notification-base.service.ts
@@ -36,7 +36,7 @@ export abstract class PoNotificationBaseService {
   /**
    * Emite uma notificação de sucesso.
    *
-   * @param notification {PoNotification | string} Objeto com os dados da notificação ou somente a string com a mensagem da notificação.
+   * @param {PoNotification | string} notification Objeto com os dados da notificação ou somente a string com a mensagem da notificação.
    */
   public success(notification: PoNotification | string) {
     this.createToaster(this.buildToaster(notification, PoToasterType.Success));
@@ -45,7 +45,7 @@ export abstract class PoNotificationBaseService {
   /**
    * Emite uma notificação de atenção.
    *
-   * @param notification {PoNotification | string} Objeto com os dados da notificação ou somente a string com a mensagem da notificação
+   * @param {PoNotification | string} notification Objeto com os dados da notificação ou somente a string com a mensagem da notificação
    */
   public warning(notification: PoNotification | string) {
     this.createToaster(this.buildToaster(notification, PoToasterType.Warning));
@@ -54,7 +54,7 @@ export abstract class PoNotificationBaseService {
   /**
    * Emite uma notificação de erro.
    *
-   * @param notification {PoNotification | string} Objeto com os dados da notificação ou somente a string com a mensagem da notificação
+   * @param {PoNotification | string} notification Objeto com os dados da notificação ou somente a string com a mensagem da notificação
    */
   public error(notification: PoNotification | string) {
     this.createToaster(this.buildToaster(notification, PoToasterType.Error));
@@ -63,7 +63,7 @@ export abstract class PoNotificationBaseService {
   /**
    * Emite uma notificação de informação.
    *
-   * @param notification {PoNotification | string} Objeto com os dados da notificação ou somente a string com a mensagem da notificação
+   * @param {PoNotification | string} notification Objeto com os dados da notificação ou somente a string com a mensagem da notificação
    */
   public information(notification: PoNotification | string) {
     this.createToaster(this.buildToaster(notification, PoToasterType.Information));
@@ -74,7 +74,7 @@ export abstract class PoNotificationBaseService {
    *
    * > Padrão 10 segundos.
    *
-   * @param defaultDuration {number} Duração em milisegundos
+   * @param {number} defaultDuration Duração em milisegundos
    */
   public setDefaultDuration(defaultDuration: number) {
     this.defaultDuration = defaultDuration;
@@ -85,7 +85,7 @@ export abstract class PoNotificationBaseService {
    *
    * Cria um objeto do tipo PoToaster de acordo o tipo.
    *
-   * @param notification {PoNotification | string} Objeto PoNotification com os dados da notificação
+   * @param {PoNotification | string} notification Objeto PoNotification com os dados da notificação
    */
   private buildToaster(notification: PoNotification | string, type: PoToasterType): PoToaster {
     let index = 0;
@@ -126,7 +126,7 @@ export abstract class PoNotificationBaseService {
    *
    * Método responsável por criar o po-toaster.
    *
-   * @param toaster {PoToaster} Objeto contendo as informações do toaster.
+   * @param {PoToaster} toaster Objeto contendo as informações do toaster.
    */
   abstract createToaster(toaster: PoToaster): void;
 
@@ -135,8 +135,8 @@ export abstract class PoNotificationBaseService {
    *
    * Método responsável por destruir o po-toaster.
    *
-   * @param toaster {ComponentRef} Número da posição ou instancia do toaster a ser destruído.
-   * @param orientation {PoToasterOrientation} Orientação do PoToaster: Top ou Bottom
+   * @param {ComponentRef} toaster Número da posição ou instancia do toaster a ser destruído.
+   * @param {PoToasterOrientation} orientation Orientação do PoToaster: Top ou Bottom
    */
   abstract destroyToaster(toaster: ComponentRef<any>): void;
 

--- a/projects/ui/tsconfig.lib.json
+++ b/projects/ui/tsconfig.lib.json
@@ -13,7 +13,7 @@
     ]
   },
   "angularCompilerOptions": {
-    "annotateForClosureCompiler": true,
+    "annotateForClosureCompiler": false,
     "skipTemplateCodegen": true,
     "strictMetadataEmit": true,
     "fullTemplateTypeCheck": true,


### PR DESCRIPTION
**PO-DYNAMIC-FORM**

**DTHFUI-2415**

***

**PR Checklist**

- [x] Código
- [x] Testes unitários
- [x] Documentação
- [x] Samples

***

**Qual o comportamento atual?**
O componente não permite atribuir foco ao campo na inicialização ou mesmo através de um método.

**Qual o novo comportamento?**
Agora é possível atribuir foco ao campo desejado. Isto poderá ser feito na inicialização do componente através da propriedade `p-auto-focus` atribuindo o nome do campo à ela ou, disparando o método `focus` e passando como parâmetro o nome do campo.

**Simulação**
Utilizar os samples do *dynamic form*.