### PR TITLE
feat(decorator): novo InputBoolean e InputRequired

### DIFF
--- a/projects/ui/src/lib/decorators/index.ts
+++ b/projects/ui/src/lib/decorators/index.ts
@@ -1,0 +1,2 @@
+export * from './input-boolean/input-boolean.decorator';
+export * from './input-required/input-required.decorator';

--- a/projects/ui/src/lib/decorators/input-boolean/input-boolean.decorator.spec.ts
+++ b/projects/ui/src/lib/decorators/input-boolean/input-boolean.decorator.spec.ts
@@ -1,0 +1,42 @@
+import { Component } from '@angular/core';
+import { TestBed } from '@angular/core/testing';
+
+import { configureTestSuite, expectPropertiesValues } from '../../util-test/util-expect.spec';
+import { InputBoolean } from './input-boolean.decorator';
+
+@Component({
+  selector: 'mock-component',
+  template: ''
+})
+class PoMockComponent {
+  @InputBoolean() myProperty: boolean;
+}
+
+describe('InputBoolean:', () => {
+  let fixture: any;
+  let component: PoMockComponent;
+
+  configureTestSuite(() => {
+    TestBed.configureTestingModule({
+      declarations: [ PoMockComponent ]
+    });
+  });
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(PoMockComponent);
+    component = fixture.componentInstance;
+  });
+
+  it('should update property with `true` if valid values', () => {
+    const validValues = [ true, 'true', 1, '' ];
+
+    expectPropertiesValues(component, 'myProperty', validValues, true);
+  });
+
+  it('should update property with `false` if invalid values', () => {
+    const invalidValues = [ 10, 0.5, 'test', undefined ];
+
+    expectPropertiesValues(component, 'myProperty', invalidValues, false);
+  });
+
+});

--- a/projects/ui/src/lib/decorators/input-boolean/input-boolean.decorator.ts
+++ b/projects/ui/src/lib/decorators/input-boolean/input-boolean.decorator.ts
@@ -1,0 +1,22 @@
+import { convertToBoolean } from '../../utils/util';
+import { changeValueByCallback } from '../utils-decorators';
+import { PropertyDecoratorInterface } from '../property-decorator.interface';
+
+/**
+ * Converte o valor de um campo de entrada para booleano.
+ *
+ * Forma de utilização:
+ *
+ * ```
+ * @Input('p-loading') @InputBoolean() loading: boolean;
+ * ```
+ */
+
+export function InputBoolean(): any {
+  return function(target: any, property: string, originalDescriptor?) {
+
+    const decoratorProperties: PropertyDecoratorInterface = { target, property, originalDescriptor };
+
+    return changeValueByCallback(decoratorProperties, 'InputBoolean', convertToBoolean);
+  };
+}

--- a/projects/ui/src/lib/decorators/input-required/input-required.decorator.spec.ts
+++ b/projects/ui/src/lib/decorators/input-required/input-required.decorator.spec.ts
@@ -1,0 +1,48 @@
+import { Component, OnInit } from '@angular/core';
+import { TestBed } from '@angular/core/testing';
+
+import { configureTestSuite } from '../../util-test/util-expect.spec';
+import { InputRequired } from './input-required.decorator';
+
+@Component({
+  selector: 'mock-component',
+  template: ''
+})
+class PoMockComponent implements OnInit {
+  @InputRequired() myProperty: any;
+  ngOnInit() {}
+}
+
+describe('InputRequired:', () => {
+  let fixture: any;
+  let component: PoMockComponent;
+
+  configureTestSuite(() => {
+    TestBed.configureTestingModule({
+      declarations: [ PoMockComponent ]
+    });
+  });
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(PoMockComponent);
+    component = fixture.componentInstance;
+  });
+
+  it('should call console.warn if `myProperty` is null', () => {
+    spyOn(console, 'warn');
+    const consoleMessage = 'PoMockComponent: myProperty is required, but was not provided';
+
+    component.ngOnInit();
+
+    expect(console.warn).toHaveBeenCalledWith(consoleMessage);
+  });
+
+  it('shouldn`t call console.warn if `myProperty` is defined', () => {
+    spyOn(console, 'warn');
+    component.myProperty = 'value';
+
+    component.ngOnInit();
+
+    expect(console.warn).not.toHaveBeenCalled();
+  });
+});

