### PR TITLE
feat(combo): implementa a propriedade p-auto-focus

### DIFF
--- a/projects/ui/src/lib/components/po-field/po-combo/po-combo-base.component.ts
+++ b/projects/ui/src/lib/components/po-field/po-combo/po-combo-base.component.ts
@@ -2,6 +2,7 @@ import { AbstractControl, ControlValueAccessor, Validator } from '@angular/forms
 import { EventEmitter, Input, OnInit, Output } from '@angular/core';
 
 import { browserLanguage, convertToBoolean, isTypeof, removeDuplicatedOptions, poLocaleDefault, validValue } from '../../../utils/util';
+import { InputBoolean } from '../../../decorators';
 import { requiredFailed } from '../validators';
 
 import { PoComboFilter } from './interfaces/po-combo-filter.interface';
@@ -84,6 +85,19 @@ export abstract class PoComboBaseComponent implements ControlValueAccessor, OnIn
   visibleOptions: Array<PoComboOption | PoComboGroup> = [];
 
   private validatorChange: any;
+
+  /**
+   * @optional
+   *
+   * @description
+   *
+   * Aplica foco no elemento ao ser iniciado.
+   *
+   * > Caso mais de um elemento seja configurado com essa propriedade, apenas o último elemento declarado com ela terá o foco.
+   *
+   * @default `false`
+   */
+  @Input('p-auto-focus') @InputBoolean() autoFocus: boolean = false;
 
   /** Label no componente. */
   @Input('p-label') label?: string;

--- a/projects/ui/src/lib/components/po-field/po-combo/po-combo.component.spec.ts
+++ b/projects/ui/src/lib/components/po-field/po-combo/po-combo.component.spec.ts
@@ -1689,6 +1689,24 @@ describe('PoComboComponent - with service:', () => {
       expect(fakeThis.service.getObjectByValue).not.toHaveBeenCalled();
     });
 
+    it('ngAfterViewInit: should call `focus` if `autoFocus` is true.', () => {
+      component.autoFocus = true;
+
+      const spyFocus = spyOn(component, 'focus');
+      component.ngAfterViewInit();
+
+      expect(spyFocus).toHaveBeenCalled();
+    });
+
+    it('ngAfterViewInit: shouldn´t call `focus` if `autoFocus` is false.', () => {
+      component.autoFocus = false;
+
+      const spyFocus = spyOn(component, 'focus');
+      component.ngAfterViewInit();
+
+      expect(spyFocus).not.toHaveBeenCalled();
+    });
+
     it('ngOnDestroy: should not unsubscribe if getSubscription is falsy.', () => {
 
       component['getSubscription'] = fakeSubscription;

--- a/projects/ui/src/lib/components/po-field/po-combo/po-combo.component.ts
+++ b/projects/ui/src/lib/components/po-field/po-combo/po-combo.component.ts
@@ -1,4 +1,4 @@
-import { ChangeDetectorRef, Component, ContentChild, ElementRef, forwardRef,
+import { AfterViewInit, ChangeDetectorRef, Component, ContentChild, ElementRef, forwardRef,
   IterableDiffers, OnDestroy, Renderer2, ViewChild } from '@angular/core';
 import { DomSanitizer, SafeHtml } from '@angular/platform-browser';
 import { NG_VALIDATORS, NG_VALUE_ACCESSOR } from '@angular/forms';
@@ -84,7 +84,7 @@ const poComboContainerPositionDefault = 'bottom';
     }
   ]
 })
-export class PoComboComponent extends PoComboBaseComponent implements OnDestroy {
+export class PoComboComponent extends PoComboBaseComponent implements AfterViewInit, OnDestroy {
 
   private _isServerSearching: boolean = false;
 
@@ -140,6 +140,12 @@ export class PoComboComponent extends PoComboBaseComponent implements OnDestroy 
 
   get isServerSearching() {
     return this._isServerSearching;
+  }
+
+  ngAfterViewInit() {
+    if (this.autoFocus) {
+      this.focus();
+    }
   }
 
   ngOnDestroy() {


### PR DESCRIPTION
**PO-COMBO**

**DTHFUI-2485**

***

**PR Checklist**

- [x] Código
- [x] Testes unitários
- [x] Documentação
- [ ] Samples

***

**Qual o comportamento atual?**
Como usuário eu gostaria de abrir um formulário com o componente já focado para que ajudasse a navegação do usuário. Hoje isso não é possível.

**Qual o novo comportamento?**
Agora o componente também permite inicializar focado ao definir `p-auto-focus`.

**Simulação**
Definir `p-auto-focus` em algum *sample* do componente.
