### PR TITLE
fix(table): corrige colspan quando detail estiver aberto

### DIFF
--- a/projects/ui/src/lib/components/po-table/po-table.component.spec.ts
+++ b/projects/ui/src/lib/components/po-table/po-table.component.spec.ts
@@ -650,23 +650,6 @@ describe('PoTableComponent:', () => {
     expect(component['setTableOpacity']).toHaveBeenCalled();
   }));
 
-  it('should count columns for master detail', () => {
-    const columnManager = 1;
-    component.columns = [...columns];
-
-    const countColumns = columns.length + 1 + columnManager;
-
-    expect(component.columnCountForMasterDetail()).toBe(countColumns);
-
-    component.actions = [...actions];
-    fixture.detectChanges();
-    expect(component.columnCountForMasterDetail()).toBe(countColumns + 1);
-
-    component.checkbox = true;
-    fixture.detectChanges();
-    expect(component.columnCountForMasterDetail()).toBe(countColumns + 2);
-  });
-
   it('should calculate when height is a number in function calculateHeightTableContainer', () => {
     const fakeThis = {
       getHeightTableFooter: () => 0,
@@ -1559,6 +1542,41 @@ describe('PoTableComponent:', () => {
       component.onVisibleColumnsChange(newColumns);
 
       expect(spyDetectChanges).toHaveBeenCalled();
+    });
+
+    it('columnCountForMasterDetail: should return 7 columnCount if has actions and 5 columns', () => {
+      component.actions = [...singleAction];
+      component.columns = [...columns];
+
+      const columnCountAction = 1;
+
+      const countColumns = columns.length + 1 + columnCountAction;
+
+      expect(component.columnCountForMasterDetail()).toBe(countColumns);
+    });
+
+    it('columnCountForMasterDetail: should return 7 columnCount if actions is empty and has 5 columns', () => {
+      component.actions = [];
+      component.columns = [...columns];
+
+      const columnCountColumnManager = 1;
+
+      const countColumns = columns.length + 1 + columnCountColumnManager;
+
+      expect(component.columnCountForMasterDetail()).toBe(countColumns);
+    });
+
+    it('columnCountForMasterDetail: should return 8 columnCount if actions is empty, has 5 columns and has checkbox', () => {
+      component.actions = [];
+      component.columns = [...columns];
+      component.checkbox = true;
+
+      const columnCountColumnManager = 1;
+      const columnCountCheckbox = 1;
+
+      const countColumns = columns.length + 1 + columnCountColumnManager + columnCountCheckbox;
+
+      expect(component.columnCountForMasterDetail()).toBe(countColumns);
     });
 
   });

--- a/projects/ui/src/lib/components/po-table/po-table.component.ts
+++ b/projects/ui/src/lib/components/po-table/po-table.component.ts
@@ -215,7 +215,9 @@ export class PoTableComponent extends PoTableBaseComponent implements AfterViewI
   }
 
   columnCountForMasterDetail() {
-    const columnManager = 1;
+    // caso tiver ações será utilizado a sua coluna para exibir o columnManager
+    const columnManager = this.actions.length ? 0 : 1;
+
     return (this.mainColumns.length + 1) + (this.actions.length > 0 ? 1 : 0) + (this.checkbox ? 1 : 0) + columnManager;
   }
 


### PR DESCRIPTION
**Table**

**DTHFUI-2499**
_____________________________________________________________________________

**PR Checklist**

- [x] Código
- [x] Testes unitários
- [ ] Documentação
- [ ] Samples

**Qual o comportamento atual?**
Ao abrir o detail da tabela, o colspan da linha estava sendo contado de forma incorreta,
já que quando há ações a coluna é reutilizada pelo column manager.


**Qual o novo comportamento?**
TH Column Manager passa a reutiliza a td das ações na contagem do colspan do detail, para que não 
amontoe as colunas.

**Simulação**
- Utilizar o Sample Po Table Air Fare
- Abrir um master detail;