--- a/projects/ui/src/lib/decorators/input-required/input-required.decorator.ts
+++ b/projects/ui/src/lib/decorators/input-required/input-required.decorator.ts
@@ -1,0 +1,37 @@
+import { PropertyDecoratorInterface } from '../property-decorator.interface';
+import { validatePropertyOnLifeCycle } from '../utils-decorators';
+
+/**
+ * @docsPrivate
+ *
+ * @description
+ *
+ * Verifica se uma entrada de um componente foi preenchida.
+ *
+ * Na ausência da propriedade o decorator irá disparar um warn no console
+ * do navegador do usuário.
+ *
+ * > Esta verificação é feita apenas no ngOnInit do componente.
+ *
+ * Forma de utilização:
+ * ```
+ * @Input('p-label') @InputRequired() label: string;
+ * ```
+ *
+ * Referência:
+ * https://netbasal.com/how-to-add-angular-component-input-validation-b078a30af97f
+ * https://medium.com/@abdelelmedny/angular-input-decorators-5d38089070aa
+ */
+
+export function InputRequired() {
+  return function(target: any, property: string) {
+    const decoratorProperties: PropertyDecoratorInterface = { target, property };
+    validatePropertyOnLifeCycle(decoratorProperties, 'ngOnInit', validateProperty);
+  };
+}
+
+function validateProperty(property: string, target: any) {
+  if (this[property] == null) {
+    console.warn(`${target.constructor.name}: ${property} is required, but was not provided`);
+  }
+}

--- a/projects/ui/src/lib/decorators/property-decorator.interface.ts
+++ b/projects/ui/src/lib/decorators/property-decorator.interface.ts
@@ -1,0 +1,17 @@
+/**
+ * @description
+ *
+ * Estrutura dos parâmetros de um decorator de propriedade.
+ */
+export interface PropertyDecoratorInterface {
+
+  /** Métodos de acesso a propriedade, por exemplo: `get` e `set`. */
+  originalDescriptor?: Object;
+
+  /** Nome da propriedade. */
+  property?: string;
+
+  /** Instância da classe da propriedade. */
+  target?: any;
+
+}

