### PR TITLE
feat(table): adiciona p-expanded e p-collapsed

### DIFF
--- a/projects/ui/src/lib/components/po-table/po-table-base.component.spec.ts
+++ b/projects/ui/src/lib/components/po-table/po-table-base.component.spec.ts
@@ -863,71 +863,210 @@ describe('PoTableBaseComponent:', () => {
       expect(component.showMore.emit).toHaveBeenCalledWith(undefined);
     });
 
+    describe('toggleDetail:', () => {
+      it('should change status of row with detail', () => {
+        const currentRow = {
+          id: 1,
+          $selected: true,
+          details: [{ id: 4 }],
+          $showDetail: true
+        };
+        component.toggleDetail(currentRow);
+        expect(currentRow.$showDetail).toBeFalsy();
+      });
+    });
+
+    describe('expand:', () => {
+      it('should expand a row with detail and emit a expanded event', () => {
+        const currentRow = {
+          id: 2,
+          $selected: true,
+          details: [{ id: 5 }],
+          $showDetail: false
+        };
+        const spyEmit = spyOn(component.expanded, 'emit');
+        component.expand(currentRow);
+        expect(spyEmit).toHaveBeenCalledWith(currentRow);
+      });
+
+      it('with index: should expand a row with detail and emit a expanded event', () => {
+        const rows = [{
+          id: 1,
+          $selected: true,
+          details: [{ id: 4 }],
+          $showDetail: true
+        }, {
+          id: 2,
+          $selected: true,
+          details: [{ id: 5 }],
+          $showDetail: false
+        }];
+
+        component.items = rows;
+        const spyEmit = spyOn(component.expanded, 'emit');
+        component.expand(1);
+        expect(spyEmit).toHaveBeenCalledWith(rows[1]);
+      });
+
+      it('with index: should set row to zero if you call with a negative index', () => {
+        const rows = [{
+          id: 1,
+          $selected: true,
+          details: [{ id: 4 }],
+          $showDetail: true
+        }, {
+          id: 2,
+          $selected: true,
+          details: [{ id: 5 }],
+          $showDetail: false
+        }];
+
+        component.items = rows;
+        const spyEmit = spyOn(component.expanded, 'emit');
+        component.expand(-10);
+        expect(spyEmit).toHaveBeenCalledWith(rows[0]);
+      });
+    });
+
+    describe('collapse:', () => {
+      it('should collapse a row with detail and emit a expanded event', () => {
+        const currentRow = {
+          id: 2,
+          $selected: true,
+          details: [{ id: 5 }],
+          $showDetail: false
+        };
+        const spyEmit = spyOn(component.collapsed, 'emit');
+        component.collapse(currentRow);
+        expect(spyEmit).toHaveBeenCalledWith(currentRow);
+      });
+
+      it('with index: should collapse a row with detail and emit a expanded event', () => {
+        const rows = [{
+          id: 1,
+          $selected: true,
+          details: [{ id: 4 }],
+          $showDetail: true
+        }, {
+          id: 2,
+          $selected: true,
+          details: [{ id: 5 }],
+          $showDetail: false
+        }];
+
+        component.items = rows;
+        const spyEmit = spyOn(component.collapsed, 'emit');
+        component.collapse(1);
+        expect(spyEmit).toHaveBeenCalledWith(rows[1]);
+      });
+
+      it('with index: should set row to zero if you call with a negative index', () => {
+        const rows = [{
+          id: 1,
+          $selected: true,
+          details: [{ id: 4 }],
+          $showDetail: true
+        }, {
+          id: 2,
+          $selected: true,
+          details: [{ id: 5 }],
+          $showDetail: false
+        }];
+
+        component.items = rows;
+        const spyEmit = spyOn(component.collapsed, 'emit');
+        component.collapse(-10);
+        expect(spyEmit).toHaveBeenCalledWith(rows[0]);
+      });
+
+      it('with index: should handle when an invalid index is sent', () => {
+        const rows = [{
+          id: 1,
+          $selected: true,
+          details: [{ id: 4 }],
+          $showDetail: true
+        }];
+        spyOn((component as any), 'changeShowDetail').and.callThrough();
+
+        component.items = rows;
+        component.collapse(55);
+
+        expect((component as any).changeShowDetail).toHaveBeenCalled();
+      });
+    });
+
   });
 
   describe('Properties:', () => {
     const booleanValidTrueValues = [true, 'true', 1, ''];
     const booleanInvalidValues = [undefined, null, NaN, 2, 'string'];
 
-    it('p-literals: should be in portuguese if browser is setted with an unsupported language', () => {
-      spyOn(utilsFunctions, <any>'browserLanguage').and.returnValue('zw');
+    describe('p-literals:', () => {
+      it('should be in portuguese if browser is setted with an unsupported language', () => {
+        spyOn(utilsFunctions, <any>'browserLanguage').and.returnValue('zw');
 
-      component.literals = {};
+        component.literals = {};
 
-      expect(component.literals).toEqual(poTableLiteralsDefault[poLocaleDefault]);
-    });
+        expect(component.literals).toEqual(poTableLiteralsDefault[poLocaleDefault]);
+      });
 
-    it('p-literals: should be in portuguese if browser is setted with `pt`', () => {
-      spyOn(utilsFunctions, <any>'browserLanguage').and.returnValue('pt');
+      it('should be in portuguese if browser is setted with `pt`', () => {
+        spyOn(utilsFunctions, <any>'browserLanguage').and.returnValue('pt');
 
-      component.literals = {};
+        component.literals = {};
 
-      expect(component.literals).toEqual(poTableLiteralsDefault.pt);
-    });
+        expect(component.literals).toEqual(poTableLiteralsDefault.pt);
+      });
 
-    it('p-literals: should be in english if browser is setted with `en`', () => {
-      spyOn(utilsFunctions, <any>'browserLanguage').and.returnValue('en');
+      it('should be in english if browser is setted with `en`', () => {
+        spyOn(utilsFunctions, <any>'browserLanguage').and.returnValue('en');
 
-      component.literals = {};
+        component.literals = {};
 
-      expect(component.literals).toEqual(poTableLiteralsDefault.en);
-    });
+        expect(component.literals).toEqual(poTableLiteralsDefault.en);
+      });
 
-    it('p-literals: should be in spanish if browser is setted with `es`', () => {
-      spyOn(utilsFunctions, <any>'browserLanguage').and.returnValue('es');
+      it('should be in spanish if browser is setted with `es`', () => {
+        spyOn(utilsFunctions, <any>'browserLanguage').and.returnValue('es');
 
-      component.literals = {};
+        component.literals = {};
 
-      expect(component.literals).toEqual(poTableLiteralsDefault.es);
-    });
+        expect(component.literals).toEqual(poTableLiteralsDefault.es);
+      });
 
-    it('p-literals: should be in russian if browser is setted with `ru`', () => {
-      spyOn(utilsFunctions, <any>'browserLanguage').and.returnValue('ru');
+      it('should be in russian if browser is setted with `ru`', () => {
+        spyOn(utilsFunctions, <any>'browserLanguage').and.returnValue('ru');
 
-      component.literals = {};
+        component.literals = {};
 
-      expect(component.literals).toEqual(poTableLiteralsDefault.ru);
-    });
+        expect(component.literals).toEqual(poTableLiteralsDefault.ru);
+      });
 
-    it('p-literals: should accept custom literals', () => {
-      spyOn(utilsFunctions, <any>'browserLanguage').and.returnValue(poLocaleDefault);
+      it('should accept custom literals', () => {
+        spyOn(utilsFunctions, <any>'browserLanguage').and.returnValue(poLocaleDefault);
 
-      const customLiterals = Object.assign({}, poTableLiteralsDefault[poLocaleDefault]);
+        const customLiterals = Object.assign({}, poTableLiteralsDefault[poLocaleDefault]);
 
-      // Custom some literals
-      customLiterals.noData = 'No data custom';
+        // Custom some literals
+        customLiterals.noData = 'No data custom';
 
-      component.literals = customLiterals;
+        component.literals = customLiterals;
 
-      expect(component.literals).toEqual(customLiterals);
-    });
+        expect(component.literals).toEqual(customLiterals);
+      });
 
-    it('p-literals: should update property with default literals if is setted with invalid values', () => {
-      const invalidValues = [null, undefined, false, true, '', 'literals', 0, 10, [], [1, 2], () => {}];
+      it('should update property with default literals if is setted with invalid values', () => {
+        const invalidValues = [null, undefined, false, true, '', 'literals', 0, 10, [], [1, 2], () => {}];
 
-      spyOn(utilsFunctions, <any>'browserLanguage').and.returnValue(poLocaleDefault);
+        spyOn(utilsFunctions, <any>'browserLanguage').and.returnValue(poLocaleDefault);
 
-      expectPropertiesValues(component, 'literals', invalidValues, poTableLiteralsDefault[poLocaleDefault]);
+        expectPropertiesValues(component, 'literals', invalidValues, poTableLiteralsDefault[poLocaleDefault]);
+      });
+
+      it('should get literals directly from poTableLiteralsDefault if it not initialized', () => {
+        spyOn(utilsFunctions, <any>'browserLanguage').and.returnValue('pt');
+        expect(component.literals).toEqual(poTableLiteralsDefault['pt']);
+      });
     });
 
     it('p-loading: should update property `p-loading` with valid values.', () => {
@@ -1005,7 +1144,6 @@ describe('PoTableBaseComponent:', () => {
 
       expect(component['sortType']).toBe('descending');
     });
-
   });
 
 });

--- a/projects/ui/src/lib/components/po-table/po-table-base.component.ts
+++ b/projects/ui/src/lib/components/po-table/po-table-base.component.ts
@@ -398,19 +398,19 @@ export abstract class PoTableBaseComponent implements OnChanges {
    */
   @Input('p-max-columns') maxColumns?: number;
 
-  /**
-   * Ação executada quando todas as linhas são selecionadas por meio do *checkbox* que seleciona todas as linhas.
-   */
+  /** Ação executada quando todas as linhas são selecionadas por meio do *checkbox* que seleciona todas as linhas. */
   @Output('p-all-selected') allSelected?: EventEmitter<any> = new EventEmitter<any>();
 
-  /**
-   * Ação executada quando a seleção das linhas é desmarcada por meio do *checkbox* que seleciona todas as linhas.
-   */
+  /** Ação executada quando a seleção das linhas é desmarcada por meio do *checkbox* que seleciona todas as linhas. */
   @Output('p-all-unselected') allUnselected?: EventEmitter<any> = new EventEmitter<any>();
 
-  /**
-   * Ação executada ao selecionar uma linha do `po-table`.
-   */
+  /** Ação executada ao colapsar uma linha do `po-table`. */
+  @Output('p-collapsed') collapsed?: EventEmitter<any> = new EventEmitter<any>();
+
+  /** Ação executada ao expandir uma linha do `po-table`. */
+  @Output('p-expanded') expanded?: EventEmitter<any> = new EventEmitter<any>();
+
+  /** Ação executada ao selecionar uma linha do `po-table`. */
   @Output('p-selected') selected?: EventEmitter<any> = new EventEmitter<any>();
 
   /**
@@ -434,9 +434,7 @@ export abstract class PoTableBaseComponent implements OnChanges {
    */
   @Output('p-sort-by') sortBy?: EventEmitter<PoTableColumnSort> = new EventEmitter<PoTableColumnSort>();
 
-  /**
-   * Ação executada ao desmarcar a seleção de uma linha do `po-table`.
-   */
+  /** Ação executada ao desmarcar a seleção de uma linha do `po-table`. */
   @Output('p-unselected') unselected?: EventEmitter<any> = new EventEmitter<any>();
 
   selectAll = false;
@@ -458,6 +456,27 @@ export abstract class PoTableBaseComponent implements OnChanges {
   abstract calculateHeightTableContainer(height);
 
   abstract calculateWidthHeaders();
+
+  private changeShowDetail(row: any, showDetail: boolean) {
+    if (!!row) {
+      row.$showDetail = showDetail;
+      this.emitExpandEvents(row);
+    }
+  }
+
+  /** Método onde usuário pode via programação colapsar o detalhe de uma linha. */
+  collapse(param: any | number) {
+    this.setShowDetail(param, false) ;
+  }
+
+  /** Método onde usuário pode via programação expandir o detalhe de uma linha. */
+  expand(param: any | number) {
+    this.setShowDetail(param, true) ;
+  }
+
+  private emitExpandEvents(row: any) {
+    row.$showDetail ? this.expanded.emit(row) : this.collapsed.emit(row);
+  }
 
   protected abstract showContainer(container);
 
@@ -536,6 +555,11 @@ export abstract class PoTableBaseComponent implements OnChanges {
 
   hasItems(): boolean {
     return this.items && this.items.length > 0;
+  }
+
+  /** Método que expande e colapsa o detalhe da linha. */
+  toggleDetail(row: any) {
+    this.setShowDetail(row, !row.$showDetail) ;
   }
 
   toggleRowAction(row: any) {
@@ -630,6 +654,15 @@ export abstract class PoTableBaseComponent implements OnChanges {
         column['link'] = 'link';
       }
     });
+  }
+
+  private setShowDetail(param: any | number, showDetail: boolean) {
+    if (typeof param === 'number') {
+      const index = param < 0 ? 0 : param;
+      this.changeShowDetail(this.items[index], showDetail);
+    } else {
+      this.changeShowDetail(param, showDetail);
+    }
   }
 
   private unselectOtherRows(rows: Array<any>, row) {

--- a/projects/ui/src/lib/components/po-table/po-table.component.html
+++ b/projects/ui/src/lib/components/po-table/po-table.component.html
@@ -151,7 +151,7 @@
           </td>
           <td *ngIf="(getColumnMasterDetail() !== undefined) && !hideDetail || hasRowTemplate"
             class="po-table-column-detail-toggle"
-            (click)="row.$showDetail = !row.$showDetail">
+            (click)="toggleDetail(row)">
             <span *ngIf="(containsMasterDetail(row) && !hasRowTemplate) || isShowRowTemplate(row, rowIndex) && hasRowTemplate"
               class="po-icon po-clickable"
               [class.po-icon-arrow-up]="row.$showDetail"

--- a/projects/ui/src/lib/components/po-table/samples/sample-po-table-airfare/sample-po-table-airfare.component.html
+++ b/projects/ui/src/lib/components/po-table/samples/sample-po-table-airfare/sample-po-table-airfare.component.html
@@ -16,8 +16,11 @@
   [p-columns]="columns"
   [p-items]="items"
   [p-max-columns]="6"
+  (p-collapsed)="collapseDetail($event)"
+  (p-expanded)="expandDetail($event)"
   (p-selected)="sumTotal($event)"
   (p-unselected)="decreaseTotal($event)">
+
 </po-table>
 
 <po-divider></po-divider>
@@ -29,12 +32,29 @@
   p-value="{{total | currency:'USD'}}">
 </po-info>
 
+<po-info
+  class="po-md-6 po-mb-sm-2 po-mb-md-2 po-lb-lg-2"
+  p-label="Expanded Itens"
+  p-orientation="horizontal"
+  p-value="{{totalExpanded}}">
+</po-info>
+
 <div class="po-row">
   <po-button
     class="po-md-3"
     p-icon="po-icon-cart"
     p-label="Add items to cart"
     (p-click)="addToCart()">
+  </po-button>
+  <po-button
+    class="po-md-3"
+    p-label="Expand all detail"
+    (p-click)="expandAll()">
+  </po-button>
+  <po-button
+    class="po-md-3"
+    p-label="Collapse all detail"
+    (p-click)="collapseAll()">
   </po-button>
 </div>
 

--- a/projects/ui/src/lib/components/po-table/samples/sample-po-table-airfare/sample-po-table-airfare.component.ts
+++ b/projects/ui/src/lib/components/po-table/samples/sample-po-table-airfare/sample-po-table-airfare.component.ts
@@ -26,6 +26,7 @@ export class SamplePoTableAirfareComponent {
   detail: any;
   items: Array<any> = this.sampleAirfare.getItems();
   total: number = 0;
+  totalExpanded = 0;
 
   @ViewChild(PoModalComponent, { static: true }) poModal: PoModalComponent;
   @ViewChild(PoTableComponent, { static: true }) poTable: PoTableComponent;
@@ -65,6 +66,19 @@ export class SamplePoTableAirfareComponent {
     this.items.forEach(item => item.$selected = false);
   }
 
+  collapseAll() {
+    this.items.forEach(item => {
+      if (item.detail) {
+        this.poTable.collapse(item);
+      }
+    });
+  }
+
+  collapseDetail(row: any) {
+    this.totalExpanded -= 1;
+    this.totalExpanded = this.totalExpanded < 0 ? 0 : this.totalExpanded ;
+  }
+
   decreaseTotal(row: any) {
     if (row.value) {
       this.total -= row.value;
@@ -81,6 +95,19 @@ export class SamplePoTableAirfareComponent {
       item.value = item.value - (item.value * 0.2);
       item.disableDiscount = true;
     }
+  }
+
+  expandAll() {
+    this.totalExpanded = 0;
+    this.items.forEach((item, index) => {
+      if (item.detail) {
+        this.poTable.expand(index);
+      }
+    });
+  }
+
+  expandDetail(row: any) {
+    this.totalExpanded += 1;
   }
 
   sumTotal(row: any) {

--- a/projects/ui/src/lib/components/po-table/samples/sample-po-table-labs/sample-po-table-labs.component.html
+++ b/projects/ui/src/lib/components/po-table/samples/sample-po-table-labs/sample-po-table-labs.component.html
@@ -17,6 +17,8 @@
   [p-striped]="properties.includes('striped')"
   (p-all-selected)="changeEvent('p-all-selected')"
   (p-all-unselected)="changeEvent('p-all-unselected')"
+  (p-collapsed)="changeEvent('p-collapsed')"
+  (p-expanded)="changeEvent('p-expanded')"
   (p-selected)="changeEvent('p-selected')"
   (p-show-more)="showMore()"
   (p-unselected)="changeEvent('p-unselected')">


### PR DESCRIPTION
**TABLE**

**DTHFUI-1609**
_____________________________________________________________________________

**PR Checklist**

- [X] Código
- [X] Testes unitários
- [X] Documentação
- [X] Samples

**Qual o comportamento atual?**
Ao utilizar o thf-table há a possibilidade de incluir os registros com uma setinha para expansão dos mesmos.
Atualmente não há um evento que seja disparado ao realizar esta expansão, não sendo possível identificar qual registro exato que está sendo expandido.

**Qual o novo comportamento?**

- Adicionado output p-expanded: ação disparada ao expandir um registro/linha;
- Adicionado output p-collapsed: ação disparada ao expandir um registro/linha;
- Adicionado método expand: método público para expandir um registro/linha;
- Adicionado método collapse: método público para colapsar um registro/linha;

**Simulação**
Utilizar sample do componente.