### PR TITLE
fix(input): corrige o bug ao colar um texto com o mouse no input

### DIFF
--- a/projects/ui/src/lib/components/po-field/po-input-generic/po-input-generic.spec.ts
+++ b/projects/ui/src/lib/components/po-field/po-input-generic/po-input-generic.spec.ts
@@ -225,17 +225,25 @@ describe('PoInputGeneric:', () => {
     expect(fakeThis.inputEl.nativeElement.value).toBe('12345');
   });
 
-  it('should not call "callOnChange" on eventInput with mask', () => {
+  it('should call mask.blur on eventInput with mask', () => {
     const fakeThis = {
       mask: true,
-      callOnChange: () => {},
-      validMaxLength: () => {},
-      maxlength: ''
+      callOnChange: (v: any) => {},
+      inputEl: component.inputEl,
+      objMask: {
+        blur: (v: any) => {},
+        valueToInput: '',
+        valueToModel: ''
+      }
     };
 
+    fakeEvent.target.value = '1234567890';
+
+    spyOn(fakeThis.objMask, 'blur');
     spyOn(fakeThis, 'callOnChange');
     component.eventOnInput.call(fakeThis, fakeEvent);
-    expect(fakeThis.callOnChange).not.toHaveBeenCalled();
+    expect(fakeThis.callOnChange).toHaveBeenCalled();
+    expect(fakeThis.objMask.blur).toHaveBeenCalled();
   });
 
   it('should valid maxlength when its defined', () => {

--- a/projects/ui/src/lib/components/po-field/po-input-generic/po-input-generic.ts
+++ b/projects/ui/src/lib/components/po-field/po-input-generic/po-input-generic.ts
@@ -77,11 +77,16 @@ export abstract class PoInputGeneric extends PoInputBaseComponent implements Aft
   }
 
   eventOnInput(e: any) {
+    let value = '';
     if (!this.mask) {
-      const value = this.validMaxLength(this.maxlength, e.target.value);
+      value = this.validMaxLength(this.maxlength, e.target.value);
       this.inputEl.nativeElement.value = value;
-      this.callOnChange(value);
+    } else {
+      this.objMask.blur(e);
+      this.inputEl.nativeElement.value = this.objMask.valueToInput;
+      value = this.objMask.valueToModel;
     }
+    this.callOnChange(value);
   }
 
   validMaxLength(maxlength: number, value: string) {


### PR DESCRIPTION
**po-input**

**DTHFUI-2294**
_____________________________________________________________________________

**PR Checklist**

- [X] Código
- [X] Testes unitários
- [ ] Documentação
- [ ] Samples

**Qual o comportamento atual?**
Quando é usado o mouse para colar um valor no componente po-input
com mask, o model não é atualizado.

**Qual o novo comportamento?**
O evento de input verifica se possui mask preenchido, se houver,
é disparado o metódo blur do mask e depois o onChange para atualizar
o model.

**Simulação**
Criar um po-input com mask e ngModel.
Copiar um valor.
Clicar com o botão direito no input e clicar em colar.
O model deve estar com o valor colado.
