### PR TITLE
perf(table): implementa alguns itens de performance

### DIFF
--- a/projects/ui/src/lib/components/po-table/po-table-base.component.spec.ts
+++ b/projects/ui/src/lib/components/po-table/po-table-base.component.spec.ts
@@ -1,11 +1,11 @@
 import * as utilsFunctions from '../../utils/util';
 import { expectPropertiesValues, expectSettersMethod } from '../../util-test/util-expect.spec';
 import { PoDateService } from '../../services/po-date/po-date.service';
+import { poLocaleDefault } from '../../utils/util';
 
 import { PoTableAction } from './interfaces/po-table-action.interface';
 import { PoTableBaseComponent, poTableLiteralsDefault } from './po-table-base.component';
 import { PoTableColumn } from './interfaces/po-table-column.interface';
-import { poLocaleDefault } from '../../utils/util';
 
 class PoTableComponent extends PoTableBaseComponent {
   calculateWidthHeaders() { }
@@ -383,19 +383,19 @@ describe('PoTableBaseComponent:', () => {
     component.sort = true;
     const column = component.columns[1];
 
-    spyOn(component, 'sortArray').and.callThrough();
+    spyOn(component, <any>'sortArray').and.callThrough();
     component.sortColumn(column);
-    expect(component.sortArray).toHaveBeenCalledWith(column, true);
+    expect(component['sortArray']).toHaveBeenCalledWith(column, true);
 
     component.sortColumn(column);
-    expect(component.sortArray).toHaveBeenCalledWith(column, false);
+    expect(component['sortArray']).toHaveBeenCalledWith(column, false);
   });
 
   it('should sort values descending', () => {
     const column = component.columns[1];
     const sortedItemsDesc = items.slice().sort((a, b) => b.numberData - a.numberData);
 
-    component.sortArray(column, false);
+    component['sortArray'](column, false);
     expect(component.items).toEqual(sortedItemsDesc);
   });
 
@@ -403,7 +403,8 @@ describe('PoTableBaseComponent:', () => {
     const column = component.columns[1];
     const sortedItemsAsc = items.slice().sort((a, b) => a.numberData - b.numberData);
 
-    component.sortArray(column, true);
+    component['sortArray'](column, true);
+
     expect(component.items).toEqual(sortedItemsAsc);
   });
 
@@ -422,29 +423,19 @@ describe('PoTableBaseComponent:', () => {
     expect(component.items).toContain(newItem);
   });
 
-  it('should return name column detail', () => {
-    expect(component.getNameColumnDetail()).toBe('detail');
-  });
-
   it('should return detail columns and not call sort array using detail column', () => {
     const columnDetail = component.columns[3];
 
-    expect(component.getColumnMasterDetail()).toEqual(component.columns[3]);
-    spyOn(component, 'sortArray');
+    expect(component['getColumnMasterDetail']()).toEqual(component.columns[3]);
+    spyOn(component, <any> 'sortArray');
+
     component.sortColumn(columnDetail);
-    expect(component.sortArray).not.toHaveBeenCalled();
-  });
 
-  it('should return null because not have master-detail', () => {
-    const fakeThis = {
-      getColumnMasterDetail: () => this.columnsTable
-    };
-
-    expect(component.getNameColumnDetail.call(fakeThis)).toBeNull();
+    expect(component['sortArray']).not.toHaveBeenCalled();
   });
 
   it('should not return the columns of type subtitle', () => {
-    expect(component.getSubtitleColumns().length).toBe(0);
+    expect(component['getSubtitleColumns']().length).toBe(0);
   });
 
   it('should return the columns of type subtitle', () => {
@@ -455,19 +446,19 @@ describe('PoTableBaseComponent:', () => {
       { value: 'canceled', color: 'color-07', label: 'Cancelado', content: '3' }
     ]
     });
-    expect(component.getSubtitleColumns().length).toBe(1);
+    expect(component['getSubtitleColumns']().length).toBe(1);
   });
 
   it('should return false when items undefined in hasItems method', () => {
     component.items = undefined;
 
-    expect(component.hasItems()).toBeFalsy();
+    expect(component.hasItems).toBeFalsy();
   });
 
   it('should return true when has items in hasItems method', () => {
     component.items = [{ label: 'teste' }];
 
-    expect(component.hasItems()).toBeTruthy();
+    expect(component.hasItems).toBeTruthy();
   });
 
   describe('Methods:', () => {
@@ -714,19 +705,6 @@ describe('PoTableBaseComponent:', () => {
 
     });
 
-    it('getIconColumns: shouldn´t return the columns of type `icon`.', () => {
-      expect(component.getIconColumns().length).toBe(0);
-    });
-
-    it('getIconColumns: should return the columns of type `icon`.', () => {
-      component.columns.push(
-        { property: 'columnIcon', label: 'Like', type: 'icon', color: 'color-08', icons: [
-          { value: 'po-icon-star', action: () => this.notification() }
-        ]}
-      );
-      expect(component.getIconColumns).toBeTruthy();
-    });
-
     it('hasColumns: should return `true` if have columns and columns.length is greater then 0', () => {
       expect(component.hasColumns).toBe(true);
     });
@@ -739,13 +717,13 @@ describe('PoTableBaseComponent:', () => {
     });
 
     it('hasItems: should return `true` if have items and items.length is greater then 0', () => {
-      expect(component.hasItems()).toBe(true);
+      expect(component.hasItems).toBe(true);
     });
 
     it('hasItems: should return `false` if not have items', () => {
       component.items = undefined;
 
-      expect(component.hasItems()).toBeFalsy();
+      expect(component.hasItems).toBeFalsy();
     });
 
     it(`sortArray: should call 'sortDate' when column type is 'date'.`, () => {
@@ -753,7 +731,7 @@ describe('PoTableBaseComponent:', () => {
 
       spyOn(component['poDate'], 'sortDate');
 
-      component.sortArray(columnDate, true);
+      component['sortArray'](columnDate, true);
 
       expect(component['poDate'].sortDate).toHaveBeenCalled();
     });
@@ -763,7 +741,7 @@ describe('PoTableBaseComponent:', () => {
 
       spyOn(component['poDate'], 'sortDate');
 
-      component.sortArray(columnDate, true);
+      component['sortArray'](columnDate, true);
 
       expect(component['poDate'].sortDate).toHaveBeenCalled();
     });
@@ -773,7 +751,7 @@ describe('PoTableBaseComponent:', () => {
 
       spyOn(utilsFunctions, 'sortValues');
 
-      component.sortArray(columnDate, true);
+      component['sortArray'](columnDate, true);
 
       expect(utilsFunctions.sortValues).toHaveBeenCalled();
     });
@@ -820,15 +798,15 @@ describe('PoTableBaseComponent:', () => {
       component.sortBy.observers = <any>[{ next: () => { }}];
 
       spyOn(component.sortBy, 'emit').and.callThrough();
-      spyOn(component, 'sortArray').and.callThrough();
+      spyOn(component, <any> 'sortArray').and.callThrough();
 
       component.sortColumn(column);
       expect(component.sortBy.emit).toHaveBeenCalledWith({column, type: 'ascending'});
-      expect(component.sortArray).toHaveBeenCalled();
+      expect(component['sortArray']).toHaveBeenCalled();
 
       component.sortColumn(column);
       expect(component.sortBy.emit).toHaveBeenCalledWith({column, type: 'descending'});
-      expect(component.sortArray).toHaveBeenCalled();
+      expect(component['sortArray']).toHaveBeenCalled();
     });
 
     it(`onShowMore: 'showMore' should emit an object parameter containing 'ascending' as value of property 'type'` , () => {
@@ -1007,6 +985,92 @@ describe('PoTableBaseComponent:', () => {
       expect(component.collapsed.emit).not.toHaveBeenCalled();
     });
 
+    it('onChangeColumns: should call `setMainColumns`, `setColumnMasterDetail` and `setSubtitleColumns`', () => {
+      const spySetMainColumns = spyOn(component, <any> 'setMainColumns');
+      const spySetColumnMasterDetail = spyOn(component, <any> 'setColumnMasterDetail');
+      const spySetSubtitleColumns = spyOn(component, <any> 'setSubtitleColumns');
+
+      component['onChangeColumns']();
+
+      expect(spySetMainColumns).toHaveBeenCalled();
+      expect(spySetColumnMasterDetail).toHaveBeenCalled();
+      expect(spySetSubtitleColumns).toHaveBeenCalled();
+    });
+
+    it('setColumnMasterDetail: should set `columnMasterDetail` and call `getColumnMasterDetail`', () => {
+      const detailColumn: PoTableColumn = { property: 'detail', type: 'detail' };
+      const expectedValue = { ...detailColumn };
+
+      const spyGetColumnMasterDetail = spyOn(component, <any> 'getColumnMasterDetail').and.callThrough();
+
+      component.columns = [{ ...detailColumn }];
+      component['setColumnMasterDetail']();
+
+      expect(component.columnMasterDetail).toEqual(expectedValue);
+      expect(spyGetColumnMasterDetail).toHaveBeenCalled();
+    });
+
+    it('setMainColumns: should set mainColumns with visibleColumns, hasMainColumns with true and allColumnsWidthPixels with false', () => {
+      const visibleColumns: Array<PoTableColumn> = [
+        { property: 'name' }
+      ];
+
+      const invisibleColumns: Array<PoTableColumn> = [
+        { property: 'age', visible: false },
+        { property: 'address', type: 'auhdsuha' }
+      ];
+
+      component['_columns'] = [...visibleColumns, ...invisibleColumns];
+
+      const expectedValue = [...visibleColumns];
+
+      component['setMainColumns']();
+
+      expect(component.mainColumns).toEqual(expectedValue);
+      expect(component.hasMainColumns).toBe(true);
+      expect(component.allColumnsWidthPixels).toBe(false);
+
+    });
+
+    it('setMainColumns: should set mainColumns with visibleColumns, hasMainColumns with true and allColumnsWidthPixels with true', () => {
+      const visibleColumns: Array<PoTableColumn> = [
+        { property: 'name', width: '50px' },
+        { property: 'age', width: '50px' }
+      ];
+
+      const invisibleColumns: Array<PoTableColumn> = [
+        { property: 'age', visible: false },
+        { property: 'address', type: 'auhdsuha' }
+      ];
+
+      component['_columns'] = [...visibleColumns, ...invisibleColumns];
+
+      const expectedValue = [...visibleColumns];
+
+      component['setMainColumns']();
+
+      expect(component.mainColumns).toEqual(expectedValue);
+      expect(component.allColumnsWidthPixels).toBe(true);
+      expect(component.hasMainColumns).toBe(true);
+
+    });
+
+    it('setSubtitleColumns: should set `subtitleColumns` and call `getSubtitleColumns`', () => {
+      const subTitleColumn: PoTableColumn = { property: 'sub', type: 'subtitle', subtitles: [
+        { value: 'arrived', color: 'color-07', label: 'Arrived', content: 'OK' }
+      ] };
+
+      const expectedValue = [{ ...subTitleColumn }];
+
+      const spyGetSubtitleColumns = spyOn(component, <any> 'getSubtitleColumns').and.callThrough();
+
+      component.columns = [{ property: 'name'}, { ...subTitleColumn }];
+      component['setSubtitleColumns']();
+
+      expect(component.subtitleColumns).toEqual(expectedValue);
+      expect(spyGetSubtitleColumns).toHaveBeenCalled();
+    });
+
   });
 
   describe('Properties:', () => {
@@ -1112,7 +1176,7 @@ describe('PoTableBaseComponent:', () => {
     it('p-columns, p-items: should call `getDefaultColumns` with item if doesn`t have columns but has items to set default column', () => {
       const item = { table: 'table' };
 
-      spyOn(component, <any>'getDefaultColumns');
+      spyOn(component, <any>'getDefaultColumns').and.callThrough();
 
       component.items = [item];
       component.columns = [];
@@ -1156,6 +1220,22 @@ describe('PoTableBaseComponent:', () => {
 
       expect(component['sortType']).toBe('descending');
     });
+
+    it('nameColumnDetail: should return name column detail', () => {
+      const nameColumn = 'extras';
+      const detailColumn = { property: nameColumn, type: 'detail' };
+
+      component.columns = [{ property: 'name' }, { ...detailColumn }];
+
+      expect(component.nameColumnDetail).toBe(nameColumn);
+    });
+
+    it('nameColumnDetail: should return null if not have master-detail', () => {
+      component.columns = [ { property: 'name' } ];
+
+      expect(component.nameColumnDetail).toBeNull();
+    });
+
   });
 
 });

--- a/projects/ui/src/lib/components/po-table/po-table-base.component.ts
+++ b/projects/ui/src/lib/components/po-table/po-table-base.component.ts
@@ -85,6 +85,14 @@ export abstract class PoTableBaseComponent implements OnChanges {
   private _literals: PoTableLiterals;
   private _loading?: boolean = false;
 
+  allColumnsWidthPixels: boolean;
+  columnMasterDetail: PoTableColumn;
+  hasMainColumns: boolean = false;
+  mainColumns: Array<PoTableColumn> = [];
+  selectAll = false;
+  sortedColumn = { property: <PoTableColumn>null, ascending: true };
+  subtitleColumns: Array<PoTableColumn> = [];
+
   /**
    * @description
    *
@@ -95,7 +103,7 @@ export abstract class PoTableBaseComponent implements OnChanges {
     this._items = Array.isArray(items) ? items : [];
 
     // when haven't items, selectAll should be unchecked.
-    if (!this.hasItems()) {
+    if (!this.hasItems) {
       this.selectAll = false;
     } else if (!this.hasColumns) {
       this.columns = this.getDefaultColumns(items[0]);
@@ -123,9 +131,11 @@ export abstract class PoTableBaseComponent implements OnChanges {
     if (this._columns.length) {
       this.setColumnLink();
       this.calculateWidthHeaders();
-    } else if (this.hasItems()) {
+    } else if (this.hasItems) {
       this._columns = this.getDefaultColumns(this.items[0]);
     }
+
+    this.onChangeColumns();
   }
 
   get columns() {
@@ -445,8 +455,22 @@ export abstract class PoTableBaseComponent implements OnChanges {
   /** Evento executado ao desmarcar a seleção de uma linha do `po-table`. */
   @Output('p-unselected') unselected?: EventEmitter<any> = new EventEmitter<any>();
 
-  selectAll = false;
-  sortedColumn = { property: <PoTableColumn>null, ascending: true };
+  get hasColumns(): boolean {
+    return this.columns && this.columns.length > 0;
+  }
+
+  get hasItems(): boolean {
+    return !!(this.items && this.items.length);
+  }
+
+  get nameColumnDetail() {
+    return this.columnMasterDetail ? this.columnMasterDetail.property : null;
+  }
+
+  get validColumns() {
+    const typesValid = ['string', 'number', 'boolean', 'date', 'time', 'dateTime', 'currency', 'subtitle', 'link', 'label', 'icon'];
+    return this.columns.filter(col => !col.type || typesValid.includes(col.type));
+  }
 
   private get sortType(): PoTableColumnSortType {
     return this.sortedColumn.ascending ? PoTableColumnSortType.Ascending : PoTableColumnSortType.Descending;
@@ -459,16 +483,6 @@ export abstract class PoTableBaseComponent implements OnChanges {
       this.selectAll = false;
       this.hideSelectAll = true;
     }
-  }
-
-  abstract calculateHeightTableContainer(height);
-
-  abstract calculateWidthHeaders();
-
-  protected abstract showContainer(container);
-
-  get hasColumns(): boolean {
-    return this.columns && this.columns.length > 0;
   }
 
   /**
@@ -489,6 +503,20 @@ export abstract class PoTableBaseComponent implements OnChanges {
    */
   expand(rowIndex: number) {
     this.setShowDetail(rowIndex, true);
+  }
+
+  /**
+   * Retorna as linhas do `po-table` que estão selecionadas.
+   */
+  getSelectedRows() {
+    return this.items.filter(item => item.$selected);
+  }
+
+  /**
+   * Retorna as linhas do `po-table` que não estão selecionadas.
+   */
+  getUnselectedRows() {
+    return this.items.filter(item => !item.$selected);
   }
 
   selectAllRows() {
@@ -515,53 +543,8 @@ export abstract class PoTableBaseComponent implements OnChanges {
     this.emitSelectEvents(row);
   }
 
-  // Retorna a coluna da lista de colunas que é do tipo detail
-  getColumnMasterDetail() {
-    return this.columns.find(col => col.type === 'detail');
-  }
-
   getClassColor(row, column) {
     return column.color ? `po-text-${this.getColumnColor(row, column)}` : '';
-  }
-
-  getColumnColor(row, column) {
-    const columnColor = column.color;
-
-    return isTypeof(columnColor, 'function') ? columnColor(row, column.property) : columnColor;
-  }
-
-  // Retorna as colunas com status
-  getSubtitleColumns() {
-    return this.columns.filter(col => col.type === 'subtitle');
-  }
-
-  // Retorna as colunas com ícones
-  getIconColumns() {
-    return this.columns.filter(col => col.type === 'icon');
-  }
-
-  // Retorna o nome da coluna do tipo detail
-  getNameColumnDetail() {
-    const detail = this.getColumnMasterDetail();
-    return detail ? detail.property : null;
-  }
-
-  /**
-   * Retorna as linhas do `po-table` que estão selecionadas.
-   */
-  getSelectedRows() {
-    return this.items.filter(item => item.$selected);
-  }
-
-  /**
-   * Retorna as linhas do `po-table` que não estão selecionadas.
-   */
-  getUnselectedRows() {
-    return this.items.filter(item => !item.$selected);
-  }
-
-  hasItems(): boolean {
-    return this.items && this.items.length > 0;
   }
 
   toggleDetail(row: any) {
@@ -593,25 +576,17 @@ export abstract class PoTableBaseComponent implements OnChanges {
     this.sortedColumn.property = column;
   }
 
-  sortArray(column: PoTableColumn, ascending: boolean) {
-
-    this.items.sort((leftSide, rightSide): number => {
-
-      if (column.type === 'date' || column.type === 'dateTime') {
-        return this.poDate.sortDate(leftSide[column.property], rightSide[column.property], ascending);
-      } else {
-        return sortValues(leftSide[column.property], rightSide[column.property], ascending);
-      }
-
-    });
-
-  }
-
   onShowMore(): void {
     const sort = this.sortedColumn.property ? { column: this.sortedColumn.property, type: this.sortType } : undefined;
 
     this.showMore.emit(sort);
   }
+
+  protected abstract calculateHeightTableContainer(height);
+
+  protected abstract calculateWidthHeaders();
+
+  protected abstract showContainer(container);
 
   protected getDefaultColumns(item: any) {
     const keys = Object.keys(item);
@@ -644,6 +619,27 @@ export abstract class PoTableBaseComponent implements OnChanges {
     row.$selected ? this.selected.emit(row) : this.unselected.emit(row);
   }
 
+  private getColumnColor(row, column) {
+    const columnColor = column.color;
+
+    return isTypeof(columnColor, 'function') ? columnColor(row, column.property) : columnColor;
+  }
+
+  // Retorna a coluna da lista de colunas que é do tipo detail
+  private getColumnMasterDetail() {
+    return this.columns.find(col => col.type === 'detail');
+  }
+
+  // Colunas que são inseridas no <head> da tabela
+  private getMainColumns() {
+    return this.validColumns.filter(col => col.visible !== false);
+  }
+
+  // Retorna as colunas com status
+  private getSubtitleColumns() {
+    return this.columns.filter(col => col.type === 'subtitle');
+  }
+
   private isEverySelected(items: Array<any>): boolean {
     const someCheckedOrIndeterminate = item => item.$selected || item.$selected === null;
     const everyChecked = item => item.$selected;
@@ -659,12 +655,30 @@ export abstract class PoTableBaseComponent implements OnChanges {
     return false;
   }
 
+  private onChangeColumns() {
+    this.setMainColumns();
+    this.setColumnMasterDetail();
+    this.setSubtitleColumns();
+  }
+
   private setColumnLink() {
     this.columns.forEach(column => {
       if (column['type'] === 'link' && !column['link']) {
         column['link'] = 'link';
       }
     });
+  }
+
+  private setColumnMasterDetail() {
+    this.columnMasterDetail = this.getColumnMasterDetail();
+  }
+
+  private setMainColumns() {
+    this.mainColumns = this.getMainColumns();
+
+    this.hasMainColumns = !!this.mainColumns.length;
+
+    this.allColumnsWidthPixels = this.verifyWidthColumnsPixels();
   }
 
   private setShowDetail(rowIdentifier: any | number, isShowDetail: boolean) {
@@ -676,12 +690,34 @@ export abstract class PoTableBaseComponent implements OnChanges {
     row.$showDetail = isShowDetail;
   }
 
+  private setSubtitleColumns() {
+    this.subtitleColumns = this.getSubtitleColumns();
+  }
+
+  private sortArray(column: PoTableColumn, ascending: boolean) {
+
+    this.items.sort((leftSide, rightSide): number => {
+
+      if (column.type === 'date' || column.type === 'dateTime') {
+        return this.poDate.sortDate(leftSide[column.property], rightSide[column.property], ascending);
+      } else {
+        return sortValues(leftSide[column.property], rightSide[column.property], ascending);
+      }
+
+    });
+
+  }
+
   private unselectOtherRows(rows: Array<any>, row) {
     rows.forEach(item => {
       if (item !== row) {
         item.$selected = false;
       }
     });
+  }
+
+  private verifyWidthColumnsPixels() {
+    return this.hasMainColumns ? this.mainColumns.every(column => column.width && column.width.includes('px')) : false;
   }
 
 }

--- a/projects/ui/src/lib/components/po-table/po-table-column-label/po-table-column-label.component.spec.ts
+++ b/projects/ui/src/lib/components/po-table/po-table-column-label/po-table-column-label.component.spec.ts
@@ -31,7 +31,6 @@ describe('PoTableColumnLabelComponent:', () => {
       { value: 'danger', label: 'Danger', color: 'color-07' },
     ];
 
-    fixture.detectChanges();
   });
 
   it('should be created', () => {

--- a/projects/ui/src/lib/components/po-table/po-table-column-label/po-table-column-label.component.ts
+++ b/projects/ui/src/lib/components/po-table/po-table-column-label/po-table-column-label.component.ts
@@ -1,4 +1,4 @@
-import { Component, Input } from '@angular/core';
+import { ChangeDetectionStrategy, Component, Input } from '@angular/core';
 
 import { PoColorPaletteService } from './../../../services/po-color-palette/po-color-palette.service';
 import { PoTableColumnLabel } from './po-table-column-label.interface';
@@ -13,7 +13,8 @@ import { PoTableColumnLabel } from './po-table-column-label.interface';
 
 @Component({
   selector: 'po-table-column-label',
-  templateUrl: './po-table-column-label.component.html'
+  templateUrl: './po-table-column-label.component.html',
+  changeDetection: ChangeDetectionStrategy.OnPush
 })
 export class PoTableColumnLabelComponent {
 

--- a/projects/ui/src/lib/components/po-table/po-table-column-link/po-table-column-link.component.spec.ts
+++ b/projects/ui/src/lib/components/po-table/po-table-column-link/po-table-column-link.component.spec.ts
@@ -27,7 +27,6 @@ describe('PoTableColumnLinkComponent:', () => {
     fixture = TestBed.createComponent(PoTableColumnLinkComponent);
     component = fixture.componentInstance;
 
-    fixture.detectChanges();
     nativeElement = fixture.debugElement.nativeElement;
   });
 

--- a/projects/ui/src/lib/components/po-table/po-table-column-link/po-table-column-link.component.ts
+++ b/projects/ui/src/lib/components/po-table/po-table-column-link/po-table-column-link.component.ts
@@ -1,4 +1,4 @@
-import { Component, Input } from '@angular/core';
+import { ChangeDetectionStrategy, Component, Input } from '@angular/core';
 
 import { isExternalLink } from '../../../utils/util';
 
@@ -11,7 +11,8 @@ import { isExternalLink } from '../../../utils/util';
  */
 @Component({
   selector: 'po-table-column-link',
-  templateUrl: './po-table-column-link.component.html'
+  templateUrl: './po-table-column-link.component.html',
+  changeDetection: ChangeDetectionStrategy.OnPush
 })
 
 export class PoTableColumnLinkComponent {

--- a/projects/ui/src/lib/components/po-table/po-table-icon/po-table-icon.component.spec.ts
+++ b/projects/ui/src/lib/components/po-table/po-table-icon/po-table-icon.component.spec.ts
@@ -25,7 +25,6 @@ describe('PoTableIconComponent:', () => {
     fixture = TestBed.createComponent(PoTableIconComponent);
     component = fixture.componentInstance;
 
-    fixture.detectChanges();
     nativeElement = fixture.debugElement.nativeElement;
   });
 

--- a/projects/ui/src/lib/components/po-table/po-table-icon/po-table-icon.component.ts
+++ b/projects/ui/src/lib/components/po-table/po-table-icon/po-table-icon.component.ts
@@ -1,4 +1,4 @@
-import { Component, EventEmitter, Input, Output } from '@angular/core';
+import { ChangeDetectionStrategy, Component, EventEmitter, Input, Output } from '@angular/core';
 
 /**
  * @docsPrivate
@@ -9,7 +9,8 @@ import { Component, EventEmitter, Input, Output } from '@angular/core';
  */
 @Component({
   selector: 'po-table-icon',
-  templateUrl: './po-table-icon.component.html'
+  templateUrl: './po-table-icon.component.html',
+  changeDetection: ChangeDetectionStrategy.OnPush
 })
 
 export class PoTableIconComponent {

--- a/projects/ui/src/lib/components/po-table/po-table-subtitle-circle/po-table-subtitle-circle.component.spec.ts
+++ b/projects/ui/src/lib/components/po-table/po-table-subtitle-circle/po-table-subtitle-circle.component.spec.ts
@@ -35,7 +35,6 @@ describe('PoTableSubtitleCircleComponent:', () => {
       { value: 'content', label: 'Label', color: 'color-03', content: 'Content' },
     ];
 
-    fixture.detectChanges();
   });
 
   it('should be created', () => {

--- a/projects/ui/src/lib/components/po-table/po-table-subtitle-circle/po-table-subtitle-circle.component.ts
+++ b/projects/ui/src/lib/components/po-table/po-table-subtitle-circle/po-table-subtitle-circle.component.ts
@@ -1,4 +1,4 @@
-import { Component, Input } from '@angular/core';
+import { ChangeDetectionStrategy, Component, Input } from '@angular/core';
 
 import { PoColorPaletteService } from './../../../services/po-color-palette/po-color-palette.service';
 import { PoTableSubtitleColumn } from './../po-table-subtitle-footer/po-table-subtitle-column.interface';
@@ -12,7 +12,8 @@ import { PoTableSubtitleColumn } from './../po-table-subtitle-footer/po-table-su
  */
 @Component({
   selector: 'po-table-subtitle-circle',
-  templateUrl: './po-table-subtitle-circle.component.html'
+  templateUrl: './po-table-subtitle-circle.component.html',
+  changeDetection: ChangeDetectionStrategy.OnPush
 })
 export class PoTableSubtitleCircleComponent {
 

--- a/projects/ui/src/lib/components/po-table/po-table.component.html
+++ b/projects/ui/src/lib/components/po-table/po-table.component.html
@@ -7,10 +7,10 @@
     <div class="po-table-main-container">
       <div #tableWrapper
         class="po-table-wrapper"
-        [class.po-table-header-fixed-columns-pixels]="verifyWidthColumnsPixels()"
+        [class.po-table-header-fixed-columns-pixels]="allColumnsWidthPixels"
         [style.opacity]="tableOpacity">
 
-        <div class="po-table-container" *ngIf="height" [style.height.px]="heightTableContainer">
+        <div *ngIf="height" class="po-table-container" [style.height.px]="heightTableContainer">
           <div class="po-table-header-fixed po-table-header"></div>
           <div class="po-table-container-fixed-inner">
             <ng-container *ngTemplateOutlet="tableTemplate"></ng-container>
@@ -26,9 +26,10 @@
   </div>
 
   <div class="po-table-footer" *ngIf="hasFooter">
-    <div *ngFor="let column of getSubtitleColumns()">
-      <po-table-subtitle-footer [p-literals]="literals" [p-subtitles]="column.subtitles"></po-table-subtitle-footer>
-    </div>
+    <ng-container *ngFor="let column of subtitleColumns; trackBy: trackBy">
+      <po-table-subtitle-footer [p-literals]="literals" [p-subtitles]="column.subtitles">
+      </po-table-subtitle-footer>
+    </ng-container>
   </div>
 </po-container>
 
@@ -63,46 +64,20 @@
 
         <th *ngIf="!hasMainColumns" #noColumnsHeader class="po-table-header-column po-text-center">
           <ng-container *ngIf="height; then noColumnsWithHeight; else noColumnsWithoutHeight"> </ng-container>
-
-          <ng-template #noColumnsWithHeight>
-            <div class="po-table-header-fixed-inner" [style.width.px]="noColumnsHeader.offsetWidth">
-              {{ hasValidColumns ? literals.noVisibleColumn : literals.noColumns }}
-            </div>
-          </ng-template>
-
-          <ng-template #noColumnsWithoutHeight>
-            {{ hasValidColumns ? literals.noVisibleColumn : literals.noColumns }}
-          </ng-template>
-
         </th>
 
-        <th *ngFor="let column of mainColumns; let i = index" #headersTable
+        <th *ngFor="let column of mainColumns; let i = index; trackBy: trackBy" #headersTable
           class="po-table-header-ellipsis"
           [style.width]="column.width" [style.max-width]="column.width" [style.min-width]="column.width"
           [class.po-clickable]="sort"
           [class.po-table-column-right]= "column.type === 'currency' || column.type === 'number'"
           [class.po-table-header-subtitle]="column.type === 'subtitle'"
           (click)="sortColumn(column)">
-            <div *ngIf="height" class="po-table-header-fixed-inner">
-              <ng-container *ngTemplateOutlet="contentHeaderTemplate"></ng-container>
-            </div>
-            <div *ngIf="!height">
-              <ng-container *ngTemplateOutlet="contentHeaderTemplate"></ng-container>
-            </div>
-            <ng-template #contentHeaderTemplate>
-              <span *ngIf="sort"
-                [class.po-table-header-icon-unselected]= "sortedColumn?.property !== column"
-                [class.po-table-header-icon-descending]= "sortedColumn?.property === column && sortedColumn.ascending"
-                [class.po-table-header-icon-ascending]= "sortedColumn?.property === column && !sortedColumn.ascending">
-              </span>
-              <span
-                class="po-table-header-ellipsis po-table-header-block"
-                [p-tooltip]="tooltipText"
-                (mouseenter)="tooltipMouseEnter($event)"
-                (mouseleave)="tooltipMouseLeave()">
-                {{ getColumnTitleLabel(column) }}
-              </span>
-            </ng-template>
+
+          <div [class.po-table-header-fixed-inner]="height">
+            <ng-container *ngTemplateOutlet="contentHeaderTemplate; context: { $implicit: column }">
+            </ng-container>
+          </div>
         </th>
 
         <th #columnManager *ngIf="hasValidColumns"
@@ -124,32 +99,24 @@
       </tr>
     </thead>
 
-    <tbody class="po-table-group-row" *ngIf="!hasItems() || !hasMainColumns">
+    <tbody class="po-table-group-row" *ngIf="!hasItems || !hasMainColumns">
       <tr class="po-table-row">
-        <td [colSpan]="columnCount()" class="po-table-no-data po-text-center">
+        <td [colSpan]="columnCount" class="po-table-no-data po-text-center">
           <span> {{ literals.noData }} </span>
         </td>
       </tr>
     </tbody>
 
     <ng-container *ngIf="hasMainColumns">
-      <tbody class="po-table-group-row" *ngFor="let row of items, let rowIndex = index;">
+
+      <tbody class="po-table-group-row" *ngFor="let row of items, let rowIndex = index; trackBy: trackBy">
         <tr class="po-table-row" [class.po-table-row-active]="row.$selected || row.$selected === null && checkbox">
           <td *ngIf="checkbox" class="po-table-column po-table-column-checkbox">
-            <ng-container *ngIf="singleSelect; then inputRadio; else inputCheckbox"> </ng-container>
-
-            <ng-template #inputRadio>
-              <input type="radio" class="po-radio-group-input" [class.po-radio-group-input-checked]="row.$selected">
-              <label class="po-radio-group-label po-clickable" (click)="checkbox ? selectRow(row) : 'javascript:;'"></label>
-            </ng-template>
-
-            <ng-template #inputCheckbox>
-              <input type="checkbox" class="po-table-checkbox" [class.po-table-checkbox-checked]="row.$selected">
-              <label class="po-table-checkbox-label po-clickable" (click)="checkbox ? selectRow(row) : 'javascript:;'"></label>
-            </ng-template>
-
+            <ng-container
+              *ngTemplateOutlet="singleSelect ? inputRadio : inputCheckbox; context: { $implicit: row }">
+            </ng-container>
           </td>
-          <td *ngIf="(getColumnMasterDetail() !== undefined) && !hideDetail || hasRowTemplate"
+          <td *ngIf="columnMasterDetail && !hideDetail || hasRowTemplate"
             class="po-table-column-detail-toggle"
             (click)="toggleDetail(row)">
             <span *ngIf="(containsMasterDetail(row) && !hasRowTemplate) || isShowRowTemplate(row, rowIndex) && hasRowTemplate"
@@ -159,7 +126,7 @@
             </span>
           </td>
 
-          <td *ngFor="let column of mainColumns, let columnIndex = index;"
+          <td *ngFor="let column of mainColumns, let columnIndex = index; trackBy: trackBy"
             [style.width]="column.width" [style.max-width]="column.width" [style.min-width]="column.width"
             [class.po-table-column]="column.type !== 'icon'"
             [class.po-table-column-right]="column.type == 'currency' || column.type == 'number'"
@@ -222,23 +189,21 @@
         </tr>
 
         <tr *ngIf="hasMainColumns && hasRowTemplate && row.$showDetail && isShowRowTemplate(row, rowIndex)">
-          <td class="po-table-row-template-container" [colSpan]="columnCountForMasterDetail()">
-
+          <td class="po-table-row-template-container" [colSpan]="columnCountForMasterDetail">
             <ng-template
               [ngTemplateOutlet]="tableRowTemplate.templateRef"
               [ngTemplateOutletContext]="{ $implicit: row, rowIndex: rowIndex }">
             </ng-template>
-
           </td>
         </tr>
 
         <tr *ngIf="hasMainColumns && isShowMasterDetail(row)">
-          <td class="po-table-column-detail" [colSpan]="columnCountForMasterDetail()">
+          <td class="po-table-column-detail" [colSpan]="columnCountForMasterDetail">
 
             <po-table-detail
               [p-checkbox]="checkbox && !detailHideSelect"
-              [p-detail]="getColumnMasterDetail().detail"
-              [p-items]="row[getNameColumnDetail()]"
+              [p-detail]="columnMasterDetail.detail"
+              [p-items]="row[nameColumnDetail]"
               (p-select-row)="selectDetailRow($event)">
             </po-table-detail>
 
@@ -253,6 +218,41 @@
   [p-actions]="actions"
   [p-target]="popupTarget">
 </po-popup>
+
+<ng-template #inputRadio let-row>
+  <input type="radio" class="po-radio-group-input" [class.po-radio-group-input-checked]="row.$selected">
+  <label class="po-radio-group-label po-clickable" (click)="checkbox ? selectRow(row) : 'javascript:;'"></label>
+</ng-template>
+
+<ng-template #inputCheckbox let-row>
+  <input type="checkbox" class="po-table-checkbox" [class.po-table-checkbox-checked]="row.$selected">
+  <label class="po-table-checkbox-label po-clickable" (click)="checkbox ? selectRow(row) : 'javascript:;'"></label>
+</ng-template>
+
+<ng-template #contentHeaderTemplate let-column>
+  <span *ngIf="sort"
+    [class.po-table-header-icon-unselected]= "sortedColumn?.property !== column"
+    [class.po-table-header-icon-descending]= "sortedColumn?.property === column && sortedColumn.ascending"
+    [class.po-table-header-icon-ascending]= "sortedColumn?.property === column && !sortedColumn.ascending">
+  </span>
+  <span
+    class="po-table-header-ellipsis po-table-header-block"
+    [p-tooltip]="tooltipText"
+    (mouseenter)="tooltipMouseEnter($event)"
+    (mouseleave)="tooltipMouseLeave()">
+    {{ column.label || (column.property | titlecase) }}
+  </span>
+</ng-template>
+
+<ng-template #noColumnsWithHeight>
+  <div class="po-table-header-fixed-inner" [style.width.px]="noColumnsHeader?.nativeElement.offsetWidth">
+    {{ hasValidColumns ? literals.noVisibleColumn : literals.noColumns }}
+  </div>
+</ng-template>
+
+<ng-template #noColumnsWithoutHeight>
+  {{ hasValidColumns ? literals.noVisibleColumn : literals.noColumns }}
+</ng-template>
 
 <po-table-column-manager
   [p-columns]="columns"

--- a/projects/ui/src/lib/components/po-table/po-table.component.spec.ts
+++ b/projects/ui/src/lib/components/po-table/po-table.component.spec.ts
@@ -438,44 +438,6 @@ describe('PoTableComponent:', () => {
     expect(columnDetails).toBeNull();
   });
 
-  it('should count the number columns of table', () => {
-    component.columns = columnsWithDetail;
-    component.checkbox = true;
-    component.hideDetail = false;
-    component.actions = actions;
-
-    expect(component.columnCount()).toBe(8);
-  });
-
-  it('should count the number columns of table with master-detail undefined', () => {
-    component.columns = [...columns];
-    component.checkbox = true;
-    component.actions = actions;
-    expect(component.columnCount()).toBe(7);
-  });
-
-  it('should count the number columns of table with checkbox false', () => {
-    component.columns = [...columns];
-    component.checkbox = false;
-    component.actions = actions;
-    expect(component.columnCount()).toBe(6);
-  });
-
-  it('should count the number columns of table with hideDetail false', () => {
-    component.columns = columnsWithDetail;
-    component.actions = actions;
-    component.checkbox = true;
-    component.hideDetail = true;
-    expect(component.columnCount()).toBe(7);
-  });
-
-  it('should count the number columns of table without action', () => {
-    component.columns = columnsWithDetail;
-    component.checkbox = true;
-    component.actions.length = 0;
-    expect(component.columnCount()).toBe(7);
-  });
-
   it('should toggle column sort', () => {
     const itemSorted = component.columns[0];
     component.sort = true;
@@ -614,7 +576,7 @@ describe('PoTableComponent:', () => {
       { property: 'test', width: '40px', label: 'test' },
       { property: 'test', width: '20px', label: 'test' }
     ];
-    expect(component.verifyWidthColumnsPixels()).toBe(true);
+    expect(component['verifyWidthColumnsPixels']()).toBe(true);
   });
 
   it('verifyWidthColumnsPixels should return false if one colum doesn`t have pixel width', () => {
@@ -623,13 +585,13 @@ describe('PoTableComponent:', () => {
       { property: 'test', width: '40px', label: 'test' },
       { property: 'test', width: '20px', label: 'test' }
     ];
-    expect(component.verifyWidthColumnsPixels()).toBe(false);
+    expect(component['verifyWidthColumnsPixels']()).toBe(false);
   });
 
   it('verifyWidthColumnsPixels should return false if doesn`t have columns', () => {
     component.items = [];
     component.columns = [];
-    expect(component.verifyWidthColumnsPixels()).toBe(false);
+    expect(component['verifyWidthColumnsPixels']()).toBe(false);
   });
 
   xit('should set table height', () => {
@@ -640,13 +602,13 @@ describe('PoTableComponent:', () => {
   });
 
   it('should call calculateWidthHeaders and setTableOpacity in debounceResize', fakeAsync(() => {
-    spyOn(component, 'calculateWidthHeaders');
+    spyOn(component, <any> 'calculateWidthHeaders');
     spyOn(component, <any> 'setTableOpacity');
 
     component['debounceResize']();
     tick(500);
 
-    expect(component.calculateWidthHeaders).toHaveBeenCalled();
+    expect(component['calculateWidthHeaders']).toHaveBeenCalled();
     expect(component['setTableOpacity']).toHaveBeenCalled();
   }));
 
@@ -660,13 +622,13 @@ describe('PoTableComponent:', () => {
       }
     };
 
-    component.calculateHeightTableContainer.call(fakeThis, '10');
+    component['calculateHeightTableContainer'].call(fakeThis, '10');
     expect(fakeThis.heightTableContainer).toBe(10);
 
-    component.calculateHeightTableContainer.call(fakeThis, '100');
+    component['calculateHeightTableContainer'].call(fakeThis, '100');
     expect(fakeThis.heightTableContainer).toBe(100);
 
-    component.calculateHeightTableContainer.call(fakeThis, 50);
+    component['calculateHeightTableContainer'].call(fakeThis, 50);
     expect(fakeThis.heightTableContainer).toBe(50);
   });
 
@@ -680,13 +642,13 @@ describe('PoTableComponent:', () => {
       }
     };
 
-    component.calculateHeightTableContainer.call(fakeThis, 'a10');
+    component['calculateHeightTableContainer'].call(fakeThis, 'a10');
     expect(fakeThis.heightTableContainer).toBeUndefined();
 
-    component.calculateHeightTableContainer.call(fakeThis, undefined);
+    component['calculateHeightTableContainer'].call(fakeThis, undefined);
     expect(fakeThis.heightTableContainer).toBeUndefined();
 
-    component.calculateHeightTableContainer.call(fakeThis, null);
+    component['calculateHeightTableContainer'].call(fakeThis, null);
     expect(fakeThis.heightTableContainer).toBeUndefined();
   });
 
@@ -694,14 +656,14 @@ describe('PoTableComponent:', () => {
     component['footerHeight'] = 1;
     spyOn(component, <any>'getHeightTableFooter').and.returnValue(10);
 
-    expect(component.verifyChangeHeightInFooter()).toBeTruthy();
+    expect(component['verifyChangeHeightInFooter']()).toBeTruthy();
   });
 
   it('should return false in verifyChangeHeightInFooter', () => {
     component['footerHeight'] = 10;
     spyOn(component, <any>'getHeightTableFooter').and.returnValue(10);
 
-    expect(component.verifyChangeHeightInFooter()).toBeFalsy();
+    expect(component['verifyChangeHeightInFooter']()).toBeFalsy();
   });
 
   it('should calculate height when change the footer height', () => {
@@ -710,10 +672,11 @@ describe('PoTableComponent:', () => {
 
     spyOn(component, <any>'verifyChangeHeightInFooter').and.returnValue(true);
     spyOn(component, <any>'getHeightTableFooter').and.returnValue(10);
-    spyOn(component, 'calculateHeightTableContainer');
-    component.verifyCalculateHeightTableContainer();
+    spyOn(component, <any> 'calculateHeightTableContainer');
 
-    expect(component.calculateHeightTableContainer).toHaveBeenCalled();
+    component['verifyCalculateHeightTableContainer']();
+
+    expect(component['calculateHeightTableContainer']).toHaveBeenCalled();
     expect(component['footerHeight']).toBe(10);
   });
 
@@ -722,10 +685,11 @@ describe('PoTableComponent:', () => {
     component['footerHeight'] = 100;
 
     spyOn(component, <any>'verifyChangeHeightInFooter').and.returnValue(false);
-    spyOn(component, 'calculateHeightTableContainer');
-    component.verifyCalculateHeightTableContainer();
+    spyOn(component, <any> 'calculateHeightTableContainer');
 
-    expect(component.calculateHeightTableContainer).not.toHaveBeenCalled();
+    component['verifyCalculateHeightTableContainer']();
+
+    expect(component['calculateHeightTableContainer']).not.toHaveBeenCalled();
   });
 
   it('should not create column`s header dynamics and footer when not exists items', () => {
@@ -1284,7 +1248,7 @@ describe('PoTableComponent:', () => {
     it(`calculateHeightTableContainer: should call 'setTableOpacity' with 1`, () => {
       spyOn(component, <any>'setTableOpacity');
 
-      component.calculateHeightTableContainer(400);
+      component['calculateHeightTableContainer'](400);
 
       expect(component['setTableOpacity']).toHaveBeenCalledWith(1);
     });
@@ -1301,7 +1265,7 @@ describe('PoTableComponent:', () => {
 
       spyOn(fakeThis.changeDetector, 'detectChanges');
 
-      component.calculateHeightTableContainer.call(fakeThis, 400);
+      component['calculateHeightTableContainer'].call(fakeThis, 400);
 
       expect(fakeThis.changeDetector.detectChanges).toHaveBeenCalled();
 
@@ -1514,24 +1478,6 @@ describe('PoTableComponent:', () => {
       expect(component['getDefaultColumns']).not.toHaveBeenCalled();
     });
 
-    it('getColumnTitleLabel: should return `column.label` value if `column.label` is valid', () => {
-      const label = 'Label';
-      const column: PoTableColumn = { label: label };
-
-      expect(component.getColumnTitleLabel(column)).toBe(label);
-    });
-
-    it(`getColumnTitleLabel: should return the 'column.property' value with uppercase first letter if 'column.label'
-        is invalid and 'capitalizeFirstLetter' is called with property value`, () => {
-      const label = 'Label';
-      const propertyValue = 'label';
-      const column: PoTableColumn = { property: propertyValue };
-      spyOn(utilsFunctions, 'capitalizeFirstLetter').and.returnValue(label);
-
-      expect(component.getColumnTitleLabel(column)).toBe(label);
-      expect(utilsFunctions.capitalizeFirstLetter).toHaveBeenCalledWith(propertyValue);
-    });
-
     it('onVisibleColumnsChange: should set `columns` and call `detectChanges`', () => {
       const newColumns: Array<PoTableColumn> = [ { property: 'age', visible: false } ];
 
@@ -1544,39 +1490,11 @@ describe('PoTableComponent:', () => {
       expect(spyDetectChanges).toHaveBeenCalled();
     });
 
-    it('columnCountForMasterDetail: should return 7 columnCount if has actions and 5 columns', () => {
-      component.actions = [...singleAction];
-      component.columns = [...columns];
+    it('trackBy: should return index param', () => {
+      const index = 1;
+      const expectedValue = index;
 
-      const columnCountAction = 1;
-
-      const countColumns = columns.length + 1 + columnCountAction;
-
-      expect(component.columnCountForMasterDetail()).toBe(countColumns);
-    });
-
-    it('columnCountForMasterDetail: should return 7 columnCount if actions is empty and has 5 columns', () => {
-      component.actions = [];
-      component.columns = [...columns];
-
-      const columnCountColumnManager = 1;
-
-      const countColumns = columns.length + 1 + columnCountColumnManager;
-
-      expect(component.columnCountForMasterDetail()).toBe(countColumns);
-    });
-
-    it('columnCountForMasterDetail: should return 8 columnCount if actions is empty, has 5 columns and has checkbox', () => {
-      component.actions = [];
-      component.columns = [...columns];
-      component.checkbox = true;
-
-      const columnCountColumnManager = 1;
-      const columnCountCheckbox = 1;
-
-      const countColumns = columns.length + 1 + columnCountColumnManager + columnCountCheckbox;
-
-      expect(component.columnCountForMasterDetail()).toBe(countColumns);
+      expect(component.trackBy(index)).toBe(expectedValue);
     });
 
   });
@@ -1875,45 +1793,45 @@ describe('PoTableComponent:', () => {
 
       it(`should return true if 'checkbox', 'hasItems' and 'hasMainColumns' are true`, () => {
         component.checkbox = true;
+        component.columns = [...columns];
 
-        spyOn(component, 'hasItems').and.returnValue(true);
-        spyOnProperty(component, 'hasMainColumns').and.returnValue(true);
+        spyOnProperty(component, 'hasItems').and.returnValue(true);
 
         expect(component.hasCheckboxColumn).toBe(true);
       });
 
       it(`should return false if 'checkbox', 'hasItems' and 'hasMainColumns' are false`, () => {
         component.checkbox = false;
+        component.columns = [];
 
-        spyOn(component, 'hasItems').and.returnValue(false);
-        spyOnProperty(component, 'hasMainColumns').and.returnValue(false);
+        spyOnProperty(component, 'hasItems').and.returnValue(false);
 
         expect(component.hasCheckboxColumn).toBe(false);
       });
 
       it(`should return false if 'checkbox', 'hasItems' are true and 'hasMainColumns' is false`, () => {
         component.checkbox = true;
+        component.hasMainColumns = false;
 
-        spyOn(component, 'hasItems').and.returnValue(true);
-        spyOnProperty(component, 'hasMainColumns').and.returnValue(false);
+        spyOnProperty(component, 'hasItems').and.returnValue(true);
 
         expect(component.hasCheckboxColumn).toBe(false);
       });
 
       it(`should return false if 'checkbox', 'hasMainColumns' are true and 'hasItems' is false`, () => {
         component.checkbox = true;
+        component.hasMainColumns = true;
 
-        spyOn(component, 'hasItems').and.returnValue(false);
-        spyOnProperty(component, 'hasMainColumns').and.returnValue(true);
+        spyOnProperty(component, 'hasItems').and.returnValue(false);
 
         expect(component.hasCheckboxColumn).toBe(false);
       });
 
       it(`should return false if 'hasItems', 'hasMainColumns' are true and 'checkbox' is false`, () => {
         component.checkbox = false;
+        component.hasMainColumns = true;
 
-        spyOn(component, 'hasItems').and.returnValue(true);
-        spyOnProperty(component, 'hasMainColumns').and.returnValue(true);
+        spyOnProperty(component, 'hasItems').and.returnValue(true);
 
         expect(component.hasCheckboxColumn).toBe(false);
       });
@@ -1921,28 +1839,28 @@ describe('PoTableComponent:', () => {
     });
 
     it(`hasFooter: should return false if 'hasItems' and 'hasVisibleSubtitleColumns' are false`, () => {
-      spyOn(component, 'hasItems').and.returnValue(false);
+      spyOnProperty(component, 'hasItems').and.returnValue(false);
       spyOnProperty(component, 'hasVisibleSubtitleColumns').and.returnValue(false);
 
       expect(component.hasFooter).toBe(false);
     });
 
     it(`hasFooter: should return true if 'hasItems' and 'hasVisibleSubtitleColumns' are true`, () => {
-      spyOn(component, 'hasItems').and.returnValue(true);
+      spyOnProperty(component, 'hasItems').and.returnValue(true);
       spyOnProperty(component, 'hasVisibleSubtitleColumns').and.returnValue(true);
 
       expect(component.hasFooter).toBe(true);
     });
 
     it(`hasFooter: should return false if 'hasItems' is true and 'hasVisibleSubtitleColumns' is false`, () => {
-      spyOn(component, 'hasItems').and.returnValue(true);
+      spyOnProperty(component, 'hasItems').and.returnValue(true);
       spyOnProperty(component, 'hasVisibleSubtitleColumns').and.returnValue(false);
 
       expect(component.hasFooter).toBe(false);
     });
 
     it(`hasFooter: should return false if 'hasItems' is false and 'hasVisibleSubtitleColumns' is true`, () => {
-      spyOn(component, 'hasItems').and.returnValue(false);
+      spyOnProperty(component, 'hasItems').and.returnValue(false);
       spyOnProperty(component, 'hasVisibleSubtitleColumns').and.returnValue(true);
 
       expect(component.hasFooter).toBe(false);
@@ -1980,51 +1898,47 @@ describe('PoTableComponent:', () => {
       expect(component.hasMainColumns).toBe(false);
     });
 
-    it(`hasMasterDetailColumn: should return true if 'hasMainColumns', 'hasItems', 'getColumnMasterDetail' are true and
+    it(`hasMasterDetailColumn: should return true if 'hasMainColumns', 'hasItems', 'columnMasterDetail' are true and
       'hideDetail' is false`, () => {
-
-      spyOnProperty(component, 'hasMainColumns').and.returnValue(true);
-      spyOn(component, 'hasItems').and.returnValue(true);
-      spyOn(component, 'getColumnMasterDetail').and.returnValue(<any>true);
-
+      component.hasMainColumns = true;
+      component.columnMasterDetail = columnsDetail[0];
       component.hideDetail = false;
+
+      spyOnProperty(component, 'hasItems').and.returnValue(true);
 
       expect(component.hasMasterDetailColumn).toBe(true);
     });
 
     it(`hasMasterDetailColumn: should return true if 'hasMainColumns', 'hasItems', 'hasRowTemplate' are true and
-      'hideDetail' and 'getColumnMasterDetail' are false`, () => {
-
-      spyOnProperty(component, 'hasMainColumns').and.returnValue(true);
-      spyOnProperty(component, 'hasRowTemplate').and.returnValue(true);
-      spyOn(component, 'hasItems').and.returnValue(true);
-      spyOn(component, 'getColumnMasterDetail').and.returnValue(<any>false);
-
+      'hideDetail' and 'columnMasterDetail' are false`, () => {
+      component.hasMainColumns = true;
+      component.columnMasterDetail = undefined;
       component.hideDetail = false;
+
+      spyOnProperty(component, 'hasRowTemplate').and.returnValue(true);
+      spyOnProperty(component, 'hasItems').and.returnValue(true);
 
       expect(component.hasMasterDetailColumn).toBe(true);
     });
 
     it(`hasMasterDetailColumn: should return false if 'hasMainColumns' is false and 'hasItems', 'hasRowTemplate' are true and
-      'hideDetail' and 'getColumnMasterDetail' are false`, () => {
-
-      spyOnProperty(component, 'hasMainColumns').and.returnValue(false);
-      spyOnProperty(component, 'hasRowTemplate').and.returnValue(true);
-      spyOn(component, 'hasItems').and.returnValue(true);
-      spyOn(component, 'getColumnMasterDetail').and.returnValue(<any>false);
-
+      'hideDetail' and 'columnMasterDetail' are false`, () => {
+      component.hasMainColumns = false;
+      component.columnMasterDetail = undefined;
       component.hideDetail = false;
+
+      spyOnProperty(component, 'hasRowTemplate').and.returnValue(true);
+      spyOnProperty(component, 'hasItems').and.returnValue(true);
 
       expect(component.hasMasterDetailColumn).toBe(false);
     });
 
     it(`hasMasterDetailColumn: should return false if 'hasMainColumns', 'hasItems', 'hasRowTemplate', 'hideDetail' are true`, () => {
-
-      spyOnProperty(component, 'hasMainColumns').and.returnValue(true);
-      spyOnProperty(component, 'hasRowTemplate').and.returnValue(true);
-      spyOn(component, 'hasItems').and.returnValue(true);
-
+      component.hasMainColumns = false;
       component.hideDetail = true;
+
+      spyOnProperty(component, 'hasRowTemplate').and.returnValue(true);
+      spyOnProperty(component, 'hasItems').and.returnValue(true);
 
       expect(component.hasMasterDetailColumn).toBe(false);
     });
@@ -2149,6 +2063,79 @@ describe('PoTableComponent:', () => {
       component.actions = [ ...actions ];
 
       expect(component.isSingleAction).toBe(false);
+    });
+
+    it('columnCountForMasterDetail: should return 7 columnCount if has actions and 5 columns', () => {
+      component.actions = [...singleAction];
+      component.columns = [...columns];
+
+      const columnCountAction = 1;
+
+      const countColumns = columns.length + 1 + columnCountAction;
+
+      expect(component.columnCountForMasterDetail).toBe(countColumns);
+    });
+
+    it('columnCountForMasterDetail: should return 7 columnCount if actions is empty and has 5 columns', () => {
+      component.actions = [];
+      component.columns = [...columns];
+
+      const columnCountColumnManager = 1;
+
+      const countColumns = columns.length + 1 + columnCountColumnManager;
+
+      expect(component.columnCountForMasterDetail).toBe(countColumns);
+    });
+
+    it('columnCountForMasterDetail: should return 8 columnCount if actions is empty, has 5 columns and has checkbox', () => {
+      component.actions = [];
+      component.columns = [...columns];
+      component.checkbox = true;
+
+      const columnCountColumnManager = 1;
+      const columnCountCheckbox = 1;
+
+      const countColumns = columns.length + 1 + columnCountColumnManager + columnCountCheckbox;
+
+      expect(component.columnCountForMasterDetail).toBe(countColumns);
+    });
+
+    it('columnCount: should count the number columns of table', () => {
+      component.columns = columnsWithDetail;
+      component.checkbox = true;
+      component.hideDetail = false;
+      component.actions = actions;
+
+      expect(component.columnCount).toBe(8);
+    });
+
+    it('columnCount: should count the number columns of table with master-detail undefined', () => {
+      component.columns = [...columns];
+      component.checkbox = true;
+      component.actions = actions;
+      expect(component.columnCount).toBe(7);
+    });
+
+    it('columnCount: should count the number columns of table with checkbox false', () => {
+      component.columns = [...columns];
+      component.checkbox = false;
+      component.actions = actions;
+      expect(component.columnCount).toBe(6);
+    });
+
+    it('columnCount: should count the number columns of table with hideDetail false', () => {
+      component.columns = columnsWithDetail;
+      component.actions = actions;
+      component.checkbox = true;
+      component.hideDetail = true;
+      expect(component.columnCount).toBe(7);
+    });
+
+    it('columnCount: should count the number columns of table without action', () => {
+      component.columns = columnsWithDetail;
+      component.checkbox = true;
+      component.actions.length = 0;
+      expect(component.columnCount).toBe(7);
     });
 
   });


### PR DESCRIPTION
**Table**

**DTHFUI-2571**
_____________________________________________________________________________

**PR Checklist**

- [x] Código
- [x] Testes unitários
- [ ] Documentação
- [ ] Samples

**Qual o comportamento atual?**
A performance do componente está um pouco lenta, devido a chamadas de funções no templates,
ngDoCheck, Differs, componentes internos sem OnPush.

**Qual o novo comportamento?**
Foram revistos alguns itens, tentando não
dificultar muito a revisão/funcionamento, são eles:

- OnPush em alguns componentes (de exibição) internos.
- trackBy;
- Removido chamadas de funções desnecessárias no template;
- Removido os ng-templates de dentro dos ngFor;

- Também foi reordenado as funções;

Proxímos passos:
- Componentizar mais o componente internamente; ex: po-table-header
- Avaliar a utilização apenas de dados imutáveis;;

**Simulação**
- Utilizar samples do portal;