### PR TITLE
fix(page-dynamic-search): corrige disclaimer com label undefined

### DIFF
--- a/projects/templates/src/lib/components/po-page-dynamic-search/po-page-dynamic-search.component.spec.ts
+++ b/projects/templates/src/lib/components/po-page-dynamic-search/po-page-dynamic-search.component.spec.ts
@@ -250,6 +250,24 @@ describe('PoPageDynamicSearchComponent:', () => {
       expect(component['formatDate']).not.toHaveBeenCalled();
     });
 
+    it(`setDisclaimers: should apply 'field.property' with uppercase first letter to label's value
+      if 'field.label' is 'undefined'`, () => {
+
+      component.filters = [
+        { property: 'name' },
+        { property: 'genre' },
+      ];
+
+      const filters = { name: 'Name1', genre: 'male' } ;
+
+      const result = [
+        { label: 'Name: Name1', property: 'name', value: 'Name1' },
+        { label: 'Genre: male', property: 'genre', value: 'male' }
+      ];
+
+      expect(component['setDisclaimers'](filters)).toEqual(result);
+    });
+
   });
 
 });

--- a/projects/templates/src/lib/components/po-page-dynamic-search/po-page-dynamic-search.component.ts
+++ b/projects/templates/src/lib/components/po-page-dynamic-search/po-page-dynamic-search.component.ts
@@ -2,7 +2,7 @@ import { Component, ViewChild } from '@angular/core';
 
 import { PoDisclaimerGroup, PoDynamicFieldType, PoDynamicFormField, PoPageFilter } from '@portinari/portinari-ui';
 
-import { getBrowserLanguage } from '../../utils/util';
+import { capitalizeFirstLetter, getBrowserLanguage } from '../../utils/util';
 
 import { PoAdvancedFilterComponent } from './po-advanced-filter/po-advanced-filter.component';
 import { PoPageDynamicSearchBaseComponent } from './po-page-dynamic-search-base.component';
@@ -104,11 +104,11 @@ export class PoPageDynamicSearchComponent extends PoPageDynamicSearchBaseCompone
 
     Object.keys(filters).forEach(filter => {
       const field = this.getFieldByProperty(this.filters, filter);
-
+      const label = field.label || capitalizeFirstLetter(field.property);
       const value = field.type === PoDynamicFieldType.Date ? this.formatDate(filters[filter]) : filters[filter];
 
       disclaimers.push({
-        label: `${field.label}: ${value}`,
+        label: `${label}: ${value}`,
         property: filter,
         value: filters[filter]
       });

--- a/projects/templates/src/lib/components/po-page-dynamic-search/samples/sample-po-page-dynamic-search-hiring-processes/sample-po-page-dynamic-search-hiring-processes.component.ts
+++ b/projects/templates/src/lib/components/po-page-dynamic-search/samples/sample-po-page-dynamic-search-hiring-processes/sample-po-page-dynamic-search-hiring-processes.component.ts
@@ -37,8 +37,8 @@ export class SamplePoPageDynamicSearchHiringProcessesComponent implements OnInit
 
   public readonly filters: Array<any> = [
     { property: 'hireStatus', label: 'Hire Status', options: this.statusOptions, gridColumns: 6 },
-    { property: 'name', label: 'Name', gridColumns: 6 },
-    { property: 'city', label: 'City', gridColumns: 6 },
+    { property: 'name', gridColumns: 6 },
+    { property: 'city', gridColumns: 6 },
     { property: 'jobDescription', label: 'Job Description', options: this.jobDescriptionOptions, gridColumns: 6 },
   ];
 

--- a/projects/ui/src/lib/components/po-dynamic/po-dynamic-field.interface.ts
+++ b/projects/ui/src/lib/components/po-dynamic/po-dynamic-field.interface.ts
@@ -8,7 +8,11 @@ export interface PoDynamicField {
   /** Nome de referência do campo. */
   property: string;
 
-  /** Rótulo do campo exibido. */
+  /**
+   * Rótulo do campo exibido.
+   *
+   * Caso não seja informado, será utilizado como `label` o valor da propriedade `property` com a primeira letra em maiúsculo.
+   */
   label?: string;
 
   /**

--- a/projects/ui/src/lib/components/po-dynamic/po-dynamic-form/po-dynamic-form-field.interface.ts
+++ b/projects/ui/src/lib/components/po-dynamic/po-dynamic-form/po-dynamic-form-field.interface.ts
@@ -5,7 +5,7 @@ import { PoSelectOption } from '../../po-field/po-select/po-select-option.interf
 import { PoDynamicField } from '../po-dynamic-field.interface';
 
 /**
- * @usedBy PoDynamicFormComponent, PoAdvancedFilterComponent
+ * @usedBy PoDynamicFormComponent, PoAdvancedFilterComponent, PoPageDynamicSearchComponent
  *
  * @docsExtends PoDynamicField
  *


### PR DESCRIPTION
**page-dynamic-search**

**DTHFUI-2600**
_____________________________________________________________________________

**PR Checklist**

- [x] Código
- [x] Testes unitários
- [ ] Documentação
- [ ] Samples

**Qual o comportamento atual?**
Quando aplicados filtros em 'busca avançada', se o objeto do campo filtrado não tiver _label_ definido, concatena-se então o valor do campo com _undefined_

**Qual o novo comportamento?**
Na ausência de valor para label, deve-se concatenar o valor do campo com o valor de **property**.

**Simulação**
Basta remover um dos label do filters do sample de caso de uso SamplePoPageDynamicSearchHiringProcessesComponent.