### PR TITLE
feat(table): adiciona eventos e metodos para colapsar e expandir

### DIFF
--- a/projects/ui/src/lib/components/po-table/po-table-base.component.spec.ts
+++ b/projects/ui/src/lib/components/po-table/po-table-base.component.spec.ts
@@ -863,71 +863,222 @@ describe('PoTableBaseComponent:', () => {
       expect(component.showMore.emit).toHaveBeenCalledWith(undefined);
     });
 
+    it('toggleDetail: should set showDetail to false', () => {
+      const currentRow = {
+        id: 1,
+        $selected: true,
+        details: [{ id: 4 }],
+        $showDetail: true
+      };
+      component.toggleDetail(currentRow);
+      expect(currentRow.$showDetail).toBe(false);
+    });
+
+    it('toggleDetail: should set showDetail to true', () => {
+      const currentRow = {
+        id: 1,
+        $selected: true,
+        details: [{ id: 4 }],
+        $showDetail: false
+      };
+      component.toggleDetail(currentRow);
+      expect(currentRow.$showDetail).toBe(true);
+    });
+
+    it('toggleDetail: should emit expanded if detail is opened', () => {
+      const currentRow = {
+        id: 1,
+        $selected: true,
+        details: [{ id: 4 }],
+        $showDetail: false
+      };
+
+      spyOn(component.expanded, 'emit');
+
+      component.toggleDetail(currentRow);
+      expect(component.expanded.emit).toHaveBeenCalled();
+    });
+
+    it('toggleDetail: should emit collapsed if detail is closed', () => {
+      const currentRow = {
+        id: 1,
+        $selected: true,
+        details: [{ id: 4 }],
+        $showDetail: true
+      };
+
+      spyOn(component.collapsed, 'emit');
+
+      component.toggleDetail(currentRow);
+      expect(component.collapsed.emit).toHaveBeenCalled();
+    });
+
+    it('expand: should set showDetail to true', () => {
+      const currentRow = {
+        id: 1,
+        $selected: true,
+        details: [{ id: 4 }],
+        $showDetail: false
+      };
+
+      component.items = [ currentRow ];
+
+      component.expand(0);
+
+      expect(component.items[0].$showDetail).toBe(true);
+    });
+
+    it('expand: should keep showDetail to true', () => {
+      const currentRow = {
+        id: 1,
+        $selected: true,
+        details: [{ id: 4 }],
+        $showDetail: true
+      };
+
+      component.items = [ currentRow ];
+
+      component.expand(0);
+
+      expect(component.items[0].$showDetail).toBe(true);
+    });
+
+    it('expand: shouldn`t emit expanded', () => {
+      const currentRow = {
+        id: 1,
+        $selected: true,
+        details: [{ id: 4 }],
+        $showDetail: false
+      };
+
+      component.items = [ currentRow ];
+
+      spyOn(component.expanded, 'emit');
+
+      component.expand(0);
+
+      expect(component.expanded.emit).not.toHaveBeenCalled();
+    });
+
+    it('collapse: should set showDetail to false', () => {
+      const currentRow = {
+        id: 1,
+        $selected: true,
+        details: [{ id: 4 }],
+        $showDetail: true
+      };
+
+      component.items = [ currentRow ];
+
+      component.collapse(0);
+
+      expect(component.items[0].$showDetail).toBe(false);
+    });
+
+    it('collapse: should keep showDetail to false', () => {
+      const currentRow = {
+        id: 1,
+        $selected: true,
+        details: [{ id: 4 }],
+        $showDetail: false
+      };
+
+      component.items = [ currentRow ];
+
+      component.collapse(0);
+
+      expect(component.items[0].$showDetail).toBe(false);
+    });
+
+    it('collapse: shouldn`t emit collapsed', () => {
+      const currentRow = {
+        id: 1,
+        $selected: true,
+        details: [{ id: 4 }],
+        $showDetail: true
+      };
+
+      component.items = [ currentRow ];
+
+      spyOn(component.collapsed, 'emit');
+
+      component.collapse(0);
+
+      expect(component.collapsed.emit).not.toHaveBeenCalled();
+    });
+
   });
 
   describe('Properties:', () => {
     const booleanValidTrueValues = [true, 'true', 1, ''];
     const booleanInvalidValues = [undefined, null, NaN, 2, 'string'];
 
-    it('p-literals: should be in portuguese if browser is setted with an unsupported language', () => {
-      spyOn(utilsFunctions, <any>'browserLanguage').and.returnValue('zw');
+    describe('p-literals:', () => {
+      it('should be in portuguese if browser is setted with an unsupported language', () => {
+        spyOn(utilsFunctions, <any>'browserLanguage').and.returnValue('zw');
 
-      component.literals = {};
+        component.literals = {};
 
-      expect(component.literals).toEqual(poTableLiteralsDefault[poLocaleDefault]);
-    });
+        expect(component.literals).toEqual(poTableLiteralsDefault[poLocaleDefault]);
+      });
 
-    it('p-literals: should be in portuguese if browser is setted with `pt`', () => {
-      spyOn(utilsFunctions, <any>'browserLanguage').and.returnValue('pt');
+      it('should be in portuguese if browser is setted with `pt`', () => {
+        spyOn(utilsFunctions, <any>'browserLanguage').and.returnValue('pt');
 
-      component.literals = {};
+        component.literals = {};
 
-      expect(component.literals).toEqual(poTableLiteralsDefault.pt);
-    });
+        expect(component.literals).toEqual(poTableLiteralsDefault.pt);
+      });
 
-    it('p-literals: should be in english if browser is setted with `en`', () => {
-      spyOn(utilsFunctions, <any>'browserLanguage').and.returnValue('en');
+      it('should be in english if browser is setted with `en`', () => {
+        spyOn(utilsFunctions, <any>'browserLanguage').and.returnValue('en');
 
-      component.literals = {};
+        component.literals = {};
 
-      expect(component.literals).toEqual(poTableLiteralsDefault.en);
-    });
+        expect(component.literals).toEqual(poTableLiteralsDefault.en);
+      });
 
-    it('p-literals: should be in spanish if browser is setted with `es`', () => {
-      spyOn(utilsFunctions, <any>'browserLanguage').and.returnValue('es');
+      it('should be in spanish if browser is setted with `es`', () => {
+        spyOn(utilsFunctions, <any>'browserLanguage').and.returnValue('es');
 
-      component.literals = {};
+        component.literals = {};
 
-      expect(component.literals).toEqual(poTableLiteralsDefault.es);
-    });
+        expect(component.literals).toEqual(poTableLiteralsDefault.es);
+      });
 
-    it('p-literals: should be in russian if browser is setted with `ru`', () => {
-      spyOn(utilsFunctions, <any>'browserLanguage').and.returnValue('ru');
+      it('should be in russian if browser is setted with `ru`', () => {
+        spyOn(utilsFunctions, <any>'browserLanguage').and.returnValue('ru');
 
-      component.literals = {};
+        component.literals = {};
 
-      expect(component.literals).toEqual(poTableLiteralsDefault.ru);
-    });
+        expect(component.literals).toEqual(poTableLiteralsDefault.ru);
+      });
 
-    it('p-literals: should accept custom literals', () => {
-      spyOn(utilsFunctions, <any>'browserLanguage').and.returnValue(poLocaleDefault);
+      it('should accept custom literals', () => {
+        spyOn(utilsFunctions, <any>'browserLanguage').and.returnValue(poLocaleDefault);
 
-      const customLiterals = Object.assign({}, poTableLiteralsDefault[poLocaleDefault]);
+        const customLiterals = Object.assign({}, poTableLiteralsDefault[poLocaleDefault]);
 
-      // Custom some literals
-      customLiterals.noData = 'No data custom';
+        // Custom some literals
+        customLiterals.noData = 'No data custom';
 
-      component.literals = customLiterals;
+        component.literals = customLiterals;
 
-      expect(component.literals).toEqual(customLiterals);
-    });
+        expect(component.literals).toEqual(customLiterals);
+      });
 
-    it('p-literals: should update property with default literals if is setted with invalid values', () => {
-      const invalidValues = [null, undefined, false, true, '', 'literals', 0, 10, [], [1, 2], () => {}];
+      it('should update property with default literals if is setted with invalid values', () => {
+        const invalidValues = [null, undefined, false, true, '', 'literals', 0, 10, [], [1, 2], () => {}];
 
-      spyOn(utilsFunctions, <any>'browserLanguage').and.returnValue(poLocaleDefault);
+        spyOn(utilsFunctions, <any>'browserLanguage').and.returnValue(poLocaleDefault);
 
-      expectPropertiesValues(component, 'literals', invalidValues, poTableLiteralsDefault[poLocaleDefault]);
+        expectPropertiesValues(component, 'literals', invalidValues, poTableLiteralsDefault[poLocaleDefault]);
+      });
+
+      it('should get literals directly from poTableLiteralsDefault if it not initialized', () => {
+        spyOn(utilsFunctions, <any>'browserLanguage').and.returnValue('pt');
+        expect(component.literals).toEqual(poTableLiteralsDefault['pt']);
+      });
     });
 
     it('p-loading: should update property `p-loading` with valid values.', () => {
@@ -1005,7 +1156,6 @@ describe('PoTableBaseComponent:', () => {
 
       expect(component['sortType']).toBe('descending');
     });
-
   });
 
 });

--- a/projects/ui/src/lib/components/po-table/po-table-base.component.ts
+++ b/projects/ui/src/lib/components/po-table/po-table-base.component.ts
@@ -398,19 +398,27 @@ export abstract class PoTableBaseComponent implements OnChanges {
    */
   @Input('p-max-columns') maxColumns?: number;
 
-  /**
-   * Ação executada quando todas as linhas são selecionadas por meio do *checkbox* que seleciona todas as linhas.
-   */
+  /** Evento executado quando todas as linhas são selecionadas por meio do *checkbox* que seleciona todas as linhas. */
   @Output('p-all-selected') allSelected?: EventEmitter<any> = new EventEmitter<any>();
 
-  /**
-   * Ação executada quando a seleção das linhas é desmarcada por meio do *checkbox* que seleciona todas as linhas.
-   */
+  /** Evento executado quando a seleção das linhas é desmarcada por meio do *checkbox* que seleciona todas as linhas. */
   @Output('p-all-unselected') allUnselected?: EventEmitter<any> = new EventEmitter<any>();
 
   /**
-   * Ação executada ao selecionar uma linha do `po-table`.
+   * Evento executado ao colapsar uma linha do `po-table`.
+   *
+   * > Como parâmetro o componente envia o item colapsado.
    */
+  @Output('p-collapsed') collapsed?: EventEmitter<any> = new EventEmitter<any>();
+
+  /**
+   * Evento executado ao expandir uma linha do `po-table`.
+   *
+   * > Como parâmetro o componente envia o item expandido.
+   */
+  @Output('p-expanded') expanded?: EventEmitter<any> = new EventEmitter<any>();
+
+  /** Evento executado ao selecionar uma linha do `po-table`. */
   @Output('p-selected') selected?: EventEmitter<any> = new EventEmitter<any>();
 
   /**
@@ -425,7 +433,7 @@ export abstract class PoTableBaseComponent implements OnChanges {
   @Output('p-show-more') showMore?: EventEmitter<PoTableColumnSort> = new EventEmitter<PoTableColumnSort>();
 
   /**
-   * Ação executada ao ordenar colunas da tabela.
+   * Evento executado ao ordenar colunas da tabela.
    *
    * Recebe um objeto `{ column, type }` onde:
    *
@@ -434,9 +442,7 @@ export abstract class PoTableBaseComponent implements OnChanges {
    */
   @Output('p-sort-by') sortBy?: EventEmitter<PoTableColumnSort> = new EventEmitter<PoTableColumnSort>();
 
-  /**
-   * Ação executada ao desmarcar a seleção de uma linha do `po-table`.
-   */
+  /** Evento executado ao desmarcar a seleção de uma linha do `po-table`. */
   @Output('p-unselected') unselected?: EventEmitter<any> = new EventEmitter<any>();
 
   selectAll = false;
@@ -463,6 +469,26 @@ export abstract class PoTableBaseComponent implements OnChanges {
 
   get hasColumns(): boolean {
     return this.columns && this.columns.length > 0;
+  }
+
+  /**
+   * Método que colapsa uma linha com detalhe quando executada.
+   *
+   * @param { number } rowIndex Índice da linha que será colapsada.
+   * > Ao reordenar os dados da tabela, o valor contido neste índice será alterado conforme a ordenação.
+   */
+  collapse(rowIndex: number) {
+    this.setShowDetail(rowIndex, false);
+  }
+
+  /**
+   * Método que expande uma linha com detalhe quando executada.
+   *
+   * @param { number } rowIndex Índice da linha que será expandida.
+   * > Ao reordenar os dados da tabela, o valor contido neste índice será alterado conforme a ordenação.
+   */
+  expand(rowIndex: number) {
+    this.setShowDetail(rowIndex, true);
   }
 
   selectAllRows() {
@@ -538,6 +564,11 @@ export abstract class PoTableBaseComponent implements OnChanges {
     return this.items && this.items.length > 0;
   }
 
+  toggleDetail(row: any) {
+    this.setShowDetail(row, !row.$showDetail);
+    this.emitExpandEvents(row);
+  }
+
   toggleRowAction(row: any) {
     const toggleShowAction = row.$showAction;
 
@@ -601,6 +632,10 @@ export abstract class PoTableBaseComponent implements OnChanges {
     }
   }
 
+  private emitExpandEvents(row: any) {
+    row.$showDetail ? this.expanded.emit(row) : this.collapsed.emit(row);
+  }
+
   private emitSelectAllEvents(selectAll: boolean, rows: any) {
     selectAll ? this.allSelected.emit(rows) : this.allUnselected.emit(rows);
   }
@@ -630,6 +665,15 @@ export abstract class PoTableBaseComponent implements OnChanges {
         column['link'] = 'link';
       }
     });
+  }
+
+  private setShowDetail(rowIdentifier: any | number, isShowDetail: boolean) {
+
+    const isRowIndex = typeof rowIdentifier === 'number' && this.items[rowIdentifier];
+
+    const row = isRowIndex ? this.items[rowIdentifier] : rowIdentifier;
+
+    row.$showDetail = isShowDetail;
   }
 
   private unselectOtherRows(rows: Array<any>, row) {

--- a/projects/ui/src/lib/components/po-table/po-table.component.html
+++ b/projects/ui/src/lib/components/po-table/po-table.component.html
@@ -151,7 +151,7 @@
           </td>
           <td *ngIf="(getColumnMasterDetail() !== undefined) && !hideDetail || hasRowTemplate"
             class="po-table-column-detail-toggle"
-            (click)="row.$showDetail = !row.$showDetail">
+            (click)="toggleDetail(row)">
             <span *ngIf="(containsMasterDetail(row) && !hasRowTemplate) || isShowRowTemplate(row, rowIndex) && hasRowTemplate"
               class="po-icon po-clickable"
               [class.po-icon-arrow-up]="row.$showDetail"

--- a/projects/ui/src/lib/components/po-table/samples/sample-po-table-airfare/sample-po-table-airfare.component.html
+++ b/projects/ui/src/lib/components/po-table/samples/sample-po-table-airfare/sample-po-table-airfare.component.html
@@ -16,6 +16,8 @@
   [p-columns]="columns"
   [p-items]="items"
   [p-max-columns]="6"
+  (p-collapsed)="onCollapseDetail()"
+  (p-expanded)="onExpandDetail()"
   (p-selected)="sumTotal($event)"
   (p-unselected)="decreaseTotal($event)">
 </po-table>
@@ -29,12 +31,29 @@
   p-value="{{total | currency:'USD'}}">
 </po-info>
 
+<po-info
+  class="po-md-6 po-mb-sm-2 po-mb-md-2 po-lb-lg-2"
+  p-label="Expanded Itens"
+  p-orientation="horizontal"
+  [p-value]="totalExpanded">
+</po-info>
+
 <div class="po-row">
   <po-button
     class="po-md-3"
     p-icon="po-icon-cart"
     p-label="Add items to cart"
     (p-click)="addToCart()">
+  </po-button>
+  <po-button
+    class="po-md-3"
+    p-label="Expand all detail"
+    (p-click)="expandAll()">
+  </po-button>
+  <po-button
+    class="po-md-3"
+    p-label="Collapse all detail"
+    (p-click)="collapseAll()">
   </po-button>
 </div>
 
@@ -46,19 +65,19 @@
   <po-info
     class="po-sm-6"
     p-label="Airline"
-    p-value="{{ detail?.airline }}">
+    [p-value]="detail?.airline">
   </po-info>
 
   <po-info
     class="po-sm-2"
     p-label="Initials"
-    p-value="{{ detail?.initials }}">
+    [p-value]="detail?.initials">
   </po-info>
 
   <po-info
     class="po-sm-4"
     p-label="Class"
-    p-value="{{ detail?.class }}">
+    [p-value]="detail?.class">
   </po-info>
 
 </po-modal>

--- a/projects/ui/src/lib/components/po-table/samples/sample-po-table-airfare/sample-po-table-airfare.component.ts
+++ b/projects/ui/src/lib/components/po-table/samples/sample-po-table-airfare/sample-po-table-airfare.component.ts
@@ -26,6 +26,7 @@ export class SamplePoTableAirfareComponent {
   detail: any;
   items: Array<any> = this.sampleAirfare.getItems();
   total: number = 0;
+  totalExpanded = 0;
 
   @ViewChild(PoModalComponent, { static: true }) poModal: PoModalComponent;
   @ViewChild(PoTableComponent, { static: true }) poTable: PoTableComponent;
@@ -65,6 +66,15 @@ export class SamplePoTableAirfareComponent {
     this.items.forEach(item => item.$selected = false);
   }
 
+  collapseAll() {
+    this.items.forEach((item, index) => {
+      if (item.detail) {
+        this.onCollapseDetail();
+        this.poTable.collapse(index);
+      }
+    });
+  }
+
   decreaseTotal(row: any) {
     if (row.value) {
       this.total -= row.value;
@@ -81,6 +91,25 @@ export class SamplePoTableAirfareComponent {
       item.value = item.value - (item.value * 0.2);
       item.disableDiscount = true;
     }
+  }
+
+  expandAll() {
+    this.totalExpanded = 0;
+    this.items.forEach((item, index) => {
+      if (item.detail) {
+        this.onExpandDetail();
+        this.poTable.expand(index);
+      }
+    });
+  }
+
+  onCollapseDetail() {
+    this.totalExpanded -= 1;
+    this.totalExpanded = this.totalExpanded < 0 ? 0 : this.totalExpanded;
+  }
+
+  onExpandDetail() {
+    this.totalExpanded += 1;
   }
 
   sumTotal(row: any) {

--- a/projects/ui/src/lib/components/po-table/samples/sample-po-table-labs/sample-po-table-labs.component.html
+++ b/projects/ui/src/lib/components/po-table/samples/sample-po-table-labs/sample-po-table-labs.component.html
@@ -17,6 +17,8 @@
   [p-striped]="properties.includes('striped')"
   (p-all-selected)="changeEvent('p-all-selected')"
   (p-all-unselected)="changeEvent('p-all-unselected')"
+  (p-collapsed)="changeEvent('p-collapsed')"
+  (p-expanded)="changeEvent('p-expanded')"
   (p-selected)="changeEvent('p-selected')"
   (p-show-more)="showMore()"
   (p-unselected)="changeEvent('p-unselected')">


### PR DESCRIPTION
**TABLE**

**DTHFUI-1609**
_____________________________________________________________________________

**PR Checklist**

- [X] Código
- [X] Testes unitários
- [X] Documentação
- [X] Samples

**Qual o comportamento atual?**
Ao utilizar o thf-table há a possibilidade de incluir os registros com uma setinha para expansão dos mesmos.
Atualmente não há um evento que seja disparado ao realizar esta expansão, não sendo possível identificar qual registro exato que está sendo expandido.

**Qual o novo comportamento?**

- Adicionado output p-expanded: ação disparada ao expandir um registro/linha;
- Adicionado output p-collapsed: ação disparada ao expandir um registro/linha;
- Adicionado método expand: método público para expandir um registro/linha;
- Adicionado método collapse: método público para colapsar um registro/linha;

**Simulação**
Utilizar sample do componente.