### PR TITLE
fix(lookup): corrige comportamento focal na tabulação do html

### DIFF
--- a/projects/ui/src/lib/components/po-dynamic/po-dynamic-form/samples/sample-po-dynamic-form-register/sample-po-dynamic-form-register.component.ts
+++ b/projects/ui/src/lib/components/po-dynamic/po-dynamic-form/samples/sample-po-dynamic-form-register/sample-po-dynamic-form-register.component.ts
@@ -27,7 +27,7 @@ export class SamplePoDynamicFormRegisterComponent {
       { label: 'Rio de Janeiro', value: 3 },
       { label: 'Minas Gerais', value: 4 }
     ]},
-    { property: 'city', disabled: true },
+    { property: 'city', disabled: true, gridColumns: 6 },
     { property: 'entryTime', label: 'Entry time', type: 'time', divider: 'Work data', gridColumns: 6 },
     { property: 'exitTime', label: 'Exit time', type: 'time', gridColumns: 6 },
     { property: 'wage', type: 'currency', gridColumns: 6 },
@@ -43,7 +43,7 @@ export class SamplePoDynamicFormRegisterComponent {
       property: 'favoriteHero',
       gridColumns: 6,
       gridSmColumns: 12,
-      label: 'Favorite Hero',
+      label: 'Favorite hero',
       searchService: 'https://thf.totvs.com.br/sample/api/comboOption/heroes',
       columns: [ { property: 'nickname', label: 'Hero' }, { property: 'label', label: 'Name' }]
     },

--- a/projects/ui/src/lib/components/po-field/po-lookup/po-lookup.component.html
+++ b/projects/ui/src/lib/components/po-field/po-lookup/po-lookup.component.html
@@ -6,6 +6,7 @@
   <div class="po-field-container-content">
     <input #inp
       class="po-input po-input-icon-right"
+      tabindex="0"
       type="text"
       [autocomplete]="autocomplete"
       [disabled]="disabled"
@@ -14,9 +15,13 @@
       (blur)="searchEvent()">
 
     <div class="po-field-icon-container-right">
-      <span tabindex="1" #iconLookup (click)="openLookup()" (focus)="inp.focus()" class="po-icon po-field-icon po-icon-search"
+      <span #iconLookup
+        class="po-icon po-field-icon po-icon-search"
+        tabindex="-1"
+        [class.po-field-icon]="!disabled"
         [class.po-field-icon-disabled]="disabled"
-        [class.po-field-icon]="!disabled">
+        (click)="openLookup()"
+        (focus)="inp.focus()">
       </span>
     </div>
   </div>

--- a/projects/ui/src/lib/components/po-field/po-lookup/po-lookup.component.spec.ts
+++ b/projects/ui/src/lib/components/po-field/po-lookup/po-lookup.component.spec.ts
@@ -36,7 +36,7 @@ export const routes: Routes = [
   { path: '', redirectTo: 'home', pathMatch: 'full' }
 ];
 
-describe('PoLookupComponent: ', () => {
+describe('PoLookupComponent:', () => {
   let component: PoLookupComponent;
   let fixture: ComponentFixture<PoLookupComponent>;
   const fakeSubscription = <any>{ unsubscribe: () => {} };
@@ -119,7 +119,7 @@ describe('PoLookupComponent: ', () => {
 
   });
 
-  describe('Methods: ', () => {
+  describe('Methods:', () => {
     const objectSelected = { label: 'teste', value: 123 };
 
     it('searchEvent: should call `searchById` when the current value isn`t equal to the old value.',
@@ -377,6 +377,14 @@ describe('PoLookupComponent: ', () => {
 
   describe('Templates:', () => {
 
+    let nativeElement;
+    const eventClick = document.createEvent('MouseEvents');
+    eventClick.initEvent('click', true, false);
+
+    beforeEach(() => {
+      nativeElement = fixture.debugElement.nativeElement;
+    });
+
     xit('focus of search span should focus input', fakeAsync(() => {
       const element = fixture.debugElement.nativeElement;
       const input = element.querySelector('.po-input');
@@ -387,6 +395,24 @@ describe('PoLookupComponent: ', () => {
       tick();
 
       expect(input.focus).toHaveBeenCalled();
+    }));
+
+    it('should apply focus on field after model is closed.', inject([LookupFilterService], ( lookupFilterService: LookupFilterService) => {
+      const input = nativeElement.querySelector('.po-input.po-input-icon-right');
+      input.dispatchEvent(eventClick);
+
+      component.service = lookupFilterService;
+      spyOn(component['poLookupModalService'], 'openModal').and.callThrough();
+      spyOn(component, <any>'isAllowedOpenModal').and.returnValue(true);
+      component.openLookup();
+      fixture.detectChanges();
+
+      const closeButton = document.querySelector('.po-modal-header-close-button .po-icon.po-icon-close');
+      closeButton.dispatchEvent(eventClick);
+      fixture.detectChanges();
+
+      const activeElement = document.activeElement.querySelector('.po-input.po-input-icon-right');
+      expect(activeElement).toEqual(input);
     }));
 
     it(`should show optional if the field isn't 'required', has 'label' and 'p-optional' is true.`, () => {


### PR DESCRIPTION
**PO-LOOKUP**

**DTHFUI-2528**

***

**PR Checklist**

- [x] Código
- [x] Testes unitários
- [ ] Documentação
- [ ] Samples

***

**Qual o comportamento atual?**
- Quando existe um lookup na página o mesmo recebe o foco mesmo não sendo o primeiro elemento que deveria receber o foco.
- Abrindo o link https://portinari.io/documentation/po-dynamic-form?view=web e apertar TAB várias vezes, o mesmo vai cair em um loop infinito sem permitir que o usuário passe pelos outros elementos.

**Qual o novo comportamento?**
Agora o componente respeita a ordem da tabulação entre o *tabindex* dos demais elementos da tela e também remove a sobreposição da navegação entre os mesmos.

**Simulação**
https://portinari.io/documentation/po-dynamic-form?view=web