### PR TITLE
feat(checkbox-group): implementa a propriedade p-auto-focus

### DIFF
--- a/projects/ui/src/lib/components/po-field/po-checkbox-group/po-checkbox-group-base.component.ts
+++ b/projects/ui/src/lib/components/po-field/po-checkbox-group/po-checkbox-group-base.component.ts
@@ -2,6 +2,7 @@ import { AbstractControl, ControlValueAccessor, Validator } from '@angular/forms
 import { EventEmitter, Input, Output } from '@angular/core';
 
 import { convertToBoolean, convertToInt, uuid } from './../../../utils/util';
+import { InputBoolean } from '../../../decorators';
 import { requiredFailed } from '../validators';
 
 import { PoCheckboxGroupOption } from './interfaces/po-checkbox-group-option.interface';
@@ -53,6 +54,19 @@ export class PoCheckboxGroupBaseComponent implements ControlValueAccessor, Valid
   private _indeterminate?: boolean = false;
   private _options?: Array<PoCheckboxGroupOption>;
   private _required?: boolean = false;
+
+  /**
+   * @optional
+   *
+   * @description
+   *
+   * Aplica foco no elemento ao ser iniciado.
+   *
+   * > Caso mais de um elemento seja configurado com essa propriedade, apenas o último elemento declarado com ela terá o foco.
+   *
+   * @default `false`
+   */
+  @Input('p-auto-focus') @InputBoolean() autoFocus: boolean = false;
 
   /** Nome dos checkboxes */
   @Input('name') name: string;

