### PR TITLE
feat(http-interceptor): permite exibição de múltiplas mensagens do back end

### DIFF
--- a/projects/ui/src/lib/interceptors/po-http-interceptor/po-http-interceptor-base.service.ts
+++ b/projects/ui/src/lib/interceptors/po-http-interceptor/po-http-interceptor-base.service.ts
@@ -1,9 +1,16 @@
+import { ComponentRef } from '@angular/core';
 import { HttpInterceptor, HttpHandler, HttpRequest, HttpResponse, HttpEvent, HttpErrorResponse } from '@angular/common/http';
 
 import { Observable } from 'rxjs';
 import { tap } from 'rxjs/operators';
 
+import { PoComponentInjectorService } from '../../services/po-component-injector/po-component-injector.service';
+import { PoHttpInterceptorDetail } from './po-http-interceptor-detail/po-http-interceptor-detail.interface';
+import { PoHttpInterceptorDetailComponent } from './po-http-interceptor-detail/po-http-interceptor-detail.component';
+
+// DEPRECATED 4.x.x
 const NO_ERROR_HEADER_PARAM = 'X-Portinari-No-Error';
+const NO_MESSAGE_HEADER_PARAM = 'X-Portinari-No-Message';
 
 /**
  * @description
@@ -15,30 +22,39 @@ const NO_ERROR_HEADER_PARAM = 'X-Portinari-No-Error';
  * Ao analisar o objeto `_messages` retornado pela requisição, o serviço exibirá notificações com mensagens na tela.
  * Os retornos de erros com códigos 4xx e 5xx são tratados automaticamente, sem a necessidade de incluir o `_messages`.
  *
- * Também existe a possibilidade de não apresentar a notificação quando houver algum erro com códigos 4xx e 5xx,
- * utilizando o parâmetro `X-Portinari-No-Error` que foi definido conforme o
- * [**Guia de implementação das APIs TOTVS**](http://tdn.totvs.com/pages/viewpage.action?pageId=484701395) (em Cabeçalhos Customizados).
- * O parâmetro `X-Portinari-No-Error` deve ser informado no cabeçalho da requisição com o valor `'true'` para funcionar corretamente,
- * por exemplo:
+ * É possível dispensar a notificação para o usuário utilizando-se no cabeçalho da requisição os parâmetros listados abaixo com o valor
+ * igual a `true`:
+ *
+ * - `X-Portinari-No-Message`: Não exibe notificações de erro e/ou sucesso.
+ *
+ * - **Depreciado** `X-Portinari-No-Error`: não mostra notificações de erro com códigos `4xx` e `5xx`.
  *
  * ```
  * ...
- *  const headers = { 'X-Portinari-No-Error': 'true' };
+ *  const headers = { 'X-Portinari-No-Message': 'true' };
  *
  *  this.http.get(`/customers/1`, { headers: headers });
  * ...
  *
  * ```
- * > Após a validação no interceptor, o parâmetro será removido do cabeçalho da requisição.
+ *
+ * Mais detalhes no tópico sobre cabeçalhos customizados no
+ * [**Guia de implementação das APIs TOTVS**](http://tdn.totvs.com/pages/viewpage.action?pageId=484701395)
+ *
+ * > Após a validação no interceptor, os parâmetros serão removidos do cabeçalho da requisição.
  *
  * O `Content-Type` deve ser `application/json` e a estrutura de mensagem recebida pelo serviço deve seguir o
  * [**Guia de implementação das APIs TOTVS**](http://tdn.totvs.com/pages/viewpage.action?pageId=484701395)
  * (em Mensagens de sucesso para coleções), exemplo:
- *  - _messages: lista de mensagens de erro ou informativo resultante do serviço.
- *    - type: success, warning, error, e information;
+ *  - _messages: lista de mensagens ou objeto de mensagem, resultante do serviço.
+ *    - type: success, warning, error, e information (será exibido a `tag` apenas se esta propriedade possuir valor);
  *    - code: título ou código da mensagem;
  *    - message: texto da mensagem;
  *    - detailedMessage: detalhamento do erro ou informativo;
+ *
+ * Ao clicar na ação 'Detalhes' no
+ * [`po-notification`](/documentation/po-notification) os detalhes das mensagens de sucesso e de erro são apresentados em
+ * um [`po-modal`](/documentation/po-modal) com um [`po-accordion`](/documentation/po-accordion) que possui um item por mensagem.
  *
  * Ao importar o módulo `PoModule` na aplicação, o `po-http-interceptor` é automaticamente configurado sem a necessidade
  * de qualquer configuração extra.
@@ -69,18 +85,20 @@ export abstract class PoHttpInterceptorBaseService implements HttpInterceptor {
 
   notificationTypes = ['success', 'warning', 'error', 'information'];
 
-  constructor(private notification: any, private dialog: any) { }
+  private httpInterceptorDetailComponent: ComponentRef<PoHttpInterceptorDetailComponent> = undefined;
+
+  constructor(private componentInjector: PoComponentInjectorService, private notification: any) { }
 
   intercept(request: HttpRequest<any>, next: HttpHandler): Observable<HttpEvent<any>> {
     const cloneRequest = request.clone();
 
-    request = request.headers.has(NO_ERROR_HEADER_PARAM) ? this.cloneRequestWithoutNoErrorHeaderParam(request) : request;
+    request = request && this.hasParameters(request) ? this.cloneRequestWithoutParameters(request) : request;
 
     return next.handle(request).pipe(tap((response: HttpEvent<any>) => {
 
       if (response instanceof HttpResponse) {
 
-        this.processResponse(response);
+        this.processResponse(response, cloneRequest);
 
       }
     }, (error: HttpErrorResponse) => {
@@ -90,13 +108,15 @@ export abstract class PoHttpInterceptorBaseService implements HttpInterceptor {
     }));
   }
 
-  processResponse(response: HttpResponse<any>) {
-    if (response.body && response.body._messages) {
+  processResponse(response: HttpResponse<any>, request: HttpRequest<any>) {
+    const hasNoMessageParam = this.hasNoMessageParam(request);
+
+    if (!hasNoMessageParam && response.body && response.body._messages) {
 
       const messages = response.body._messages;
 
       if (messages instanceof Array) {
-        messages.forEach((message: any) => {
+        messages.forEach((message: PoHttpInterceptorDetail) => {
           this.showNotification(message);
         });
       } else {
@@ -111,15 +131,41 @@ export abstract class PoHttpInterceptorBaseService implements HttpInterceptor {
       : { code: 0, message: 'Servidor não está respondendo.', detailedMessage: response.message };
 
     const hasNoErrorParam = this.hasNoErrorParam(request);
+    const hasNoMessageParam = this.hasNoMessageParam(request);
 
-    // not show the notification when has NoError parameter on header of request.
-    if (errorResponse && errorResponse.message && !hasNoErrorParam) {
+    if (errorResponse && errorResponse.message && !hasNoErrorParam && !hasNoMessageParam) {
       this.showNotification({ ...errorResponse, type: 'error' });
     }
   }
 
-  private cloneRequestWithoutNoErrorHeaderParam(request: HttpRequest<any>): HttpRequest<any> {
-    return request && request.clone({headers: request.headers.delete(NO_ERROR_HEADER_PARAM)});
+  private cloneRequestWithoutParameters(request: HttpRequest<any>): HttpRequest<any> {
+    const headers = request.headers
+      .delete(NO_ERROR_HEADER_PARAM)
+      .delete(NO_MESSAGE_HEADER_PARAM);
+
+    return request.clone({ headers });
+  }
+
+  private createModal(responseMessage: PoHttpInterceptorDetail) {
+    const details = responseMessage.details ? [ responseMessage, ...responseMessage.details ] : [ responseMessage ];
+
+    this.httpInterceptorDetailComponent = this.componentInjector.createComponentInApplication(PoHttpInterceptorDetailComponent);
+    this.httpInterceptorDetailComponent.instance.detail = details;
+    this.httpInterceptorDetailComponent.instance.closed.subscribe(() => this.destroyModal());
+    this.httpInterceptorDetailComponent.instance.open();
+  }
+
+  private destroyModal() {
+    if (this.httpInterceptorDetailComponent) {
+      this.componentInjector.destroyComponentInApplication(this.httpInterceptorDetailComponent);
+      this.httpInterceptorDetailComponent = undefined;
+    }
+  }
+
+  private hasMessage(responseMessage: PoHttpInterceptorDetail) {
+    const hasMessageProperties = responseMessage.message;
+
+    return responseMessage && hasMessageProperties;
   }
 
   private hasNoErrorParam(request: HttpRequest<any>): boolean {
@@ -128,7 +174,22 @@ export abstract class PoHttpInterceptorBaseService implements HttpInterceptor {
     return noErrorParam && noErrorParam.toString().toLocaleLowerCase() === 'true';
   }
 
+  private hasNoMessageParam(request: HttpRequest<any>): boolean {
+    const noMessageParam = request && request.headers.get(NO_MESSAGE_HEADER_PARAM);
+
+    return noMessageParam && noMessageParam.toString().toLocaleLowerCase() === 'true';
+  }
+
+  private hasParameters(request: HttpRequest<any>) {
+    return request.headers.has(NO_ERROR_HEADER_PARAM) || request.headers.has(NO_MESSAGE_HEADER_PARAM);
+  }
+
   private showNotification(response: any) {
+
+    if (!this.hasMessage(response)) {
+      return;
+    }
+
     const typeNotification = this.notificationTypes.includes(response.type) ? response.type : 'information';
 
     const notificationAction = this.generateNotificationAction(response);
@@ -140,26 +201,26 @@ export abstract class PoHttpInterceptorBaseService implements HttpInterceptor {
     });
   }
 
-  private generateNotificationAction(errorResponse: any) {
+  private generateDetailModal(responseMessage: any) {
+    return () => {
+      if (!this.httpInterceptorDetailComponent) {
+        this.createModal(responseMessage);
+      }
+    };
+  }
+
+  private generateNotificationAction(responseMessage: any) {
 
     let notificationAction;
     let notificationLabel;
 
-    let notificationMessage = errorResponse.message.concat(` ${errorResponse.detailedMessage}`);
-
-    if (errorResponse.details && errorResponse.details instanceof Array) {
-      errorResponse.details.forEach((detailError: any) => {
-        notificationMessage += `\n${detailError.message}`;
-      });
-    }
-
-    if (errorResponse.helpUrl && !(errorResponse.detailedMessage || errorResponse.details)) {
+    if (responseMessage.helpUrl && !(responseMessage.detailedMessage || responseMessage.details)) {
       notificationLabel = 'Ajuda';
-      notificationAction = this.generateUrlHelpFunction(errorResponse.helpUrl);
+      notificationAction = this.generateUrlHelpFunction(responseMessage.helpUrl);
 
-    } else if (errorResponse.detailedMessage || errorResponse.details) {
+    } else if (responseMessage.detailedMessage || responseMessage.details) {
       notificationLabel = 'Detalhes';
-      notificationAction = this.generateDialogDetailFunction(errorResponse, notificationMessage);
+      notificationAction = this.generateDetailModal(responseMessage);
     }
     return { label: notificationLabel, action: notificationAction };
   }
@@ -168,13 +229,4 @@ export abstract class PoHttpInterceptorBaseService implements HttpInterceptor {
     return () => { window.open(helpUrl, '_blank'); };
   }
 
-  private generateDialogDetailFunction(errorResponse: any, notificationMessage: string) {
-    return () => {
-      this.dialog.alert({
-        title: errorResponse.code,
-        message: notificationMessage,
-        ok: errorResponse.helpUrl ? this.generateUrlHelpFunction(errorResponse.helpUrl) : undefined
-      });
-    };
-  }
 }

--- a/projects/ui/src/lib/interceptors/po-http-interceptor/po-http-interceptor-detail/po-http-interceptor-detail-literals.interface.ts
+++ b/projects/ui/src/lib/interceptors/po-http-interceptor/po-http-interceptor-detail/po-http-interceptor-detail-literals.interface.ts
@@ -1,0 +1,38 @@
+export const poHttpInterceptorDetailLiteralsDefault = {
+  en: <any> {
+    closeButton: 'Close',
+    details: 'Details',
+    detail: 'Detail',
+    error: 'Error',
+    warning: 'Warning',
+    info: 'Information',
+    success: 'Success'
+  },
+  es: <any> {
+    closeButton: 'Cerrar',
+    details: 'Detalles',
+    detail: 'Detalle',
+    error: 'Error',
+    warning: 'Advertencia',
+    info: 'Informacion',
+    success: 'Éxito'
+  },
+  pt: <any> {
+    closeButton: 'Fechar',
+    details: 'Detalhes',
+    detail: 'Detalhe',
+    error: 'Erro',
+    warning: 'Aviso',
+    info: 'Informação',
+    success: 'Sucesso'
+  },
+  ru: <any>{
+    closeButton: 'близко',
+    details: 'Детали',
+    detail: 'деталь',
+    error: 'ошибка',
+    warning: 'предупреждение',
+    info: 'информация',
+    success: 'Yспех'
+  }
+};

--- a/projects/ui/src/lib/interceptors/po-http-interceptor/po-http-interceptor-detail/po-http-interceptor-detail.component.html
+++ b/projects/ui/src/lib/interceptors/po-http-interceptor/po-http-interceptor-detail/po-http-interceptor-detail.component.html
@@ -1,0 +1,22 @@
+<po-modal
+  p-hide-close p-size="lg"
+  [p-primary-action]="primaryAction"
+  [p-title]="title">
+
+  <div class="po-row">
+    <po-accordion class="po-md-12 po-mt-1 po-mb-1">
+      <po-accordion-item *ngFor="let detail of details" [p-label]="formatDetailItemTitle(detail)">
+
+        <div *ngIf="detail.type" class="po-row po-mb-1">
+          <po-tag [p-color]="typeColor(detail.type)" [p-value]="typeValue(detail.type)"></po-tag>
+        </div>
+
+        <div class="po-row">
+          <p>{{detail.detailedMessage}}</p>
+        </div>
+
+      </po-accordion-item>
+    </po-accordion>
+  </div>
+
+</po-modal>

--- a/projects/ui/src/lib/interceptors/po-http-interceptor/po-http-interceptor-detail/po-http-interceptor-detail.component.spec.ts
+++ b/projects/ui/src/lib/interceptors/po-http-interceptor/po-http-interceptor-detail/po-http-interceptor-detail.component.spec.ts
@@ -1,0 +1,292 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { configureTestSuite } from '../../../util-test/util-expect.spec';
+import * as UtilsFunctions from '../../../utils/util';
+
+import { PoAccordionModule } from '../../../components/po-accordion/po-accordion.module';
+import { PoHttpInterceptorDetail } from './po-http-interceptor-detail.interface';
+import { PoHttpInterceptorDetailComponent } from './po-http-interceptor-detail.component';
+import { PoModalModule } from '../../../components/po-modal/po-modal.module';
+import { PoTagModule } from '../../../components/po-tag/po-tag.module';
+
+describe('PoHttpInterceptorDetailComponent:', () => {
+
+  let component: PoHttpInterceptorDetailComponent;
+  let fixture: ComponentFixture<PoHttpInterceptorDetailComponent>;
+  let nativeElement: any;
+
+  configureTestSuite(() => {
+    TestBed.configureTestingModule({
+      declarations: [ PoHttpInterceptorDetailComponent ],
+      imports: [ PoAccordionModule, PoModalModule, PoTagModule ]
+    });
+  });
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(PoHttpInterceptorDetailComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+    nativeElement = fixture.debugElement.nativeElement;
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+
+  describe('Properties:', () => {
+
+    it('details: should update title', () => {
+      const details = [
+        { code: '200', detailedMessage: 'test 1', message: 'message 1', type: 'success' },
+        { code: '201', detailedMessage: 'test 2', message: 'message 2', type: 'success' },
+        { code: '400', detailedMessage: 'test 3', message: 'message 3', type: 'error' }
+      ];
+
+      component.detail = details;
+
+      expect(component.title).toBe('Details (3)');
+    });
+
+    it('details: shouldn`t add details if it is undefined', () => {
+      const details = undefined;
+
+      component.detail = details;
+
+      expect(component.details).toEqual([]);
+    });
+
+    it('details: should add details in this.details', () => {
+      const details = [
+        { code: '200', detailedMessage: 'test 1', message: 'message 1', type: 'success' },
+        { code: '201', detailedMessage: 'test 2', message: 'message 2', type: 'success' },
+        { code: '400', detailedMessage: 'test 3', message: 'message 3', type: 'error' }
+      ];
+
+      component.detail = details;
+
+      expect(component.details).toEqual(details);
+    });
+
+    it('detail: should add detail in details without detail list', () => {
+      const detail = {
+        code: '200',
+        detailedMessage: 'detailed message',
+        message: 'my message',
+        type: 'success',
+        details: [
+          { code: '200', detailedMessage: 'test 1', message: 'message 1', type: 'success' }
+        ]
+      };
+
+      const expectedDetails = [
+        {
+          code: '200',
+          detailedMessage: 'detailed message',
+          message: 'my message',
+          type: 'success',
+        }
+      ];
+      component.details = [];
+
+      component.detail = [ detail ];
+
+      expect(component.details).toEqual(expectedDetails);
+    });
+
+    it('primaryAction: should call `close` when call primaryAction.action', () => {
+      spyOn(component, 'close');
+
+      component.primaryAction.action();
+
+      expect(component.close).toHaveBeenCalled();
+    });
+
+  });
+
+  describe('Methods', () => {
+
+    it('close: should call modal.close and closed.emit', () => {
+      spyOn(component.modal, 'close');
+      spyOn(component['closed'], 'emit');
+
+      component.close();
+
+      expect(component.modal.close).toHaveBeenCalled();
+      expect(component['closed'].emit).toHaveBeenCalled();
+    });
+
+    it('open: should call modal.open', () => {
+      spyOn(component.modal, 'open');
+
+      component.open();
+
+      expect(component.modal.open).toHaveBeenCalled();
+    });
+
+    it('typeColor: should return color `color-11` if type is `success`', () => {
+      const type = 'success';
+
+      expect(component.typeColor(type)).toBe('color-11');
+    });
+
+    it('typeColor: should return color `color-08` if type is `warning`', () => {
+      const type = 'warning';
+
+      expect(component.typeColor(type)).toBe('color-08');
+    });
+
+    it('typeColor: should return color `color-07` if type is `error`', () => {
+      const type = 'error';
+
+      expect(component.typeColor(type)).toBe('color-07');
+    });
+
+    it('typeColor: should return empty string if type is `info`', () => {
+      const type = 'info';
+
+      expect(component.typeColor(type)).toBe('');
+    });
+
+    it('getValidDetailProperties: should return detail without invalid properties', () => {
+      const detail = {
+        code: '200',
+        detailedMessage: 'test 1',
+        message: 'message 1',
+        type: 'success',
+        details: [],
+        _messages: []
+      };
+
+      const expectedDetail = {
+        code: '200',
+        detailedMessage: 'test 1',
+        message: 'message 1',
+        type: 'success'
+      };
+
+      expect(component['getValidDetailProperties'](detail)).toEqual(expectedDetail);
+    });
+
+    it('formatTitle: should return literals.detail if details length is 1', () => {
+      const details = [
+        { code: '200', detailedMessage: 'test 1', message: 'message 1', type: 'success' }
+      ];
+
+      component.literals.detail = 'Detail';
+
+      expect(component['formatTitle'](details)).toBe(component.literals.detail);
+    });
+
+    it('formatTitle: should return literals.details and details legth if details length isn`t 1', () => {
+      const details = [
+        { code: '200', detailedMessage: 'test 1', message: 'message 1', type: 'success' },
+        { code: '201', detailedMessage: 'test 2', message: 'message 2', type: 'success' },
+        { code: '400', detailedMessage: 'test 3', message: 'message 3', type: 'error' }
+      ];
+
+      spyOn(UtilsFunctions, 'getShortBrowserLanguage').and.returnValue('en');
+
+      component.literals.details = 'Details';
+
+      const expectedTitle = 'Details (3)';
+
+      expect(component['formatTitle'](details)).toBe(expectedTitle);
+    });
+
+    it('formatDetailItemTitle: should return detail message if code is undefined', () => {
+      const detail: PoHttpInterceptorDetail = {
+        message: 'message',
+        code: undefined,
+        detailedMessage: ''
+      };
+
+      expect(component['formatDetailItemTitle'](detail)).toBe('message');
+    });
+
+    it('formatDetailItemTitle: should return detail message and code if code is defined', () => {
+      const detail: PoHttpInterceptorDetail = {
+        message: 'message',
+        code: '1000',
+        detailedMessage: ''
+      };
+
+      expect(component['formatDetailItemTitle'](detail)).toBe('1000 - message');
+    });
+
+    it('typeValue: should return type if poHttpInterceptorDetailLiteralsDefault not contain type', () => {
+      const type = 'test';
+
+      expect(component.typeValue(type)).toBe('test');
+    });
+
+  });
+
+  describe('Templates:', () => {
+
+    it('should contain three details if the length of the details is three', () => {
+      const details = [
+        { code: '200', detailedMessage: 'test 1', message: 'message 1', type: 'success' },
+        { code: '201', detailedMessage: 'test 2', message: 'message 2', type: 'success' },
+        { code: '400', detailedMessage: 'test 3', message: 'message 3', type: 'error' }
+      ];
+
+      component.open();
+      component.detail = details;
+
+      fixture.detectChanges();
+
+      const detailsElement = nativeElement.querySelectorAll('.po-accordion-item');
+
+      expect(detailsElement.length).toBe(3);
+    });
+
+    it('shouldn`t show detail if message is undefined', () => {
+      const details = [
+        { code: '200', detailedMessage: 'test 1', message: 'message 1', type: 'success' },
+        { code: '201', detailedMessage: 'test 2', message: undefined, type: 'success' },
+        { code: '400', detailedMessage: 'test 3', message: 'message 3', type: 'error' }
+      ];
+
+      component.open();
+      component.detail = details;
+
+      fixture.detectChanges();
+
+      const detailsElement = nativeElement.querySelectorAll('.po-accordion-item');
+
+      expect(detailsElement.length).toBe(2);
+    });
+
+    it('shouldn`t contain `po-tag` if detail.type is undefined', () => {
+      const details = [
+        { code: '200', detailedMessage: 'test 1', message: 'message 1' }
+      ];
+
+      component.open();
+      component.detail = details;
+
+      fixture.detectChanges();
+
+      const tag = nativeElement.querySelector('po-tag');
+
+      expect(tag).toBeNull();
+    });
+
+    it('should contain `po-tag` if detail.type is defined', () => {
+      const details = [
+        { code: '200', detailedMessage: 'test 1', message: 'message 1', type: 'success' }
+      ];
+
+      component.open();
+      component.detail = details;
+
+      fixture.detectChanges();
+
+      const tag = nativeElement.querySelector('po-tag');
+
+      expect(tag).toBeDefined();
+    });
+
+  });
+
+});

--- a/projects/ui/src/lib/interceptors/po-http-interceptor/po-http-interceptor-detail/po-http-interceptor-detail.component.ts
+++ b/projects/ui/src/lib/interceptors/po-http-interceptor/po-http-interceptor-detail/po-http-interceptor-detail.component.ts
@@ -1,0 +1,85 @@
+import { Component, EventEmitter, ViewChild } from '@angular/core';
+
+import { getShortBrowserLanguage } from '../../../utils/util';
+import { PoModalAction } from '../../../components/po-modal/po-modal-action.interface';
+import { PoModalComponent } from '../../../components/po-modal/po-modal.component';
+
+import { PoHttpInterceptorDetail } from './po-http-interceptor-detail.interface';
+import { poHttpInterceptorDetailLiteralsDefault } from './po-http-interceptor-detail-literals.interface';
+
+export const colors = { success: 'color-11', error: 'color-07', warning: 'color-08', info: '' };
+
+/**
+ * @docsPrivate
+ *
+ * @description
+ *
+ * Componente para a modal de detalhes exibida pelo interceptor
+ */
+@Component({
+  selector: 'po-http-interceptor-detail',
+  templateUrl: './po-http-interceptor-detail.component.html',
+})
+export class PoHttpInterceptorDetailComponent {
+
+  @ViewChild(PoModalComponent, { static: true }) modal: PoModalComponent;
+
+  closed = new EventEmitter<any>();
+  details: Array<PoHttpInterceptorDetail> = [];
+  language = getShortBrowserLanguage();
+  literals = poHttpInterceptorDetailLiteralsDefault[this.language];
+
+  primaryAction: PoModalAction = {
+    action: () => this.close(),
+    label: this.literals.closeButton
+  };
+
+  title: string;
+
+  set detail(details: Array<PoHttpInterceptorDetail>) {
+
+    if (details && details.length) {
+      this.details = this.filterByValidDetails(details);
+    }
+
+    this.title = this.formatTitle(this.details);
+  }
+
+  close() {
+    this.modal.close();
+    this.closed.emit();
+  }
+
+  formatDetailItemTitle(detail) {
+    return detail.code ? `${ detail.code } - ${ detail.message }` : detail.message;
+  }
+
+  open() {
+    this.modal.open();
+  }
+
+  typeColor(type: string): string {
+    return colors[type];
+  }
+
+  typeValue(type: string): string {
+    return poHttpInterceptorDetailLiteralsDefault[this.language][type] || type;
+  }
+
+  private addValidDetail(newDetails: Array<PoHttpInterceptorDetail>, detail: PoHttpInterceptorDetail) {
+    return detail.message ? newDetails.concat(this.getValidDetailProperties(detail)) : newDetails;
+  }
+
+  private getValidDetailProperties({ code, message, detailedMessage, type }: PoHttpInterceptorDetail) {
+    return { code, message, detailedMessage, type };
+  }
+
+  private filterByValidDetails(details: Array<PoHttpInterceptorDetail>) {
+    return details.reduce((newDetails, detail) => this.addValidDetail(newDetails, detail), []);
+  }
+
+  private formatTitle(details: Array<PoHttpInterceptorDetail>) {
+    return details.length > 1 ? `${this.literals.details} (${details.length})` : this.literals.detail;
+  }
+
+}