--- a/projects/ui/src/lib/decorators/utils-decorators.spec.ts
+++ b/projects/ui/src/lib/decorators/utils-decorators.spec.ts
@@ -1,0 +1,160 @@
+import * as UtilsDecorators from './utils-decorators';
+
+describe('validatePropertyOnLifeCycle:', () => {
+  it('should call callback on call ngOnInit', () => {
+    const target = {
+      ngOnInit: () => {},
+      myProperty: undefined
+    };
+
+    const callback = jasmine.createSpy('callback');
+
+    const decoratorProperties = { target, property: 'myProperty' };
+    UtilsDecorators.validatePropertyOnLifeCycle(decoratorProperties, 'ngOnInit', callback);
+
+    expect(callback).not.toHaveBeenCalled();
+
+    target.ngOnInit();
+
+    expect(callback).toHaveBeenCalled();
+  });
+
+  it('should create ngOnInit to call callback', () => {
+    const target = {
+      myProperty: undefined
+    };
+
+    const callback = jasmine.createSpy('callback');
+
+    const decoratorProperties = { target, property: 'myProperty' };
+    UtilsDecorators.validatePropertyOnLifeCycle(decoratorProperties, 'ngOnInit', callback);
+
+    expect(callback).not.toHaveBeenCalled();
+
+    target['ngOnInit']();
+
+    expect(callback).toHaveBeenCalled();
+  });
+
+  it('should keep implementation of ngOnInit', () => {
+    const target = {
+      myProperty: undefined,
+      ngOnInit: function() {
+        this.myProperty = true;
+      }
+    };
+
+    const callback = jasmine.createSpy('callback');
+
+    const decoratorProperties = { target, property: 'myProperty' };
+    UtilsDecorators.validatePropertyOnLifeCycle(decoratorProperties, 'ngOnInit', callback);
+
+    expect(callback).not.toHaveBeenCalled();
+
+    target['ngOnInit']();
+
+    expect(target.myProperty).toBe(true);
+  });
+});
+
+describe('changeValueByCallback:', () => {
+
+  it('should set value of validation return', () => {
+    const validation = () => 'validation return';
+
+    const target = {
+      myProperty: undefined
+    };
+
+    const decoratorProperties = { target, originalDescriptor: {} };
+
+    const descriptor = UtilsDecorators.changeValueByCallback(decoratorProperties, 'decoratorName', validation);
+
+    Object.defineProperty(target, 'myProperty', descriptor);
+
+    target.myProperty = 'new value';
+
+    expect(target.myProperty).toBe('validation return');
+  });
+
+  it('should call set with validation return', () => {
+    const validation = () => 'validation return';
+
+    const target = {
+      myProperty: undefined,
+    };
+
+    const originalSetSpy = jasmine.createSpy('set');
+    const decoratorProperties = { target, originalDescriptor: { set: originalSetSpy } };
+
+    const descriptor = UtilsDecorators.changeValueByCallback(decoratorProperties, 'decoratorName', validation);
+
+    Object.defineProperty(target, 'myProperty', descriptor);
+
+    target.myProperty = 'new value';
+
+    expect(originalSetSpy).toHaveBeenCalledWith('validation return');
+  });
+
+  it('should return original get value if get of object is defined', () => {
+    const validation = () => 'validation return';
+    const originalGetValue = 'original';
+
+    const target = {
+      myProperty: undefined,
+    };
+
+    const decoratorProperties = { target, originalDescriptor: { get: () => originalGetValue } };
+    const descriptor = UtilsDecorators.changeValueByCallback(decoratorProperties, 'decoratorName', validation);
+
+    Object.defineProperty(target, 'myProperty', descriptor);
+
+    expect(target.myProperty).toBe(originalGetValue);
+  });
+
+});
+
+describe('createPrivateProperty:', () => {
+
+  it('should return private property name with undescore', () => {
+    const privatePropertyName = '$$__property';
+    const propertyName = 'property';
+
+    const target = {
+      property: 'value'
+    };
+
+    const result = UtilsDecorators['createPrivateProperty'](target, propertyName, undefined);
+
+    expect(result).toBe(privatePropertyName);
+  });
+
+  it('should create private property in target', () => {
+    const privatePropertyName = '$$__property';
+    const propertyName = 'property';
+
+    const target = {
+      property: 'value'
+    };
+
+    UtilsDecorators['createPrivateProperty'](target, propertyName, undefined);
+
+    expect(target.hasOwnProperty(privatePropertyName)).toBe(true);
+  });
+
+  it('should call console.warn if private property name already exists', () => {
+    const propertyName = 'property';
+
+    const target = {
+      property: 'value',
+      $$__property: 'value'
+    };
+
+    spyOn(console, 'warn');
+
+    UtilsDecorators['createPrivateProperty'](target, propertyName, undefined);
+
+    expect(console.warn).toHaveBeenCalled();
+  });
+
+});

