### PR TITLE
feat(dynamic-form): adiciona metodos para inicialização

### DIFF
--- a/projects/ui/src/lib/components/po-dynamic/index.ts
+++ b/projects/ui/src/lib/components/po-dynamic/index.ts
@@ -1,5 +1,6 @@
 export * from './po-dynamic-field-type.enum';
 export * from './po-dynamic-form/po-dynamic-form-field.interface';
+export * from './po-dynamic-form/po-dynamic-form-load/po-dynamic-form-load.interface';
 export * from './po-dynamic-form/po-dynamic-form-validation/po-dynamic-form-field-changed.interface';
 export * from './po-dynamic-form/po-dynamic-form-validation/po-dynamic-form-field-validation.interface';
 export * from './po-dynamic-form/po-dynamic-form-validation/po-dynamic-form-validation.interface';

--- a/projects/ui/src/lib/components/po-dynamic/po-dynamic-form/po-dynamic-form-base.component.ts
+++ b/projects/ui/src/lib/components/po-dynamic/po-dynamic-form/po-dynamic-form-base.component.ts
@@ -12,9 +12,6 @@ import { PoDynamicFormField } from './po-dynamic-form-field.interface';
  * Componente para criação de formulários dinâmicos a partir de uma lista de objetos.
  *
  * Também é possível verificar se o formulário está válido e informar valores para a exibição de informações.