--- a/projects/ui/src/lib/interceptors/po-http-interceptor/po-http-interceptor-detail/po-http-interceptor-detail.interface.ts
+++ b/projects/ui/src/lib/interceptors/po-http-interceptor/po-http-interceptor-detail/po-http-interceptor-detail.interface.ts
@@ -1,0 +1,26 @@
+/**
+ * @docsPrivate
+ *
+ * @usedBy PoHttpInterceptorService
+ *
+ * @description
+ *
+ * Interface para as mensagens do `po-http-interceptor`.
+ */
+export interface PoHttpInterceptorDetail {
+
+  /** Código */
+  code: string;
+
+  /** Mensagem detalhada */
+  detailedMessage: string;
+
+  /** Lista de detalhes da mensagem */
+  details?: Array<PoHttpInterceptorDetail>;
+
+  /** Mensagem */
+  message: string;
+
+  /** Tipo do detalhe que pode ser: success, error, warning e info */
+  type?: string;
+}

--- a/projects/ui/src/lib/interceptors/po-http-interceptor/po-http-interceptor.module.ts
+++ b/projects/ui/src/lib/interceptors/po-http-interceptor/po-http-interceptor.module.ts
@@ -1,20 +1,36 @@
-import { NgModule } from '@angular/core';
+import { CommonModule } from '@angular/common';
 import { HTTP_INTERCEPTORS } from '@angular/common/http';
