### PR TITLE
refactor(table): propriedade p-selectable substitui a p-checkbox

### DIFF
--- a/projects/ui/src/lib/components/po-table/po-table-base.component.spec.ts
+++ b/projects/ui/src/lib/components/po-table/po-table-base.component.spec.ts
@@ -76,13 +76,27 @@ describe('PoTableBaseComponent:', () => {
     expectPropertiesValues(component, 'items', [], []);
   });
 
-  it('should set checkbox selection and call calculateWidthHeaders', () => {
+  it('should set selectable with value of checkbox', () => {
+    component.checkbox = true;
+    const expectedValue = true;
+
+    expect(component.selectable).toEqual(expectedValue);
+  });
+
+  it('should set checkbox with value of selectable', () => {
+    component.selectable = true;
+    const expectedValue = true;
+
+    expect(component.checkbox).toEqual(expectedValue);
+  });
+
+  it('should set selectable and call calculateWidthHeaders', () => {
     spyOn(component, 'calculateWidthHeaders');
     const validValues = ['', true, 1];
     const invalidValues = [undefined, null, false, 0];
 
-    expectPropertiesValues(component, 'checkbox', validValues, true);
-    expectPropertiesValues(component, 'checkbox', invalidValues, false);
+    expectPropertiesValues(component, 'selectable', validValues, true);
+    expectPropertiesValues(component, 'selectable', invalidValues, false);
     expect(component.calculateWidthHeaders).toHaveBeenCalled();
   });
 
@@ -270,7 +284,7 @@ describe('PoTableBaseComponent:', () => {
   });
 
   it('should select single row', () => {
-    component.checkbox = true;
+    component.selectable = true;
     component.singleSelect = true;
 
     const firstRow = component.items[0];
@@ -287,7 +301,7 @@ describe('PoTableBaseComponent:', () => {
   it('should select multiple rows', () => {
     component.items.forEach(item => item.$selected = false);
 
-    component.checkbox = true;
+    component.selectable = true;
     component.hideSelectAll = false;
     component.singleSelect = false;
 
@@ -304,7 +318,7 @@ describe('PoTableBaseComponent:', () => {
   it('should not select all rows if hide select all is active', () => {
 
     component.items.forEach(item => item.$selected = false);
-    component.checkbox = true;
+    component.selectable = true;
     component.hideSelectAll = true;
     component.singleSelect = false;
     component.ngOnChanges();
@@ -322,7 +336,7 @@ describe('PoTableBaseComponent:', () => {
   it('should select all rows', () => {
     component.items.forEach(item => item.$selected = false);
 
-    component.checkbox = true;
+    component.selectable = true;
     component.hideSelectAll = false;
     component.singleSelect = false;
     component.selectAllRows();
@@ -335,7 +349,7 @@ describe('PoTableBaseComponent:', () => {
   it('should set checkbox select all to checked', () => {
     component.items.forEach(item => item.$selected = false);
 
-    component.checkbox = true;
+    component.selectable = true;
     component.hideSelectAll = false;
     component.singleSelect = false;
     component.items.forEach(item =>
@@ -347,7 +361,7 @@ describe('PoTableBaseComponent:', () => {
 
   it('should set checkbox select all to unchecked', () => {
     component.items.forEach(item => item.$selected = false);
-    component.checkbox = true;
+    component.selectable = true;
     component.hideSelectAll = false;
     component.singleSelect = false;
     const firstRow = component.items[0];
@@ -359,7 +373,7 @@ describe('PoTableBaseComponent:', () => {
 
   it('should set checkbox select all to indeterminate', () => {
     component.items.forEach(item => item.$selected = false);
-    component.checkbox = true;
+    component.selectable = true;
     component.hideSelectAll = false;
     component.singleSelect = false;
 

--- a/projects/ui/src/lib/components/po-table/po-table-base.component.ts
+++ b/projects/ui/src/lib/components/po-table/po-table-base.component.ts
@@ -75,7 +75,6 @@ export const poTableLiteralsDefault = {
 export abstract class PoTableBaseComponent implements OnChanges {
 
   private _actions?: Array<PoTableAction> = [];
-  private _checkbox?: boolean;
   private _columns: Array<PoTableColumn> = [];
   private _container?: string;
   private _height?: number;
@@ -84,6 +83,7 @@ export abstract class PoTableBaseComponent implements OnChanges {
   private _items: Array<PoTableColumn>;
   private _literals: PoTableLiterals;
   private _loading?: boolean = false;
+  private _selectable?: boolean;
 
   allColumnsWidthPixels: boolean;
   columnMasterDetail: PoTableColumn;
@@ -288,7 +288,12 @@ export abstract class PoTableBaseComponent implements OnChanges {
   /**
    * @optional
    *
+   * @deprecated 2.X.X
    * @description
+   *
+   * **Deprecated**
+   *
+   * > Esta propriedade está depreciada, utilize a propriedade `p-selectable`.
    *
    * Habilita na primeira coluna a opção de selecionar linhas,
    * todos os itens da lista possuem a propriedade dinâmica `$selected` para identificar se a linha está selecionada.
@@ -298,12 +303,11 @@ export abstract class PoTableBaseComponent implements OnChanges {
    * @default `false`
    */
   @Input('p-checkbox') set checkbox(checkbox: boolean) {
-    this._checkbox = <any>checkbox === '' ? true : convertToBoolean(checkbox);
-    this.calculateWidthHeaders();
+    this.selectable = checkbox;
   }
 
   get checkbox() {
-    return this._checkbox;
+    return this.selectable;
   }
 
   /**
@@ -327,6 +331,30 @@ export abstract class PoTableBaseComponent implements OnChanges {
 
   get actions() {
     return this._actions;
+  }
+
+  /**
+   * @optional
+   *
+   * @description
+   *
+   * Permite a seleção de linhas na tabela e, caso a propriedade `p-single-select` esteja definida será possível
+   * selecionar apenas uma única linha.
+   *
+   * **Importante:**
+   *  - As linhas de detalhe definidas em `PoTableDetail` possuem comportamento independente da linha mestre;
+   *  - Cada linha possui por padrão a propriedade dinâmica `$selected`, na qual é possível validar se a linha
+   * está selecionada, por exemplo: `item.$selected` ou `item['$selected']`.
+   *
+   * @default `false`
+   */
+  @Input('p-selectable') set selectable(value: boolean) {
+    this._selectable = <any>value === '' ? true : convertToBoolean(value);
+    this.calculateWidthHeaders();
+  }
+
+  get selectable() {
+    return this._selectable;
   }
 
   /**

--- a/projects/ui/src/lib/components/po-table/po-table-detail/po-table-detail.component.html
+++ b/projects/ui/src/lib/components/po-table/po-table-detail/po-table-detail.component.html
@@ -1,7 +1,7 @@
 <table class="po-table-master-detail">
   <thead *ngIf="typeHeaderTop">
     <tr>
-      <th class="po-table-header po-table-column-checkbox" *ngIf="hasCheckbox"></th>
+      <th class="po-table-header po-table-column-selectable" *ngIf="isSelectable"></th>
       <th class="po-table-header po-table-header-column po-table-header-master-detail"></th>
       <th class="po-table-header po-table-header-ellipsis" *ngFor="let detail of detail.columns">
         {{ getColumnTitleLabel(detail) }}
@@ -10,13 +10,13 @@
   </thead>
   <tbody>
     <tr class="po-table-detail-row"
-        [class.po-table-row-active]="item.$selected && hasCheckbox"
+        [class.po-table-row-active]="item.$selected && isSelectable"
         *ngFor="let item of items">
 
-      <ng-container *ngIf="hasCheckbox; else masterDetailSpace">
+      <ng-container *ngIf="isSelectable; else masterDetailSpace">
 
         <td class="po-table-column-master-detail-space-checkbox"></td>
-        <td class="po-table-column po-table-column-checkbox">
+        <td class="po-table-column po-table-column-selectable">
           <input
             class="po-table-checkbox"
             type="checkbox"
@@ -32,7 +32,7 @@
       </ng-template>
 
       <td class="po-table-column-master-detail po-table-master-detail-label"
-        (click)="hasCheckbox ? onSelectRow(item) : 'javascript:;'"
+        (click)="isSelectable ? onSelectRow(item) : 'javascript:;'"
         *ngFor="let detail of detailColumns">
         <strong *ngIf="typeHeaderInline"> {{ getColumnTitleLabel(detail) }}: </strong>
 

--- a/projects/ui/src/lib/components/po-table/po-table-detail/po-table-detail.component.ts
+++ b/projects/ui/src/lib/components/po-table/po-table-detail/po-table-detail.component.ts
@@ -22,11 +22,6 @@ export class PoTableDetailComponent {
   private _detail: PoTableDetail;
 
   /**
-   * Define se a tabela possui a opção de `checkbox` habilitada.
-   */
-  @Input('p-checkbox') hasCheckbox?: boolean = false;
-
-  /**
    * Configuração da linha de detalhes.
    */
   @Input('p-detail') set detail(value: PoTableDetail) {
@@ -41,6 +36,11 @@ export class PoTableDetailComponent {
    * Lista de itens do _detail_ da tabela.
    */
   @Input('p-items') items: Array<any>;
+
+  /**
+   * Define se a tabela possui a opção de `selectable` habilitada.
+   */
+  @Input('p-selectable') isSelectable?: boolean = false;
 
   /**
    * Ação executada ao selecionar ou desmarcar a seleção de uma linha de detalhe do `po-table`.

--- a/projects/ui/src/lib/components/po-table/po-table.component.html
+++ b/projects/ui/src/lib/components/po-table/po-table.component.html
@@ -49,7 +49,7 @@
     <thead>
       <tr [class.po-table-header]="!height">
 
-        <th *ngIf="hasCheckboxColumn" class="po-table-column-checkbox">
+        <th *ngIf="hasSelectableColumn" class="po-table-column-selectable">
           <div [class.po-table-header-fixed-inner]="height">
             <input *ngIf="!hideSelectAll" type="checkbox" class="po-table-checkbox"
             [class.po-table-checkbox-checked]="selectAll"
@@ -110,8 +110,8 @@
     <ng-container *ngIf="hasMainColumns">
 
       <tbody class="po-table-group-row" *ngFor="let row of items, let rowIndex = index; trackBy: trackBy">
-        <tr class="po-table-row" [class.po-table-row-active]="row.$selected || row.$selected === null && checkbox">
-          <td *ngIf="checkbox" class="po-table-column po-table-column-checkbox">
+        <tr class="po-table-row" [class.po-table-row-active]="row.$selected || row.$selected === null && selectable">
+          <td *ngIf="selectable" class="po-table-column po-table-column-selectable">
             <ng-container
               *ngTemplateOutlet="singleSelect ? inputRadio : inputCheckbox; context: { $implicit: row }">
             </ng-container>
@@ -133,7 +133,7 @@
             [class.po-table-column-center]="column.type === 'subtitle'"
             [class.po-table-column-icons]="column.type === 'icon'"
             [ngClass]="getClassColor(row, column)"
-            (click)="checkbox ? selectRow(row) : 'javascript:;'">
+            (click)="selectable ? selectRow(row) : 'javascript:;'">
 
             <div class="po-table-column-cell"
               [class.po-table-body-ellipsis]="hideTextOverflow"
@@ -201,7 +201,7 @@
           <td class="po-table-column-detail" [colSpan]="columnCountForMasterDetail">
 
             <po-table-detail
-              [p-checkbox]="checkbox && !detailHideSelect"
+              [p-selectable]="selectable && !detailHideSelect"
               [p-detail]="columnMasterDetail.detail"
               [p-items]="row[nameColumnDetail]"
               (p-select-row)="selectDetailRow($event)">
@@ -221,12 +221,12 @@
 
 <ng-template #inputRadio let-row>
   <input type="radio" class="po-radio-group-input" [class.po-radio-group-input-checked]="row.$selected">
-  <label class="po-radio-group-label po-clickable" (click)="checkbox ? selectRow(row) : 'javascript:;'"></label>
+  <label class="po-radio-group-label po-clickable" (click)="selectable ? selectRow(row) : 'javascript:;'"></label>
 </ng-template>
 
 <ng-template #inputCheckbox let-row>
   <input type="checkbox" class="po-table-checkbox" [class.po-table-checkbox-checked]="row.$selected">
-  <label class="po-table-checkbox-label po-clickable" (click)="checkbox ? selectRow(row) : 'javascript:;'"></label>
+  <label class="po-table-checkbox-label po-clickable" (click)="selectable ? selectRow(row) : 'javascript:;'"></label>
 </ng-template>
 
 <ng-template #contentHeaderTemplate let-column>

--- a/projects/ui/src/lib/components/po-table/po-table.component.spec.ts
+++ b/projects/ui/src/lib/components/po-table/po-table.component.spec.ts
@@ -267,19 +267,19 @@ describe('PoTableComponent:', () => {
     expect(result).toBe(true);
   });
 
-  it('should allow checkbox selection', () => {
-    let checkboxColumn = tableElement.querySelector('.po-table-column-checkbox');
-    expect(checkboxColumn).toBeFalsy();
+  it('should allow selection', () => {
+    let selectableColumn = tableElement.querySelector('.po-table-column-selectable');
+    expect(selectableColumn).toBeFalsy();
 
-    component.checkbox = true;
+    component.selectable = true;
     fixture.detectChanges();
 
-    checkboxColumn = tableElement.querySelector('.po-table-column-checkbox');
-    expect(checkboxColumn).toBeTruthy();
+    selectableColumn = tableElement.querySelector('.po-table-column-selectable');
+    expect(selectableColumn).toBeTruthy();
   });
 
   it('should allow single row selection', () => {
-    component.checkbox = true;
+    component.selectable = true;
     component.singleSelect = true;
     component.hideSelectAll = true;
     component.selectRow(component.items[0]);
@@ -290,12 +290,12 @@ describe('PoTableComponent:', () => {
     const checkedColumns = tableElement.querySelectorAll('.po-radio-group-input-checked');
     expect(checkedColumns.length).toBe(1);
 
-    const checkboxHeader = tableElement.querySelector('th.po-table-column-checkbox .po-table-checkbox');
-    expect(checkboxHeader).toBeFalsy();
+    const selectableHeader = tableElement.querySelector('th.po-table-column-selectable .po-table-checkbox');
+    expect(selectableHeader).toBeFalsy();
   });
 
   it('should allow multiple row selection', () => {
-    component.checkbox = true;
+    component.selectable = true;
     component.singleSelect = false;
     component.selectRow(component.items[0]);
     component.selectRow(component.items[1]);
@@ -306,24 +306,24 @@ describe('PoTableComponent:', () => {
     expect(checkedColumns.length).toBe(2);
   });
 
-  it('should show indeterminate checkbox', () => {
-    component.checkbox = true;
+  it('should show indeterminate selectable', () => {
+    component.selectable = true;
     fixture.detectChanges();
 
-    let checkboxHeader = tableElement.querySelector('th.po-table-column-checkbox .po-table-checkbox-indeterminate');
-    expect(checkboxHeader).toBeFalsy();
+    let selectableHeader = tableElement.querySelector('th.po-table-column-selectable .po-table-checkbox-indeterminate');
+    expect(selectableHeader).toBeFalsy();
 
     component.selectRow(component.items[0]);
     component.selectRow(component.items[1]);
     fixture.detectChanges();
 
-    checkboxHeader = tableElement.querySelector('th.po-table-column-checkbox .po-table-checkbox-indeterminate');
-    expect(checkboxHeader).toBeTruthy();
+    selectableHeader = tableElement.querySelector('th.po-table-column-selectable .po-table-checkbox-indeterminate');
+    expect(selectableHeader).toBeTruthy();
   });
 
   it('should select one row', () => {
     const itemSelected = component.items[0];
-    component.checkbox = true;
+    component.selectable = true;
     component.hideDetail = true;
     component.columns = columnsWithDetail;
     component.selectRow(itemSelected);
@@ -338,35 +338,35 @@ describe('PoTableComponent:', () => {
   });
 
   it('should select all rows', () => {
-    component.checkbox = true;
+    component.selectable = true;
     component.selectAllRows();
 
     fixture.detectChanges();
 
-    const rowSelected = tableElement.querySelectorAll('tr.po-table-row-active>td.po-table-column-checkbox');
+    const rowSelected = tableElement.querySelectorAll('tr.po-table-row-active>td.po-table-column-selectable');
 
     expect(rowSelected).toBeTruthy();
     expect(rowSelected.length).toBe(component.items.length);
   });
 
-  it('should hide checkbox select all', () => {
-    component.checkbox = true;
+  it('should hide the option to select all', () => {
+    component.selectable = true;
     component.hideSelectAll = true;
 
     fixture.detectChanges();
 
-    const checkboxColumnHeader = tableElement.querySelector('th.po-table-column-checkbox .po-table-checkbox');
-    expect(checkboxColumnHeader).toBeFalsy();
+    const selectableColumnHeader = tableElement.querySelector('th.po-table-column-selectable .po-table-checkbox');
+    expect(selectableColumnHeader).toBeFalsy();
   });
 
-  it('should show checkbox select all', () => {
-    component.checkbox = true;
+  it('should show the option to select all', () => {
+    component.selectable = true;
     component.hideSelectAll = false;
 
     fixture.detectChanges();
 
-    const checkboxColumnHeader = tableElement.querySelector('th.po-table-column-checkbox .po-table-checkbox');
-    expect(checkboxColumnHeader).toBeTruthy();
+    const selectableColumnHeader = tableElement.querySelector('th.po-table-column-selectable .po-table-checkbox');
+    expect(selectableColumnHeader).toBeTruthy();
   });
 
   it('shouldn`t show more button', () => {
@@ -694,15 +694,15 @@ describe('PoTableComponent:', () => {
 
   it('should not create column`s header dynamics and footer when not exists items', () => {
     component.items = undefined;
-    component.checkbox = true;
+    component.selectable = true;
     component.actions = actions;
     component.hideDetail = false;
     component.columns = columnsWithDetail;
 
     fixture.detectChanges();
 
-    const checkboxColumn = nativeElement.querySelector('.po-table-column-checkbox');
-    expect(checkboxColumn).toBeNull();
+    const selectableColumn = nativeElement.querySelector('.po-table-column-selectable');
+    expect(selectableColumn).toBeNull();
 
     const masterDetailColumn = nativeElement.querySelector('.po-table-header-master-detail');
     expect(masterDetailColumn).toBeNull();
@@ -1591,9 +1591,9 @@ describe('PoTableComponent:', () => {
       expect(tableElement.querySelector('.po-table-column-actions')).toBeTruthy();
     });
 
-    it('should show detail checkbox if detail hideSelect is undefined', () => {
+    it('should show detail selectable if detail hideSelect is undefined', () => {
       component.columns = columnsWithDetailInterface;
-      component.checkbox = true;
+      component.selectable = true;
       component.hideDetail = false;
       component.items[0].$showDetail = true;
       fixture.detectChanges();
@@ -1603,10 +1603,10 @@ describe('PoTableComponent:', () => {
       expect(details).toBeTruthy();
     });
 
-    it('should show detail checkbox if detail hideSelect is false', () => {
+    it('should show detail selectable if detail hideSelect is false', () => {
       component.columns = columnsWithDetailInterface;
       component.columns[5].detail.hideSelect = false;
-      component.checkbox = true;
+      component.selectable = true;
       component.hideDetail = false;
       component.items[0].$showDetail = true;
       fixture.detectChanges();
@@ -1616,10 +1616,10 @@ describe('PoTableComponent:', () => {
       expect(details).toBeTruthy();
     });
 
-    it('shouldn`t show detail checkbox if detail hideSelect is true', () => {
+    it('shouldn`t show detail selectable if detail hideSelect is true', () => {
       component.columns = columnsWithDetailInterface;
       component.columns[5].detail.hideSelect = true;
-      component.checkbox = true;
+      component.selectable = true;
       component.hideDetail = false;
       component.items[0].$showDetail = true;
       fixture.detectChanges();
@@ -1629,9 +1629,9 @@ describe('PoTableComponent:', () => {
       expect(details).toBeNull();
     });
 
-    it('should show detail checkbox if not have a detail interface', () => {
+    it('should show detail selectable if not have a detail interface', () => {
       component.columns = columnsWithDetail;
-      component.checkbox = true;
+      component.selectable = true;
       component.hideDetail = false;
       component.items[0].$showDetail = true;
       fixture.detectChanges();
@@ -1789,51 +1789,51 @@ describe('PoTableComponent:', () => {
       expect(component.columnManagerTarget).toBeTruthy();
     });
 
-    describe(`hasCheckboxColumn`, () => {
+    describe(`hasSelectableColumn`, () => {
 
-      it(`should return true if 'checkbox', 'hasItems' and 'hasMainColumns' are true`, () => {
-        component.checkbox = true;
+      it(`should return true if 'selectable', 'hasItems' and 'hasMainColumns' are true`, () => {
+        component.selectable = true;
         component.columns = [...columns];
 
         spyOnProperty(component, 'hasItems').and.returnValue(true);
 
-        expect(component.hasCheckboxColumn).toBe(true);
+        expect(component.hasSelectableColumn).toBe(true);
       });
 
-      it(`should return false if 'checkbox', 'hasItems' and 'hasMainColumns' are false`, () => {
-        component.checkbox = false;
+      it(`should return false if 'selectable', 'hasItems' and 'hasMainColumns' are false`, () => {
+        component.selectable = false;
         component.columns = [];
 
         spyOnProperty(component, 'hasItems').and.returnValue(false);
 
-        expect(component.hasCheckboxColumn).toBe(false);
+        expect(component.hasSelectableColumn).toBe(false);
       });
 
-      it(`should return false if 'checkbox', 'hasItems' are true and 'hasMainColumns' is false`, () => {
-        component.checkbox = true;
+      it(`should return false if 'selectable', 'hasItems' are true and 'hasMainColumns' is false`, () => {
+        component.selectable = true;
         component.hasMainColumns = false;
 
         spyOnProperty(component, 'hasItems').and.returnValue(true);
 
-        expect(component.hasCheckboxColumn).toBe(false);
+        expect(component.hasSelectableColumn).toBe(false);
       });
 
-      it(`should return false if 'checkbox', 'hasMainColumns' are true and 'hasItems' is false`, () => {
-        component.checkbox = true;
+      it(`should return false if 'selectable', 'hasMainColumns' are true and 'hasItems' is false`, () => {
+        component.selectable = true;
         component.hasMainColumns = true;
 
         spyOnProperty(component, 'hasItems').and.returnValue(false);
 
-        expect(component.hasCheckboxColumn).toBe(false);
+        expect(component.hasSelectableColumn).toBe(false);
       });
 
-      it(`should return false if 'hasItems', 'hasMainColumns' are true and 'checkbox' is false`, () => {
-        component.checkbox = false;
+      it(`should return false if 'hasItems', 'hasMainColumns' are true and 'selectable' is false`, () => {
+        component.selectable = false;
         component.hasMainColumns = true;
 
         spyOnProperty(component, 'hasItems').and.returnValue(true);
 
-        expect(component.hasCheckboxColumn).toBe(false);
+        expect(component.hasSelectableColumn).toBe(false);
       });
 
     });
@@ -2087,10 +2087,10 @@ describe('PoTableComponent:', () => {
       expect(component.columnCountForMasterDetail).toBe(countColumns);
     });
 
-    it('columnCountForMasterDetail: should return 8 columnCount if actions is empty, has 5 columns and has checkbox', () => {
+    it('columnCountForMasterDetail: should return 8 columnCount if actions is empty, has 5 columns and is selectable', () => {
       component.actions = [];
       component.columns = [...columns];
-      component.checkbox = true;
+      component.selectable = true;
 
       const columnCountColumnManager = 1;
       const columnCountCheckbox = 1;
@@ -2102,7 +2102,7 @@ describe('PoTableComponent:', () => {
 
     it('columnCount: should count the number columns of table', () => {
       component.columns = columnsWithDetail;
-      component.checkbox = true;
+      component.selectable = true;
       component.hideDetail = false;
       component.actions = actions;
 
@@ -2111,14 +2111,14 @@ describe('PoTableComponent:', () => {
 
     it('columnCount: should count the number columns of table with master-detail undefined', () => {
       component.columns = [...columns];
-      component.checkbox = true;
+      component.selectable = true;
       component.actions = actions;
       expect(component.columnCount).toBe(7);
     });
 
-    it('columnCount: should count the number columns of table with checkbox false', () => {
+    it('columnCount: should count the number columns of table with selectable false', () => {
       component.columns = [...columns];
-      component.checkbox = false;
+      component.selectable = false;
       component.actions = actions;
       expect(component.columnCount).toBe(6);
     });
@@ -2126,14 +2126,14 @@ describe('PoTableComponent:', () => {
     it('columnCount: should count the number columns of table with hideDetail false', () => {
       component.columns = columnsWithDetail;
       component.actions = actions;
-      component.checkbox = true;
+      component.selectable = true;
       component.hideDetail = true;
       expect(component.columnCount).toBe(7);
     });
 
     it('columnCount: should count the number columns of table without action', () => {
       component.columns = columnsWithDetail;
-      component.checkbox = true;
+      component.selectable = true;
       component.actions.length = 0;
       expect(component.columnCount).toBe(7);
     });

--- a/projects/ui/src/lib/components/po-table/po-table.component.ts
+++ b/projects/ui/src/lib/components/po-table/po-table.component.ts
@@ -125,7 +125,7 @@ export class PoTableComponent extends PoTableBaseComponent implements AfterViewI
   get columnCount() {
     return (this.mainColumns.length +
       (this.actions.length > 0 ? 1 : 0) +
-      (this.checkbox ? 1 : 0) +
+      (this.selectable ? 1 : 0) +
       (!this.hideDetail && this.columnMasterDetail !== undefined ? 1 : 0)
     );
   }
@@ -134,7 +134,7 @@ export class PoTableComponent extends PoTableBaseComponent implements AfterViewI
     // caso tiver ações será utilizado a sua coluna para exibir o columnManager
     const columnManager = this.actions.length ? 0 : 1;
 
-    return (this.mainColumns.length + 1) + (this.actions.length > 0 ? 1 : 0) + (this.checkbox ? 1 : 0) + columnManager;
+    return (this.mainColumns.length + 1) + (this.actions.length > 0 ? 1 : 0) + (this.selectable ? 1 : 0) + columnManager;
   }
 
   get detailHideSelect() {
@@ -150,10 +150,6 @@ export class PoTableComponent extends PoTableBaseComponent implements AfterViewI
     return this.visibleActions && this.visibleActions[0];
   }
 
-  get hasCheckboxColumn(): boolean {
-    return this.checkbox && this.hasItems && this.hasMainColumns;
-  }
-
   get hasFooter(): boolean {
     return this.hasItems && this.hasVisibleSubtitleColumns;
   }
@@ -166,6 +162,10 @@ export class PoTableComponent extends PoTableBaseComponent implements AfterViewI
 
   get hasRowTemplate(): boolean {
     return !!this.tableRowTemplate;
+  }
+
+  get hasSelectableColumn(): boolean {
+    return this.selectable && this.hasItems && this.hasMainColumns;
   }
 
   get hasValidColumns() {

--- a/projects/ui/src/lib/components/po-table/samples/sample-po-table-airfare/sample-po-table-airfare.component.html
+++ b/projects/ui/src/lib/components/po-table/samples/sample-po-table-airfare/sample-po-table-airfare.component.html
@@ -5,11 +5,11 @@
 <po-divider></po-divider>
 
 <po-table
-  p-checkbox
   p-container
   p-height="400"
   p-hide-select-all="true"
   p-hide-text-overflow
+  p-selectable
   p-sort="true"
   p-striped="true"
   [p-actions]="actions"

--- a/projects/ui/src/lib/components/po-table/samples/sample-po-table-labs/sample-po-table-labs.component.html
+++ b/projects/ui/src/lib/components/po-table/samples/sample-po-table-labs/sample-po-table-labs.component.html
@@ -1,6 +1,5 @@
 <po-table
   [p-actions]="actions"
-  [p-checkbox]="selection.includes('checkbox')"
   [p-columns]="columns"
   [p-container]="container"
   [p-height]="height"
@@ -11,6 +10,7 @@
   [p-literals]="customLiterals"
   [p-loading]="properties.includes('loading')"
   [p-max-columns]="maxColumns"
+  [p-selectable]="selection.includes('selectable')"
   [p-show-more-disabled]="!properties.includes('showMoreDisabled')"
   [p-single-select]="selection.includes('singleSelect')"
   [p-sort]="properties.includes('sort')"
@@ -134,6 +134,7 @@
       class="po-lg-6"
       name="selection"
       [(ngModel)]="selection"
+      p-help="To enable 'hide select all' and 'single select' check 'selectable'."
       p-label="Selection"
       [p-options]="selectionOptions"
       (p-change)="changeSelectionOptions()">

--- a/projects/ui/src/lib/components/po-table/samples/sample-po-table-labs/sample-po-table-labs.component.ts
+++ b/projects/ui/src/lib/components/po-table/samples/sample-po-table-labs/sample-po-table-labs.component.ts
@@ -48,7 +48,7 @@ export class SamplePoTableLabsComponent implements OnInit {
   ];
 
   selectionOptions: Array<PoCheckboxGroupOption> = [
-    { label: 'Checkbox', value: 'checkbox' },
+    { label: 'Selectable', value: 'selectable' },
     { label: 'Hide select all', value: 'hideSelectAll', disabled: true },
     { label: 'Single select', value: 'singleSelect', disabled: true }
   ];
@@ -131,10 +131,10 @@ export class SamplePoTableLabsComponent implements OnInit {
 
   changeSelectionOptions() {
     const singleSelect = this.selection.includes('singleSelect');
-    const checkbox = this.selection.includes('checkbox');
+    const selectable = this.selection.includes('selectable');
 
-    this.selectionOptions[1].disabled = singleSelect || !checkbox;
-    this.selectionOptions[2].disabled = !checkbox;
+    this.selectionOptions[1].disabled = singleSelect || !selectable;
+    this.selectionOptions[2].disabled = !selectable;
 
     this.selectionOptions = [].concat(this.selectionOptions);
   }


### PR DESCRIPTION
**TABLE**

**DTHFUI-2515**
_____________________________________________________________________________

**PR Checklist**

- [x] Código
- [x] Testes unitários
- [x] Documentação
- [x] Samples

**Qual o comportamento atual?**
Atualmente existe a propriedade p-checkbox que habilita na primeira coluna a opção de selecionar linhas, porém essa propriedade pode habilitar a seleção tanto através de um checkbox quanto através de um radio (caso o desenvolvedor habilite também a funcionalidade p-single-select que permite selecionar apenas uma linha da tabela).

**Qual o novo comportamento?**
Depreciação da propriedade p-checkbox e criação da propriedade p-selectable com a mesma funcionalidade. 

**Simulação**
Testar a funcionalidade nos samples do portal.

**PS:** Ver PR no `portinari-style`