### PR TITLE
feat(radio-group): implementa a propriedade p-auto-focus

### DIFF
--- a/projects/ui/src/lib/components/po-field/po-radio-group/po-radio-group-base.component.ts
+++ b/projects/ui/src/lib/components/po-field/po-radio-group/po-radio-group-base.component.ts
@@ -2,6 +2,7 @@ import { AbstractControl, ControlValueAccessor, Validator } from '@angular/forms
 import { EventEmitter, Input, Output } from '@angular/core';
 
 import { convertToBoolean, convertToInt, removeDuplicatedOptions } from '../../../utils/util';
+import { InputBoolean } from '../../../decorators';
 import { requiredFailed } from '../validators';
 
 import { PoRadioGroupOption } from './po-radio-group-option.interface';
@@ -33,6 +34,19 @@ export abstract class PoRadioGroupBaseComponent implements ControlValueAccessor,
 
   private onChangePropagate: any = null;
   private validatorChange;
+
+  /**
+   * @optional
+   *
+   * @description
+   *
+   * Aplica foco no elemento ao ser iniciado.
+   *
+   * > Caso mais de um elemento seja configurado com essa propriedade, apenas o último elemento declarado com ela terá o foco.
+   *
+   * @default `false`
+   */
+  @Input('p-auto-focus') @InputBoolean() autoFocus: boolean = false;
 
   /** Nome das opções. */
   @Input('name') name: string;

--- a/projects/ui/src/lib/components/po-field/po-radio-group/po-radio-group.component.spec.ts
+++ b/projects/ui/src/lib/components/po-field/po-radio-group/po-radio-group.component.spec.ts
@@ -10,7 +10,7 @@ import { PoFieldContainerComponent } from '../po-field-container/po-field-contai
 import { PoRadioGroupBaseComponent } from './po-radio-group-base.component';
 import { PoRadioGroupComponent } from './po-radio-group.component';
 