- *
- * > Temos uma ferramenta para criação de formulários, onde é possível inicializá-lo através de um JSON.
- * [**Veja aqui**](tools/dynamic-form).
  */
 export class PoDynamicFormBaseComponent {
 
@@ -157,11 +154,45 @@ export class PoDynamicFormBaseComponent {
   }
 
   /**
+   * Função ou serviço que será executado na inicialização do componente.
+   *
+   * A propriedade aceita os seguintes tipos:
+   * - `string`: *Endpoint* usado pelo componente para requisição via `POST`.
+   * - `function`: Método que será executado.
+   *
+   * Ao ser executado, irá receber como parâmetro o objeto informado no `p-value`.
+   *
+   * O retorno desta função deve ser do tipo [PoDynamicFormLoad](documentation/po-dynamic-form#po-dynamic-form-load),
+   * onde o usuário poderá determinar as novas atualizações dos campos, valores e determinar o campo a ser focado.
+   *
+   * Por exemplo:
+   *
+   * ```
+   * onLoadFields(): PoDynamicFormLoad {
+   *
+   *   return {
+   *     value: { cpf: undefined },
+   *     fields: [
+   *       { property: 'cpf' }
+   *     ],
+   *     focus: 'cpf'
+   *   };
+   * }
+   *
+   * ```
+   * Para referenciar a sua função utilize a propriedade `bind`, por exemplo:
+   * ```
+   *  [p-load]="onLoadFields.bind(this)"
+   * ```
+   */
+  @Input('p-load') load?: string | Function;
+
+  /**
    * Função ou serviço para validar as **mudanças do formulário**.
    *
    * A propriedade aceita os seguintes tipos:
-   * - **String**: Endpoint usado pelo componente para requisição via `POST`.
-   * - **Function**: Método que será executado.
+   * - `string`: *Endpoint* usado pelo componente para requisição via `POST`.
+   * - `function`: Método que será executado.
    *
    * Ao ser executado, irá receber como parâmetro um objeto com o nome da propriedade
    * alterada e o novo valor, conforme a interface `PoDynamicFormFieldChanged`:

--- a/projects/ui/src/lib/components/po-dynamic/po-dynamic-form/po-dynamic-form-load/po-dynamic-form-load.interface.ts
+++ b/projects/ui/src/lib/components/po-dynamic/po-dynamic-form/po-dynamic-form-load/po-dynamic-form-load.interface.ts
@@ -1,0 +1,23 @@
+import { PoDynamicFormField } from '../po-dynamic-form-field.interface';
+import { PoDynamicFormResponse } from '../po-dynamic-form-response.interface';
+
+/**
+ * @usedBy PoDynamicFormComponent
+ *
+ * @description
+ * <a id="po-dynamic-form-load"></a>
+ *
+ * Estrutura de retorno no carregamento do formulário.
+ *
+ * @docsExtends PoDynamicFormResponse
+ */
+export interface PoDynamicFormLoad extends PoDynamicFormResponse {
+
+  /**
+   * Lista com as novas definições dos campos.
+   *
+   * > Não é necessário colocar todas as propriedades e campos, apenas as que precisam ser alteradas ou adicionadas.
+   */
+  fields?: Array<PoDynamicFormField>;
+
+}

--- a/projects/ui/src/lib/components/po-dynamic/po-dynamic-form/po-dynamic-form-load/po-dynamic-form-load.service.spec.ts
+++ b/projects/ui/src/lib/components/po-dynamic/po-dynamic-form/po-dynamic-form-load/po-dynamic-form-load.service.spec.ts
@@ -1,0 +1,102 @@
+import { HttpClientTestingModule } from '@angular/common/http/testing';
+import { TestBed } from '@angular/core/testing';
+
+import { of } from 'rxjs';
+
+import { PoDynamicFormLoadService } from './po-dynamic-form-load.service';
+
+describe('PoDynamicFormLoadService:', () => {
+
+  let service: PoDynamicFormLoadService;
+
+  const mockURL: string = 'http://po.portinari.com.br/api';
+  const value = { name: 'username' };
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [
+        HttpClientTestingModule
+      ],
+      providers: [
+        PoDynamicFormLoadService
+      ]
+    });
+
+    service = TestBed.get(PoDynamicFormLoadService);
+  });
+
+  describe('Methods:', () => {
+    const spyLoadFunction = jasmine.createSpy('validateFunction');
+
+    it('executeLoad: should call `execute` with `load` and `value`', () => {
+      const spyExecute = spyOn(service, <any> 'execute').and.returnValue(of());
+
+      service.executeLoad(spyLoadFunction, value);
+
+      expect(spyExecute).toHaveBeenCalledWith(spyLoadFunction, value);
+    });
+
+    it('executeLoad: should return default form if return of server is null', done => {
+      const defaultForm = {
+        value: {},
+        fields: [],
+        focus: undefined
+      };
+
+      spyOn(service, <any>'execute').and.returnValue(of(null));
+
+      service.executeLoad(mockURL, value).subscribe(loadedFormData => {
+        expect(loadedFormData).toEqual(defaultForm);
+        done();
+      });
+    });
+
+    it('executeLoad: should return value if return of server is not null', done => {
+      const loadedFormData = { fields: [{ property: 'name', label: 'Nome' }]};
+
+      spyOn(service, <any>'execute').and.returnValue(of(loadedFormData));
+
+      service.executeLoad(mockURL, value).subscribe(validateField => {
+        expect(validateField).toEqual(loadedFormData);
+        done();
+      });
+    });
+
+    it('createAndUpdateFieldsForm: should return merged fields between `fields` and `loadedFields` and create new loaded fields', () => {
+      const fields = [
+        { property: 'test1', required: true, visible: true },
+        { property: 'test2', required: false, visible: true },
+        { property: 'test3', required: true },
+        { property: 'test4', required: false, visible: false }
+      ];
+
+      const validatedFields = [
+        { property: 'test2', required: false, help: 'test help' },
+        { property: 'test3', required: true, visible: false },
+        { property: 'test5', required: true }
+      ];
+
+      const expectedField = [
+        { property: 'test1', required: true, visible: true },
+        { property: 'test2', required: false, visible: true, help: 'test help' },
+        { property: 'test3', required: true, visible: false },
+        { property: 'test4', required: false, visible: false },
+        { property: 'test5', required: true }
+      ];
+
+      const result = service.createAndUpdateFieldsForm(validatedFields, fields);
+
+      expect(result).toEqual(expectedField);
+    });
+
+    it('createAndUpdateFieldsForm: should return [] if `fields` and `loadedFields` are undefined', () => {
+      const expectedField = [];
+
+      const result = service.createAndUpdateFieldsForm();
+
+      expect(result).toEqual(expectedField);
+    });
+
+  });
+
+});

