### PR TITLE
feat(combo): adiciona a propriedade p-clean

### DIFF
--- a/projects/ui/src/lib/components/po-field/po-combo/po-combo-base.component.spec.ts
+++ b/projects/ui/src/lib/components/po-field/po-combo/po-combo-base.component.spec.ts
@@ -1220,6 +1220,21 @@ describe('PoComboBaseComponent:', () => {
 
       expect(spyListingComboOptions).not.toHaveBeenCalled();
     });
+
+    it('clear: should call `callModelChange` and `updateSelectedValue` and `updateComboList`', () => {
+      component.clean = true;
+
+      spyOn(component, 'callModelChange');
+      spyOn(component, 'updateSelectedValue');
+      spyOn(component, 'updateComboList');
+
+      component.clear('');
+
+      expect(component.callModelChange).toHaveBeenCalled();
+      expect(component.updateSelectedValue).toHaveBeenCalled();
+      expect(component.updateComboList).toHaveBeenCalled();
+      expect(component.selectedValue).toEqual(undefined);
+    });
   });
 
 });

--- a/projects/ui/src/lib/components/po-field/po-combo/po-combo-base.component.ts
+++ b/projects/ui/src/lib/components/po-field/po-combo/po-combo-base.component.ts
@@ -447,6 +447,9 @@ export abstract class PoComboBaseComponent implements ControlValueAccessor, OnIn
     return this._literals || poComboLiteralsDefault[browserLanguage()];
   }
 
+  /** Se verdadeiro, o campo receberá um botão para ser limpo. */
+  @Input('p-clean') @InputBoolean() clean?: boolean;
+
   /** Deve ser informada uma função que será disparada quando houver alterações no ngModel. */
   @Output('p-change') change?: EventEmitter<any> = new EventEmitter<any>();
 
@@ -712,6 +715,12 @@ export abstract class PoComboBaseComponent implements ControlValueAccessor, OnIn
       };
     }
 
+  }
+
+  clear(value) {
+    this.callModelChange(value);
+    this.updateSelectedValue(null, true, true);
+    this.updateComboList();
   }
 
   protected validateModel(model: any) {

--- a/projects/ui/src/lib/components/po-field/po-combo/po-combo.component.html
+++ b/projects/ui/src/lib/components/po-field/po-combo/po-combo.component.html
@@ -8,7 +8,7 @@
       <span class="po-icon po-field-icon {{icon}}" [class.po-field-icon-disabled]="disabled"></span>
     </div>
 
-    <input #inputElement
+    <input #inputEl
       class="po-input po-combo-input"
       [class.po-input-icon-left]="icon"
       autocomplete="off"
@@ -21,6 +21,14 @@
       (keyup)="onKeyUp($event)"
       (keyup.enter)="searchOnEnter($event.target.value)"
       (keydown)="onKeyDown($event)">
+
+    <div class="po-field-second-icon-container-right">
+      <po-clean 
+        [class.po-field-icon-disabled]="disabled"
+        (p-change-event)="clear($event)"
+        [p-element-ref]="inputElement">
+      </po-clean>
+    </div>
 
     <div class="po-field-icon-container-right">
       <span #iconArrow

--- a/projects/ui/src/lib/components/po-field/po-combo/po-combo.component.spec.ts
+++ b/projects/ui/src/lib/components/po-field/po-combo/po-combo.component.spec.ts
@@ -13,6 +13,7 @@ import { PoLoadingModule } from '../../po-loading/po-loading.module';
 import { PoFieldContainerBottomComponent } from './../po-field-container/po-field-container-bottom/po-field-container-bottom.component';
 import { PoFieldContainerComponent } from '../po-field-container/po-field-container.component';
 
+import { PoCleanComponent } from '../po-clean/po-clean.component';
 import { PoComboComponent } from './po-combo.component';
 import { PoComboFilterMode } from './po-combo-filter-mode.enum';
 import { PoComboFilterService } from './po-combo-filter.service';
@@ -36,7 +37,8 @@ describe('PoComboComponent:', () => {
       declarations: [
         PoComboComponent,
         PoFieldContainerComponent,
-        PoFieldContainerBottomComponent
+        PoFieldContainerBottomComponent,
+        PoCleanComponent
       ],
       providers: [ HttpClient, HttpHandler]
     });
@@ -1557,7 +1559,8 @@ describe('PoComboComponent - with service:', () => {
       ],
       declarations: [ PoComboComponent,
         PoFieldContainerComponent,
-        PoFieldContainerBottomComponent
+        PoFieldContainerBottomComponent,
+        PoCleanComponent
       ],
       providers: [ HttpClient, HttpHandler, PoComboFilterService]
     });

--- a/projects/ui/src/lib/components/po-field/po-combo/po-combo.component.ts
+++ b/projects/ui/src/lib/components/po-field/po-combo/po-combo.component.ts
@@ -107,7 +107,7 @@ export class PoComboComponent extends PoComboBaseComponent implements AfterViewI
   @ViewChild('containerElement', { read: ElementRef, static: false }) containerElement: ElementRef;
   @ViewChild('contentElement', { read: ElementRef, static: false }) contentElement: ElementRef;
   @ViewChild('iconArrow', { read: ElementRef, static: true }) iconElement: ElementRef;
-  @ViewChild('inputElement', { read: ElementRef, static: true }) inputElement: ElementRef;
+  @ViewChild('inputEl', { read: ElementRef, static: true }) inputElement: ElementRef;
 
   constructor(
     public element: ElementRef,

--- a/projects/ui/src/lib/components/po-field/po-combo/samples/sample-po-combo-labs/sample-po-combo-labs.component.html
+++ b/projects/ui/src/lib/components/po-field/po-combo/samples/sample-po-combo-labs/sample-po-combo-labs.component.html
@@ -3,6 +3,7 @@
   name="combo"
   [(ngModel)]="combo"
   [p-change-on-enter]="properties.includes('changeOnEnter')"
+  [p-clean]="properties.includes('clean')"
   [p-debounce-time]="debounceTime"
   [p-disabled]="properties.includes('disabled')"
   [p-disabled-init-filter]="properties.includes('disableInitFilter')"

--- a/projects/ui/src/lib/components/po-field/po-combo/samples/sample-po-combo-labs/sample-po-combo-labs.component.ts
+++ b/projects/ui/src/lib/components/po-field/po-combo/samples/sample-po-combo-labs/sample-po-combo-labs.component.ts
@@ -58,7 +58,8 @@ export class SamplePoComboLabsComponent implements OnInit {
     { value: 'optional', label: 'Optional' },
     { value: 'disabledInitFilter', label: 'Disabled Init Filter' },
     { value: 'required', label: 'Required' },
-    { value: 'sort', label: 'Sort' }
+    { value: 'sort', label: 'Sort' },
+    { value: 'clean', label: 'Clean' }
   ];
 
   ngOnInit() {


### PR DESCRIPTION
**po-combo**

**DTHFUI-2314**
_____________________________________________________________________________

**PR Checklist**

- [X] Código
- [X] Testes unitários
- [X] Documentação
- [X] Samples

**Qual o comportamento atual?**
Para limpar a seleção do combo deve apagar todos caracteres do input.

**Qual o novo comportamento?**
Ao atribuir o valor true para a propriedade p-clean e selecionar um item no combo, será exibido um ícone X. Ao clicar neste ícone, o combo será limpo.

**Simulação**
Criar um po-combo com a propriedade p-clean, escolher alguma opção do combo e clicar no X ao lado da seta. O combo deve ser limpo e o ngModel deve ser atualizado