--- a/projects/ui/src/lib/decorators/utils-decorators.ts
+++ b/projects/ui/src/lib/decorators/utils-decorators.ts
@@ -1,0 +1,81 @@
+import { PropertyDecoratorInterface } from './property-decorator.interface';
+
+/**
+ * Função utilizada pela fábrica de decoradores para validar uma propriedade de uma classe durante
+ * o ciclo de vida do Angular.
+ *
+ * @param decoratorProperties propriedades da interface PoPropertyDecoratorInterface.
+ * @param lifecycleName clico de vida que se deseja executar com a validação.
+ * @param callback função que será executada para validadar a propriedade.
+ */
+export function validatePropertyOnLifeCycle(
+  decoratorProperties: PropertyDecoratorInterface,
+  lifecycleName: string,
+  callback: Function) {
+
+  const { target, property } = decoratorProperties;
+  const emptyFunction = () => { };
+  const lifecycleFunctionClone: Function | null = target[lifecycleName] || emptyFunction;
+
+  Object.defineProperty(target, lifecycleName, {
+    value: function() {
+      callback.call(this, property, target);
+      lifecycleFunctionClone.call(this);
+    }
+  });
+
+}
+
+/**
+ * Função utilizada pela fábrica de decoradores para alterar/manipular o valor de uma propriedade.
+ *
+ * > Este decorator irá criar os métodos get e set internamente. Portanto,
+ * é importante **não** criar nomes privados para as propriedades utilizando
+ * `$$__nomeDaPropriedade` ao utilizar este decorator, pois ela será sobrescrita pela propriedade privada
+ * criada pelo decorator.
+ *
+ * @param decoratorProperties propriedades da interface PoPropertyDecoratorInterface.
+ * @param decoratorName nome do decorator
+ * @param callback função que será executada para alterar o valor da propriedade
+ */
+export function changeValueByCallback(decoratorProperties: PropertyDecoratorInterface, decoratorName: string, callback: Function) {
+  const { target, property, originalDescriptor } = decoratorProperties;
+  const privatePropertyName = createPrivateProperty(target, property, decoratorName);
+
+  return {
+    get: getter(originalDescriptor, privatePropertyName),
+    set: setter(originalDescriptor, callback, privatePropertyName)
+  };
+
+}
+function setter(originalDescriptor, callback: Function, privatePropertyName: string) {
+  return function(value): void {
+
+    if (originalDescriptor && originalDescriptor.set) {
+      originalDescriptor.set.bind(this)(callback(value));
+    }
+
+    this[privatePropertyName] = callback(value);
+  };
+}
+
+function getter(originalDescriptor: TypedPropertyDescriptor<any>, privatePropName: string) {
+  return function() {
+    return originalDescriptor && originalDescriptor.get ? originalDescriptor.get.bind(this)() : this[privatePropName];
+  };
+}
+
+export function createPrivateProperty(target: any, propertyName: string, decoratorName: string) {
+  const privatePropName = `$$__${propertyName}`;
+
+  if (Object.prototype.hasOwnProperty.call(target, privatePropName)) {
+    console.warn(`The prop "${privatePropName}" is already exist, it will be overrided by ${decoratorName} decorator.`);
+  }
+
+  Object.defineProperty(target, privatePropName, {
+    configurable: true,
+    writable: true
+  });
+
+  return privatePropName;
+}


### PR DESCRIPTION
**Decorators**

**DTHFUI-2578**
_____________________________________________________________________________

**PR Checklist**

- [x] Código
- [x] Testes unitários
- [x] Documentação
- [ ] Samples

**Qual o comportamento atual?**
Não existe

**Qual o novo comportamento?**
Implementa os novos decorators InputBoolean e InputRequired
para validação interna dos componentes.

**Simulação**
Pode substituir no po-button-base.component.ts:
```
  @Input('p-disabled') set disabled(value: boolean) {
    this._disabled = <any>value === '' ? true : convertToBoolean(value);
  }
  get disabled(): boolean {
    return this._disabled;
  }
```
Por:
```
@Input('p-disabled') @InputBoolean() disabled: boolean;
```

E no po-accordion-item-.component.ts:
```
@Input('p-label') label: string;
```
Por: 
```
@Input('p-label') @InputRequired() label: string;
```