--- a/projects/ui/src/lib/components/po-dynamic/po-dynamic-form/po-dynamic-form-load/po-dynamic-form-load.service.ts
+++ b/projects/ui/src/lib/components/po-dynamic/po-dynamic-form/po-dynamic-form-load/po-dynamic-form-load.service.ts
@@ -1,0 +1,38 @@
+import { HttpClient } from '@angular/common/http';
+import { Injectable } from '@angular/core';
+
+import { map } from 'rxjs/operators';
+
+import { PoDynamicFormField } from '../po-dynamic-form-field.interface';
+import { PoDynamicFormOperation } from '../po-dynamic-form-operation/po-dynamic-form-operation';
+
+@Injectable()
+export class PoDynamicFormLoadService extends PoDynamicFormOperation {
+
+  constructor(http: HttpClient) {
+    super(http);
+  }
+
+  createAndUpdateFieldsForm(loadedFields: Array<PoDynamicFormField> = [], fields: Array<PoDynamicFormField> = []) {
+    return [ ...loadedFields ].reduce((updatedFields, field) => {
+      const index = updatedFields.findIndex(updatedField => updatedField.property === field.property);
+      const hasProperty = index >= 0;
+
+      if (hasProperty) {
+        updatedFields[index] = { ...fields[index], ...field };
+      } else {
+        updatedFields.push(field);
+      }
+
+      return updatedFields;
+    }, [ ...fields ]);
+  }
+
+  executeLoad(load: Function | string, value: any) {
+    return this.execute(load, value)
+      .pipe(
+        map(loadedFormdData => this.setFormDefaultIfEmpty(loadedFormdData)
+      ));
+  }
+
+}

--- a/projects/ui/src/lib/components/po-dynamic/po-dynamic-form/po-dynamic-form-operation/po-dynamic-form-operation.spec.ts
+++ b/projects/ui/src/lib/components/po-dynamic/po-dynamic-form/po-dynamic-form-operation/po-dynamic-form-operation.spec.ts
@@ -1,0 +1,79 @@
+import { HttpClient } from '@angular/common/http';
+import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
+import { TestBed } from '@angular/core/testing';
+
+import { PoDynamicFormOperation } from './po-dynamic-form-operation';
+
+describe('PoDynamicFormOperation:', () => {
+  let dynamicFormOperation;
+
+  let httpMock: HttpTestingController;
+
+  const mockURL: string = 'http://po.portinari.com.br/api';
+  const value = { name: 'username' };
+
+  const spyLoadFunction = jasmine.createSpy('loadFunction');
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [
+        HttpClientTestingModule
+      ]
+    });
+
+    httpMock = TestBed.get(HttpTestingController);
+
+    const http = TestBed.get(HttpClient);
+
+    dynamicFormOperation = new PoDynamicFormOperation(http);
+  });
+
+  describe('Methods:', () => {
+
+    it('execute: should call `post` if `load` param is a string', () => {
+      const spyPost = spyOn(dynamicFormOperation, 'post');
+
+      dynamicFormOperation['execute'](mockURL, value);
+
+      expect(spyPost).toHaveBeenCalledWith(mockURL, value);
+    });
+
+    it('execute: should call the function passed as param if `load` isn`t a string', () => {
+      const spyPost = spyOn(dynamicFormOperation, <any>'post');
+
+      dynamicFormOperation['execute'](spyLoadFunction, value);
+
+      expect(spyLoadFunction).toHaveBeenCalledWith(value);
+      expect(spyPost).not.toHaveBeenCalledWith();
+    });
+
+    it('post: should call `POST` method', () => {
+      const param = { property: 'name', value };
+
+      dynamicFormOperation['post'](mockURL, param).subscribe(response => {
+        expect(response).toBeDefined();
+      });
+
+      const req = httpMock.expectOne(`${mockURL}`);
+      expect(req.request.method).toBe('POST');
+    });
+
+    it('setFormDefaultIfEmpty: should return value if its is defined', () => {
+      const validatedField = { value: 'new value' };
+
+      expect(dynamicFormOperation['setFormDefaultIfEmpty'](validatedField)).toEqual(validatedField);
+    });
+
+    it('setFormDefaultIfEmpty: should return default form if its is undefined', () => {
+      const defaultForm = {
+        value: {},
+        fields: [],
+        focus: undefined
+      };
+
+      expect(dynamicFormOperation['setFormDefaultIfEmpty'](undefined)).toEqual(defaultForm);
+    });
+
+  });
+
+});