+import { NgModule } from '@angular/core';
 
-import { PoDialogService } from './../../services/po-dialog/po-dialog.service';
+import { PoAccordionModule } from '../../components/po-accordion/po-accordion.module';
+import { PoModalModule } from '../../components/po-modal/po-modal.module';
+import { PoNotificationModule } from '../../services/po-notification/po-notification.module';
 import { PoNotificationService } from './../../services/po-notification/po-notification.service';
+import { PoTagModule } from '../../components/po-tag/po-tag.module';
+
+import { PoHttpInterceptorDetailComponent } from './po-http-interceptor-detail/po-http-interceptor-detail.component';
 import { PoHttpInterceptorService } from './po-http-interceptor.service';
 
 @NgModule({
+  imports: [
+    CommonModule,
+    PoAccordionModule,
+    PoModalModule,
+    PoNotificationModule,
+    PoTagModule
+  ],
+  declarations: [
+    PoHttpInterceptorDetailComponent,
+  ],
   providers: [
     PoHttpInterceptorService,
-    PoDialogService,
     PoNotificationService,
     {
       provide: HTTP_INTERCEPTORS,
       useClass: PoHttpInterceptorService,
       multi: true
     }
-  ]
+  ],
+  entryComponents: [PoHttpInterceptorDetailComponent]
 })
 export class PoHttpInterceptorModule { }

