### PR TITLE
feat(switch): implementa a propriedade p-auto-focus

### DIFF
--- a/projects/ui/src/lib/components/po-field/po-switch/po-switch-base.component.ts
+++ b/projects/ui/src/lib/components/po-field/po-switch/po-switch-base.component.ts
@@ -2,6 +2,7 @@ import { ControlValueAccessor } from '@angular/forms';
 import { EventEmitter, Input, Output } from '@angular/core';
 
 import { convertToBoolean } from '../../../utils/util';
+import { InputBoolean } from '../../../decorators';
 
 import { PoSwitchLabelPosition } from './po-switch-label-position.enum';
 
@@ -27,6 +28,19 @@ export class PoSwitchBaseComponent implements ControlValueAccessor {
 
   /** Nome do componente. */
   @Input('name') name: string;
+
+  /**
+   * @optional
+   *
+   * @description
+   *
+   * Aplica o foco no elemento ao ser iniciado.
+   *  > Caso mais de um elemento seja configurado com essa propriedade,
+   * o último elemento declarado com ela terá o foco.
+   *
+   * @default `false`
+   */
+  @Input('p-auto-focus') @InputBoolean() autoFocus: boolean = false;
 
   /** Rótulo exibido pelo componente. */
   @Input('p-label') label?: string;

--- a/projects/ui/src/lib/components/po-field/po-switch/po-switch.component.spec.ts
+++ b/projects/ui/src/lib/components/po-field/po-switch/po-switch.component.spec.ts
@@ -121,6 +121,26 @@ describe('PoRadioGroupComponent', () => {
 
   describe('Methods:', () => {
 
+    it('ngAfterViewInit: should call `focus` if `autoFocus` is true.', () => {
+      component.autoFocus = true;
+
+      const spyFocus = spyOn(component, 'focus');
+
+      component.ngAfterViewInit();
+
+      expect(spyFocus).toHaveBeenCalled();
+    });
+
+    it('ngAfterViewInit: shouldn`t call `focus` if `autoFocus` is false.', () => {
+      component.autoFocus = false;
+
+      const spyFocus = spyOn(component, 'focus');
+
+      component.ngAfterViewInit();
+
+      expect(spyFocus).not.toHaveBeenCalled();
+    });
+
     it('focus: should call `focus` of switch', () => {
       component.switchContainer = {
         nativeElement: {

--- a/projects/ui/src/lib/components/po-field/po-switch/po-switch.component.ts
+++ b/projects/ui/src/lib/components/po-field/po-switch/po-switch.component.ts
@@ -1,4 +1,4 @@
-import { AfterViewChecked, ChangeDetectorRef, Component, ElementRef, forwardRef, ViewChild } from '@angular/core';
+import { AfterViewChecked, AfterViewInit, ChangeDetectorRef, Component, ElementRef, forwardRef, ViewChild } from '@angular/core';
 import { NG_VALUE_ACCESSOR } from '@angular/forms';
 
 import { PoSwitchBaseComponent } from './po-switch-base.component';
@@ -42,7 +42,7 @@ import { PoSwitchLabelPosition } from './po-switch-label-position.enum';
     }
   ]
 })
-export class PoSwitchComponent extends PoSwitchBaseComponent implements AfterViewChecked {
+export class PoSwitchComponent extends PoSwitchBaseComponent implements AfterViewChecked, AfterViewInit {
 
   @ViewChild('switchContainer', { static: true }) switchContainer: ElementRef;
 
@@ -52,6 +52,12 @@ export class PoSwitchComponent extends PoSwitchBaseComponent implements AfterVie
 
   ngAfterViewChecked(): void {
     this.changeDetector.detectChanges();
+  }
+
+  ngAfterViewInit() {
+    if (this.autoFocus) {
+      this.focus();
+    }
   }
 
   /**


### PR DESCRIPTION
**Po Switch**

**DTHFUI-2485**
_____________________________________________________________________________

**PR Checklist**

- [x] Código
- [x] Testes unitários
- [x] Documentação
- [ ] Samples

**Qual o comportamento atual?**
Como usuário eu gostaria de abrir um formulário com o componente já focado para que ajudasse a navegação do usuário. Hoje isso não é possível.

**Qual o novo comportamento?**
Agora o componente também permite inicializar focado ao definir p-auto-focus.

**Simulação**
Definir p-auto-focus em algum sample do componente.