--- a/projects/ui/src/lib/components/po-field/po-checkbox-group/po-checkbox-group.component.spec.ts
+++ b/projects/ui/src/lib/components/po-field/po-checkbox-group/po-checkbox-group.component.spec.ts
@@ -108,45 +108,83 @@ describe('PoCheckboxGroupComponent:', () => {
 
   describe('Methods:', () => {
 
-    it('focus: should call `focus` of checkbox', () => {
-      component.options = [{ label: 'teste1', value: 'teste1' }, { label: 'teste2', value: 'teste2' }];
+    it('ngAfterViewInit: should call `focus` if `autoFocus` is true.', () => {
+      component.autoFocus = true;
 
-      changeDetector.detectChanges();
+      const spyFocus = spyOn(component, <any>'focus');
 
-      spyOn(component.checkboxLabels.toArray()[0].nativeElement, 'focus');
+      component.ngAfterViewInit();
 
-      component.focus();
-
-      expect(component.checkboxLabels.toArray()[0].nativeElement.focus).toHaveBeenCalled();
+      expect(spyFocus).toHaveBeenCalled();
     });
 
-    it('focus: should`t call `focus` of checkbox if option is `disabled`', () => {
-      component.options = [{ label: 'teste1', value: 'teste1', disabled: true }, { label: 'teste2', value: 'teste2' }];
+    it('ngAfterViewInit: shouldn´t call `focus` if `autoFocus` is false.', () => {
+      component.autoFocus = false;
 
-      changeDetector.detectChanges();
+      const spyFocus = spyOn(component, <any>'focus');
 
-      spyOn(component.checkboxLabels.toArray()[0].nativeElement, 'focus');
-      spyOn(component.checkboxLabels.toArray()[1].nativeElement, 'focus');
+      component.ngAfterViewInit();
 
-      component.focus();
-
-      expect(component.checkboxLabels.toArray()[0].nativeElement.focus).not.toHaveBeenCalled();
-      expect(component.checkboxLabels.toArray()[1].nativeElement.focus).toHaveBeenCalled();
+      expect(spyFocus).not.toHaveBeenCalled();
     });
 
-    it('focus: should`t call `focus` of checkbox if `disabled`', () => {
-      component.options = [{ label: 'teste1', value: 'teste1', disabled: true }, { label: 'teste2', value: 'teste2' }];
-      component.disabled = true;
+    describe('focus:', () => {
 
-      changeDetector.detectChanges();
+      it('should call `focus` of checkbox.', () => {
+        component.options = [{ label: 'teste1', value: 'teste1' }, { label: 'teste2', value: 'teste2' }];
 
-      spyOn(component.checkboxLabels.toArray()[0].nativeElement, 'focus');
-      spyOn(component.checkboxLabels.toArray()[1].nativeElement, 'focus');
+        changeDetector.detectChanges();
 
-      component.focus();
+        spyOn(component.checkboxLabels.toArray()[0].nativeElement, 'focus');
 
-      expect(component.checkboxLabels.toArray()[0].nativeElement.focus).not.toHaveBeenCalled();
-      expect(component.checkboxLabels.toArray()[1].nativeElement.focus).not.toHaveBeenCalled();
+        component.focus();
+
+        expect(component.checkboxLabels.toArray()[0].nativeElement.focus).toHaveBeenCalled();
+      });
+
+      it('shouldn`t call `focus` of checkbox if option is `disabled`.', () => {
+        component.options = [{ label: 'teste1', value: 'teste1', disabled: true }, { label: 'teste2', value: 'teste2' }];
+
+        changeDetector.detectChanges();
+
+        spyOn(component.checkboxLabels.toArray()[0].nativeElement, 'focus');
+        spyOn(component.checkboxLabels.toArray()[1].nativeElement, 'focus');
+
+        component.focus();
+
+        expect(component.checkboxLabels.toArray()[0].nativeElement.focus).not.toHaveBeenCalled();
+        expect(component.checkboxLabels.toArray()[1].nativeElement.focus).toHaveBeenCalled();
+      });
+
+      it('shouldn`t call `focus` if component is `disabled`.', () => {
+        component.options = [{ label: 'teste1', value: 'teste1' }, { label: 'teste2', value: 'teste2' }];
+        component.disabled = true;
+
+        changeDetector.detectChanges();
+
+        spyOn(component.checkboxLabels.toArray()[0].nativeElement, 'focus');
+        spyOn(component.checkboxLabels.toArray()[1].nativeElement, 'focus');
+
+        component.focus();
+
+        expect(component.checkboxLabels.toArray()[0].nativeElement.focus).not.toHaveBeenCalled();
+        expect(component.checkboxLabels.toArray()[1].nativeElement.focus).not.toHaveBeenCalled();
+      });
+
+      it('shouldn`t call `focus` if all checkboxes are `disabled`.', () => {
+        component.options = [{ label: 'teste1', value: 'teste1', disabled: true }, { label: 'teste2', value: 'teste2', disabled: true }];
+
+        changeDetector.detectChanges();
+
+        spyOn(component.checkboxLabels.toArray()[0].nativeElement, 'focus');
+        spyOn(component.checkboxLabels.toArray()[1].nativeElement, 'focus');
+
+        component.focus();
+
+        expect(component.checkboxLabels.toArray()[0].nativeElement.focus).not.toHaveBeenCalled();
+        expect(component.checkboxLabels.toArray()[1].nativeElement.focus).not.toHaveBeenCalled();
+      });
+
     });
 
     it('trackByFn: should return index', () => {

--- a/projects/ui/src/lib/components/po-field/po-checkbox-group/po-checkbox-group.component.ts
+++ b/projects/ui/src/lib/components/po-field/po-checkbox-group/po-checkbox-group.component.ts
@@ -1,4 +1,4 @@
-import { AfterViewChecked, ChangeDetectionStrategy, ChangeDetectorRef, Component, ElementRef,
+import { AfterViewChecked, AfterViewInit, ChangeDetectionStrategy, ChangeDetectorRef, Component, ElementRef,
   forwardRef, QueryList, ViewChildren } from '@angular/core';
 import { NG_VALIDATORS, NG_VALUE_ACCESSOR } from '@angular/forms';
 
@@ -42,7 +42,7 @@ import { PoCheckboxGroupOption } from './interfaces/po-checkbox-group-option.int
     }
   ]
 })
-export class PoCheckboxGroupComponent extends PoCheckboxGroupBaseComponent implements AfterViewChecked {
+export class PoCheckboxGroupComponent extends PoCheckboxGroupBaseComponent implements AfterViewChecked, AfterViewInit {
 
   @ViewChildren('checkboxLabel') checkboxLabels: QueryList<ElementRef>;
 
@@ -52,6 +52,12 @@ export class PoCheckboxGroupComponent extends PoCheckboxGroupBaseComponent imple
 
   ngAfterViewChecked(): void {
     this.changeDetector.detectChanges();
+  }
+
+  ngAfterViewInit() {
+    if (this.autoFocus) {
+      this.focus();
+    }
   }
 
   /**


### PR DESCRIPTION
**PO-CHECKBOX-GROUP**

**DTHFUI-2483**

***

**PR Checklist**

- [x] Código
- [x] Testes unitários
- [x] Documentação
- [ ] Samples

***

**Qual o comportamento atual?**
Como usuário eu gostaria de abrir um formulário com o componente já focado para que ajudasse a navegação do usuário. Hoje isso não é possível.

**Qual o novo comportamento?**
Agora o componente também permite inicializar focado ao definir `p-auto-focus`.

**Simulação**
Definir `p-auto-focus` em algum *sample* do componente.