--- a/projects/ui/src/lib/components/po-dynamic/po-dynamic-form/po-dynamic-form-operation/po-dynamic-form-operation.ts
+++ b/projects/ui/src/lib/components/po-dynamic/po-dynamic-form/po-dynamic-form-operation/po-dynamic-form-operation.ts
@@ -1,0 +1,29 @@
+import { HttpClient } from '@angular/common/http';
+
+import { of } from 'rxjs';
+
+import { PoDynamicFormLoad } from '../po-dynamic-form-load/po-dynamic-form-load.interface';
+import { PoDynamicFormValidation } from '../po-dynamic-form-validation/po-dynamic-form-validation.interface';
+
+export class PoDynamicFormOperation {
+
+  constructor(private http: HttpClient) { }
+
+  protected execute(action: Function | string, param: any) {
+    return typeof action === 'string' ?
+      this.post(action, param) : of(action(param));
+  }
+
+  protected post(url: string, body: PoDynamicFormValidation | any) {
+    return this.http.post(url, body);
+  }
+
+  protected setFormDefaultIfEmpty(validateFields: any): PoDynamicFormValidation | PoDynamicFormLoad {
+    return validateFields || {
+      value: {},
+      fields: [],
+      focus: undefined
+    };
+  }
+
+}

--- a/projects/ui/src/lib/components/po-dynamic/po-dynamic-form/po-dynamic-form-response.interface.ts
+++ b/projects/ui/src/lib/components/po-dynamic/po-dynamic-form/po-dynamic-form-response.interface.ts
@@ -1,0 +1,34 @@
+import { PoDynamicFormField } from './po-dynamic-form-field.interface';
+
+export interface PoDynamicFormResponse {
+
+  fields?: Array<PoDynamicFormField>;
+
+  /**
+   * Nome do campo que receberá o foco.
+   *
+   * Exemplo:
+   *
+   * ```
+   * focus: 'name'
+   * ```
+   */
+  focus?: string;
+
+  /**
+   * Objeto contendo os novos valores.
+   *
+   * Exemplo:
+   *
+   * ```
+   * {
+   *   name: 'new name',
+   *   age: 10
+   * }
+   * ```
+   *
+   * > Não é necessário colocar os valores de todos os campos, apenas os que foram alterados.
+   */
+  value?: any;
+
+}

--- a/projects/ui/src/lib/components/po-dynamic/po-dynamic-form/po-dynamic-form-validation/po-dynamic-form-validation.interface.ts
+++ b/projects/ui/src/lib/components/po-dynamic/po-dynamic-form/po-dynamic-form-validation/po-dynamic-form-validation.interface.ts
@@ -1,4 +1,5 @@
 import { PoDynamicFormField } from '../po-dynamic-form-field.interface';
+import { PoDynamicFormResponse } from '../po-dynamic-form-response.interface';
 
 /**
  * @usedBy PoDynamicFormComponent
@@ -7,8 +8,10 @@ import { PoDynamicFormField } from '../po-dynamic-form-field.interface';
  * <a id="po-dynamic-form-validation"></a>
  *
  * Estrutura de retorno da validação do formulário.
+ *
+ * @docsExtends PoDynamicFormResponse
  */