-describe('PoRadioGroupComponent: ', () => {
+describe('PoRadioGroupComponent:', () => {
   let component: PoRadioGroupComponent;
   let fixture: ComponentFixture<PoRadioGroupComponent>;
 
@@ -87,55 +87,77 @@ describe('PoRadioGroupComponent: ', () => {
     expect(removeDuplicatedOptions).not.toHaveBeenCalled();
   });
 
-  describe('Methods: ', () => {
+  describe('Methods:', () => {
     const fakeEventArrowKey: any = {
       keyCode: 37,
       which: 37
     };
 
-    it('focus: should call `focus` of radio', () => {
-      component.options = [{ label: 'Option 1', value: '1' }, { label: 'Option 2', value: '2' }];
+    it('ngAfterViewInit: should call `focus` if `autoFocus` is true.', () => {
+      component.autoFocus = true;
 
-      fixture.detectChanges();
+      const spyFocus = spyOn(component, 'focus');
+      component.ngAfterViewInit();
 
-      spyOn(component.radioLabels.toArray()[0].nativeElement, 'focus');
-
-      component.focus();
-
-      expect(component.radioLabels.toArray()[0].nativeElement.focus).toHaveBeenCalled();
+      expect(spyFocus).toHaveBeenCalled();
     });
 
-    it('focus: should`t call `focus` of radio if option is `disabled`', () => {
-      component.options = [
-        { label: 'Option 1', value: '1', disabled: true },
-        { label: 'Option 2', value: '2' },
-        { label: 'Option 3', value: '3' }
-      ];
+    it('ngAfterViewInit: shouldn´t call `focus` if `autoFocus` is false.', () => {
+      component.autoFocus = false;
 
-      fixture.detectChanges();
+      const spyFocus = spyOn(component, 'focus');
+      component.ngAfterViewInit();
 
-      spyOn(component.radioLabels.toArray()[0].nativeElement, 'focus');
-      spyOn(component.radioLabels.toArray()[1].nativeElement, 'focus');
-
-      component.focus();
-
-      expect(component.radioLabels.toArray()[0].nativeElement.focus).not.toHaveBeenCalled();
-      expect(component.radioLabels.toArray()[1].nativeElement.focus).toHaveBeenCalled();
+      expect(spyFocus).not.toHaveBeenCalled();
     });
 
-    it('focus: should`t call `focus` of radio if `disabled`', () => {
-      component.options = [{ label: 'Option 1', value: '1', disabled: true }, { label: 'Option 2', value: '2' }];
-      component.disabled = true;
+    describe('focus:', () => {
 
-      fixture.detectChanges();
+      it('should call `focus` of radio', () => {
+        component.options = [{ label: 'Option 1', value: '1' }, { label: 'Option 2', value: '2' }];
 
-      spyOn(component.radioLabels.toArray()[0].nativeElement, 'focus');
-      spyOn(component.radioLabels.toArray()[1].nativeElement, 'focus');
+        fixture.detectChanges();
 
-      component.focus();
+        spyOn(component.radioLabels.toArray()[0].nativeElement, 'focus');
 
-      expect(component.radioLabels.toArray()[0].nativeElement.focus).not.toHaveBeenCalled();
-      expect(component.radioLabels.toArray()[1].nativeElement.focus).not.toHaveBeenCalled();
+        component.focus();
+
+        expect(component.radioLabels.toArray()[0].nativeElement.focus).toHaveBeenCalled();
+      });
+
+      it('should call second radio option if the first option is disabled', () => {
+        component.options = [
+          { label: 'Option 1', value: '1', disabled: true },
+          { label: 'Option 2', value: '2' },
+          { label: 'Option 3', value: '3' }
+        ];
+
+        fixture.detectChanges();
+
+        spyOn(component.radioLabels.toArray()[0].nativeElement, 'focus');
+        spyOn(component.radioLabels.toArray()[1].nativeElement, 'focus');
+
+        component.focus();
+
+        expect(component.radioLabels.toArray()[0].nativeElement.focus).not.toHaveBeenCalled();
+        expect(component.radioLabels.toArray()[1].nativeElement.focus).toHaveBeenCalled();
+      });
+
+      it('shouldn`t call `focus` of radio if `disabled` property of component is true', () => {
+        component.options = [{ label: 'Option 1', value: '1', disabled: true }, { label: 'Option 2', value: '2' }];
+        component.disabled = true;
+
+        fixture.detectChanges();
+
+        spyOn(component.radioLabels.toArray()[0].nativeElement, 'focus');
+        spyOn(component.radioLabels.toArray()[1].nativeElement, 'focus');
+
+        component.focus();
+
+        expect(component.radioLabels.toArray()[0].nativeElement.focus).not.toHaveBeenCalled();
+        expect(component.radioLabels.toArray()[1].nativeElement.focus).not.toHaveBeenCalled();
+      });
+
     });
 
     it('onKeyUp: should call `changeValue` when `isArrowKey` is true.', () => {
@@ -173,7 +195,7 @@ describe('PoRadioGroupComponent: ', () => {
 
   });
 
-  describe('Templates: ', () => {
+  describe('Templates:', () => {
 
     const eventKeyBoard = document.createEvent('KeyboardEvent');
     eventKeyBoard.initEvent('keyup', true, true);

--- a/projects/ui/src/lib/components/po-field/po-radio-group/po-radio-group.component.ts
+++ b/projects/ui/src/lib/components/po-field/po-radio-group/po-radio-group.component.ts
@@ -1,4 +1,5 @@
-import { Component, DoCheck, ElementRef, forwardRef, Input, IterableDiffers, QueryList, ViewChild, ViewChildren } from '@angular/core';
+import { AfterViewInit, Component, DoCheck, ElementRef, forwardRef, Input, IterableDiffers, QueryList, ViewChild,
+  ViewChildren } from '@angular/core';
 import { NG_VALIDATORS, NG_VALUE_ACCESSOR } from '@angular/forms';
 
 import { removeDuplicatedOptions } from '../../../utils/util';
@@ -49,7 +50,7 @@ import { PoRadioGroupBaseComponent } from './po-radio-group-base.component';
     }
   ]
 })
-export class PoRadioGroupComponent extends PoRadioGroupBaseComponent implements DoCheck {
+export class PoRadioGroupComponent extends PoRadioGroupBaseComponent implements AfterViewInit, DoCheck {
 
   /** Label do campo. */
   @Input('p-label') label?: string;
@@ -65,6 +66,12 @@ export class PoRadioGroupComponent extends PoRadioGroupBaseComponent implements 
   constructor(differs: IterableDiffers) {
     super();
     this.differ = differs.find([]).create(null);
+  }
+
+  ngAfterViewInit() {
+    if (this.autoFocus) {
+      this.focus();
+    }
   }
 
   ngDoCheck() {


### PR DESCRIPTION
**PO-RADIO-GROUP**

**DTHFUI-2484**

***

**PR Checklist**

- [x] Código
- [x] Testes unitários
- [x] Documentação
- [ ] Samples

***

**Qual o comportamento atual?**
Como usuário eu gostaria de abrir um formulário com o componente já focado para que ajudasse a navegação do usuário. Hoje isso não é possível.

**Qual o novo comportamento?**
Agora o componente também permite inicializar focado ao definir `p-auto-focus`.

**Simulação**
Definir `p-auto-focus` em algum *sample* do componente.