--- a/projects/ui/src/lib/interceptors/po-http-interceptor/po-http-interceptor.service.spec.ts
+++ b/projects/ui/src/lib/interceptors/po-http-interceptor/po-http-interceptor.service.spec.ts
@@ -1,14 +1,11 @@
-import { TestBed } from '@angular/core/testing';
 import { HTTP_INTERCEPTORS } from '@angular/common/http';
+import { TestBed } from '@angular/core/testing';
 
 import { configureTestSuite } from './../../util-test/util-expect.spec';
+import { PoComponentInjectorService } from './../../services/po-component-injector/po-component-injector.service';
+import { PoNotificationService } from './../../services/po-notification/po-notification.service';
 
 import { PoHttpInterceptorBaseService } from './po-http-interceptor-base.service';
-
-import { PoDialogService } from './../../services/po-dialog/po-dialog.service';
-import { PoNotificationService } from './../../services/po-notification/po-notification.service';
-import { PoComponentInjectorService } from './../../services/po-component-injector/po-component-injector.service';
-
 import { PoHttpInterceptorService } from './po-http-interceptor.service';
 
 describe('PoHttpInterceptor', () => {
@@ -17,7 +14,6 @@ describe('PoHttpInterceptor', () => {
     TestBed.configureTestingModule({
       providers: [
         PoNotificationService,
-        PoDialogService,
         PoComponentInjectorService,
         {
           provide: HTTP_INTERCEPTORS,
@@ -30,9 +26,9 @@ describe('PoHttpInterceptor', () => {
 
   it('should be created', () => {
     const notification = TestBed.get(PoNotificationService);
-    const dialog = TestBed.get(PoDialogService);
+    const componentInjector = TestBed.get(PoComponentInjectorService);
 
-    const service = new PoHttpInterceptorService(notification, dialog);
+    const service = new PoHttpInterceptorService(notification, componentInjector);
 
     expect(service instanceof PoHttpInterceptorService).toBeTruthy();
     expect(service instanceof PoHttpInterceptorBaseService).toBeTruthy();

--- a/projects/ui/src/lib/interceptors/po-http-interceptor/po-http-interceptor.service.ts
+++ b/projects/ui/src/lib/interceptors/po-http-interceptor/po-http-interceptor.service.ts
@@ -1,8 +1,9 @@
 import { Injectable } from '@angular/core';
 
-import { PoHttpInterceptorBaseService } from './po-http-interceptor-base.service';
+import { PoComponentInjectorService } from '../../services/po-component-injector/po-component-injector.service';
 import { PoNotificationService } from './../../services/po-notification/po-notification.service';
-import { PoDialogService } from './../../services/po-dialog/po-dialog.service';
+
+import { PoHttpInterceptorBaseService } from './po-http-interceptor-base.service';
 
 /**
  * @docsExtends PoHttpInterceptorBaseService
@@ -15,7 +16,7 @@ import { PoDialogService } from './../../services/po-dialog/po-dialog.service';
  */
 @Injectable()
 export class PoHttpInterceptorService extends PoHttpInterceptorBaseService {
-  constructor(notification: PoNotificationService, dialog: PoDialogService) {
-    super(notification, dialog);
+  constructor(notification: PoNotificationService, componentInjector: PoComponentInjectorService) {
+    super(componentInjector, notification);
   }
 }

--- a/projects/ui/src/lib/interceptors/po-http-interceptor/samples/sample-po-http-interceptor-labs.component.html
+++ b/projects/ui/src/lib/interceptors/po-http-interceptor/samples/sample-po-http-interceptor-labs.component.html
@@ -1,69 +1,47 @@
-<form #f="ngForm">
+<h2>Process request with Http Interceptor</h2>
+<p>Edit response object by server with pattern expected by Http Interceptor:</p>
 
+<po-code-editor
+  [(ngModel)]="requestMessage"
+  p-height="330"
+  p-theme="vs-dark">
+</po-code-editor>
+
+<hr>
+
+<form #requestForm="ngForm">
   <div class="po-row">
-    <po-input class="po-lg-5"
-      name="text"
-      [(ngModel)]="text"
-      p-clean
-      p-label="Texto da notificação"
-      p-placeholder="Texto"
-      p-maxlength="50"
-      p-required>
-    </po-input>
-
-    <po-input class="po-md-4 po-lg-2"
-      name="code"
-      [(ngModel)]="code"
-      p-clean
-      p-label="Código"
-      p-maxlength="5"
-      p-placeholder="Código">
-    </po-input>
-
-    <po-url class="po-md-8 po-lg-5"
-      name="help"
-      [(ngModel)]="help"
-      p-clean
-      p-label="Url para Ajuda"
-      p-placeholder="Url">
-    </po-url>
-  </div>
-
-  <div class="po-row">
-    <po-radio-group class="po-md-6"
-      name="type"
-      [(ngModel)]="type"
-      p-label="Tipo de Notificação"
-      p-required
-      [p-options]="typeOptions">
-    </po-radio-group>
-
     <po-radio-group class="po-md-6"
       name="status"
       [(ngModel)]="status"
-      p-label="Status"
-      p-required
-      [p-options]="statusOptions">
+      p-label="Http Status"
+      [p-options]="statusOptions"
+      (p-change)="changeOption()">
     </po-radio-group>
-  </div>
 
-  <div class="po-row">
-    <po-switch class="po-lg-12"
-      name="noErrorHeaderParam"
-      [(ngModel)]="noErrorHeaderParam"
-      p-help="Ativa/desativa o envio do parametro X-Portinari-No-Error no cabeçalho da requisição."
-      p-label="Ativar X-Portinari-No-Error"
-      p-label-off="Não"
-      p-label-on="Sim">
+    <po-switch class="po-md-6"
+      name="noMessageHeaderParam"
+      [(ngModel)]="noMessageHeaderParam"
+      p-help="Enable/disables notification"
+      p-label="X-Portinari-No-Message"
+      p-label-off="Off"
+      p-label-on="On">
     </po-switch>
   </div>
 
-  <div class="po-row">
-    <po-button class="po-md-4"
-      p-label="Gerar Requisição"
-      [p-disabled]="!f.form.valid"
+  <div class="po-row po-mt-1">
+    <po-button
+      class="po-md-3"
+      p-label="Process Request"
       (p-click)="processRequest()">
     </po-button>
   </div>
 
+  <div class="po-row po-mt-1">
+    <po-button
+      class="po-md-3"
+      p-label="Sample Restore"
+      (p-click)="restore()">
+    </po-button>
+  </div>
 </form>


### PR DESCRIPTION
**Http Interceptor **

**DTHFUI-898**
_____________________________________________________________________________

**PR Checklist**

- [x] Código
- [x] Testes unitários
- [x] Documentação
- [x] Samples

**Qual o comportamento atual?**
As mensagens são concatenadas em uma string única e aparecem em um componente dialog, dificultando a visualização dos detalhes.

**Qual o novo comportamento?**
As mensagens são visualizadas em uma modal que possui dentro dela um accordion, que exibe os detalhes.

É possível definir um parâmetro `X-Portinari-no-Message` para não exibir mensagens de sucesso.

**Simulação**
Pode utilizar o sample lab em conjunto com o serviço que está na [PR do TFS](https://totvstfs.visualstudio.com/THF/_git/thf-sample-api-provisorio/pullrequest/17935?path=%2Froutes&_a=overview).

No sample labs utilizar o serviço com porta local: alterar de `https://thf.totvs.com.br/sample/api/message` para `http://localhost:3000/message`

IMPORTANTE - Publicar o serviço no `thf.totvs.com.br/sample/api/`.