-export interface PoDynamicFormValidation {
+export interface PoDynamicFormValidation extends PoDynamicFormResponse {
 
   /**
    * Lista com as novas definições dos campos.
@@ -16,30 +19,5 @@ export interface PoDynamicFormValidation {
    * > Não é necessário colocar todas as propriedades e campos, apenas as que foram alteradas.
    */
   fields?: Array<PoDynamicFormField>;
-
-  /** Nome do campo que receberá o foco.
-   *
-   * Exemplo:
-   *
-   * ```
-   * focus: 'name'
-   * ```
-   */
-  focus?: string;
-
-  /** Objeto contendo os novos valores.
-   *
-   * Exemplo:
-   *
-   * ```
-   * {
-   *   name: 'new name',
-   *   age: 10
-   * }
-   * ```
-   *
-   * > Não é necessário colocar os valores de todos os campos, apenas os que foram alterados.
-   */
-  value?: any;
 
 }

--- a/projects/ui/src/lib/components/po-dynamic/po-dynamic-form/samples/sample-po-dynamic-form-register/sample-po-dynamic-form-register.component.html
+++ b/projects/ui/src/lib/components/po-dynamic/po-dynamic-form/samples/sample-po-dynamic-form-register/sample-po-dynamic-form-register.component.html
@@ -1,6 +1,7 @@
 <po-dynamic-form #dynamicForm
   p-auto-focus="name"
   [p-fields]="fields"
+  [p-load]="onLoadFields.bind(this)"
   [p-validate]="this.onChangeFields.bind(this)"
   [p-value]="person">
 </po-dynamic-form>

--- a/projects/ui/src/lib/components/po-dynamic/po-dynamic-form/samples/sample-po-dynamic-form-register/sample-po-dynamic-form-register.component.ts
+++ b/projects/ui/src/lib/components/po-dynamic/po-dynamic-form/samples/sample-po-dynamic-form-register/sample-po-dynamic-form-register.component.ts
@@ -1,19 +1,22 @@
-import { Component } from '@angular/core';
+import { Component, OnInit } from '@angular/core';
 
 import { PoDynamicFormField, PoDynamicFormFieldChanged, PoDynamicFormValidation, PoNotificationService } from '@portinari/portinari-ui';
+import { PoDynamicFormRegisterService } from './sample-po-dynamic-form-register.service';
 
 @Component({
   selector: 'sample-po-dynamic-form-register',
-  templateUrl: './sample-po-dynamic-form-register.component.html'
+  templateUrl: './sample-po-dynamic-form-register.component.html',
+  providers: [ PoDynamicFormRegisterService ]
 })
-export class SamplePoDynamicFormRegisterComponent {
+export class SamplePoDynamicFormRegisterComponent implements OnInit {
 
-  person = {};
+  person = { };
 
   fields: Array<PoDynamicFormField> = [
     { property: 'name', divider: 'PERSONAL DATA', required: true, minLength: 4, maxLength: 50, gridColumns: 6, gridSmColumns: 12 },
-    { property: 'cpf', label: 'CPF', mask: '999.999.999-99', gridColumns: 6, gridSmColumns: 12 },
     { property: 'birthday', type: 'date', gridColumns: 6, gridSmColumns: 12 },
+    { property: 'cpf', label: 'CPF', mask: '999.999.999-99', gridColumns: 6, gridSmColumns: 12, visible: false },
+    { property: 'cnpj', label: 'CNPJ', mask: '99.999.999/9999-99', gridColumns: 6, gridSmColumns: 12, visible: false },
     { property: 'genre', gridColumns: 6, gridSmColumns: 12, options: ['Male', 'Female', 'Other'] },
     { property: 'shortDescription', label: 'Short Description', gridColumns: 12, gridSmColumns: 12, rows: 5 },
     { property: 'secretKey', label: 'Secret Key', gridColumns: 6, secret: true },
@@ -49,7 +52,15 @@ export class SamplePoDynamicFormRegisterComponent {
     },
   ];
 
-  constructor(public poNotification: PoNotificationService) { }
+  constructor(public poNotification: PoNotificationService, private registerService: PoDynamicFormRegisterService) { }
+
+  ngOnInit() {
+    this.person = {
+      name: 'Tony Stark',
+      birthday: '1970-05-29',
+      isJuridicPerson: false
+    };
+  }
 
   onChangeFields(changedValue: PoDynamicFormFieldChanged): PoDynamicFormValidation {
 
@@ -58,49 +69,15 @@ export class SamplePoDynamicFormRegisterComponent {
       return {
         value: { city: undefined},
         fields: [
-          { property: 'city', gridColumns: 6, options: this.getCity(changedValue.value.state), disabled: false }
+          { property: 'city', gridColumns: 6, options: this.registerService.getCity(changedValue.value.state), disabled: false }
         ]
       };
     }
 
   }
 
-  private getCity(state: number) {
-    switch (state) {
-      case 1: {
-        return [
-          { label: 'Palhoça', value: 5 },
-          { label: 'Lages', value: 6 },
-          { label: 'Balneário Camboriú', value: 7 },
-          { label: 'Brusque', value: 8 },
-        ];
-      }
-      case 2: {
-        return [
-          { label: 'São Paulo', value: 9 },
-          { label: 'Guarulhos', value: 10 },
-          { label: 'Campinas', value: 11 },
-          { label: 'São Bernardo do Campo', value: 12 }
-        ];
-      }
-      case 3: {
-        return [
-          { label: 'Rio de Janeiro', value: 13 },
-          { label: 'São Gonçalo', value: 14 },
-          { label: 'Duque de Caxias', value: 15 },
-          { label: 'Nova Iguaçu', value: 16 }
-        ];
-      }
-      case 4: {
-        return [
-          { label: 'Belo Horizonte', value: 17 },
-          { label: 'Uberlândia', value: 18 },
-          { label: 'Contagem', value: 19 },
-          { label: 'Juiz de Fora', value: 20 }
-        ];
-      }
-    }
-    return [];
+  onLoadFields(value: any) {
+    return this.registerService.getUserDocument(value);
   }
 
 }

--- a/projects/ui/src/lib/components/po-dynamic/po-dynamic-form/samples/sample-po-dynamic-form-register/sample-po-dynamic-form-register.service.ts
+++ b/projects/ui/src/lib/components/po-dynamic/po-dynamic-form/samples/sample-po-dynamic-form-register/sample-po-dynamic-form-register.service.ts
@@ -1,0 +1,54 @@
+import { Injectable } from '@angular/core';
+
+@Injectable()
+export class PoDynamicFormRegisterService {
+
+  getCity(state: number) {
+    switch (state) {
+      case 1: {
+        return [
+          { label: 'Palhoça', value: 5 },
+          { label: 'Lages', value: 6 },
+          { label: 'Balneário Camboriú', value: 7 },
+          { label: 'Brusque', value: 8 },
+        ];
+      }
+      case 2: {
+        return [
+          { label: 'São Paulo', value: 9 },
+          { label: 'Guarulhos', value: 10 },
+          { label: 'Campinas', value: 11 },
+          { label: 'São Bernardo do Campo', value: 12 }
+        ];
+      }
+      case 3: {
+        return [
+          { label: 'Rio de Janeiro', value: 13 },
+          { label: 'São Gonçalo', value: 14 },
+          { label: 'Duque de Caxias', value: 15 },
+          { label: 'Nova Iguaçu', value: 16 }
+        ];
+      }
+      case 4: {
+        return [
+          { label: 'Belo Horizonte', value: 17 },
+          { label: 'Uberlândia', value: 18 },
+          { label: 'Contagem', value: 19 },
+          { label: 'Juiz de Fora', value: 20 }
+        ];
+      }
+    }
+    return [];
+  }
+
+  getUserDocument(value) {
+    const cpfField =  { property: 'cpf', visible: true };
+    const cnpjField =  { property: 'cnpj', visible: true };
+    const document = value.isJuridicPerson ? cnpjField : cpfField;
+
+    return {
+      fields: [ document ]
+    };
+  }
+
+}

--- a/projects/ui/src/lib/components/po-dynamic/po-dynamic.module.ts
+++ b/projects/ui/src/lib/components/po-dynamic/po-dynamic.module.ts
@@ -11,6 +11,8 @@ import { PoTimePipe } from '../../pipes/po-time/po-time.pipe';
 
 import { PoDynamicFormComponent } from './po-dynamic-form/po-dynamic-form.component';
 import { PoDynamicFormFieldsComponent } from './po-dynamic-form/po-dynamic-form-fields/po-dynamic-form-fields.component';
+import { PoDynamicFormLoadService } from './po-dynamic-form/po-dynamic-form-load/po-dynamic-form-load.service';
+import { PoDynamicFormValidationService } from './po-dynamic-form/po-dynamic-form-validation/po-dynamic-form-validation.service';
 import { PoDynamicViewComponent } from './po-dynamic-view/po-dynamic-view.component';
 import { PoDynamicViewService } from './po-dynamic-view/po-dynamic-view.service';
 
@@ -33,6 +35,15 @@ import { PoDynamicViewService } from './po-dynamic-view/po-dynamic-view.service'
     PoDynamicFormComponent,
     PoDynamicViewComponent
   ],
-  providers: [ CurrencyPipe, DatePipe, DecimalPipe, PoTimePipe, TitleCasePipe, PoDynamicViewService ]
+  providers: [
+    CurrencyPipe,
+    DatePipe,
+    DecimalPipe,
+    PoTimePipe,
+    TitleCasePipe,
+    PoDynamicFormLoadService,
+    PoDynamicFormValidationService,
+    PoDynamicViewService
+  ]
 })
 export class PoDynamicModule { }


### PR DESCRIPTION
**Dynamic Form**

**DTHFUI-2416**
_____________________________________________________________________________

**PR Checklist**

- [x] Código
- [x] Testes unitários
- [x] Documentação
- [x] Samples

**Qual o comportamento atual?**
N/A

**Qual o novo comportamento?**
Adiciona a propriedade `p-load`, a qual, pode-se informar uma função ou uma url de um serviço, que retorne PoDynamicFormLoad, criando novos campos, atualizando-os e permitindo foca-los.

**Simulação**
- Utilizar o Sample;
- Pode-se criar um serviço no https://www.mockable.io/ e utilizar no componente;
- Importante testar funcionalidades já existentes, como p-validate;