### PR TITLE
feat(select): implementa a propriedade p-auto-focus

### DIFF
--- a/projects/ui/src/lib/components/po-field/po-select/po-select-base.component.ts
+++ b/projects/ui/src/lib/components/po-field/po-select/po-select-base.component.ts
@@ -2,6 +2,7 @@ import { AbstractControl, ControlValueAccessor, Validator } from '@angular/forms
 import { ChangeDetectorRef, ElementRef, EventEmitter, Input, Output } from '@angular/core';
 
 import { convertToBoolean, removeDuplicatedOptions, removeUndefinedAndNullOptions } from '../../../utils/util';
+import { InputBoolean } from '../../../decorators';
 import { requiredFailed } from '../validators';
 
 import { PoSelectOption } from './po-select-option.interface';
@@ -27,6 +28,19 @@ export abstract class PoSelectBaseComponent implements ControlValueAccessor, Val
   private _required?: boolean = false;
 
   private onValidatorChange;
+
+  /**
+   * @optional
+   *
+   * @description
+   *
+   * Aplica foco no elemento ao ser iniciado.
+   * > Caso mais de um elemento seja configurado com essa propriedade,
+   * o último elemento declarado com ela terá o foco.
+   *
+   * @default `false`
+   */
+  @Input('p-auto-focus') @InputBoolean() autoFocus: boolean = false;
 
   /** Adiciona uma label no componente. */
   @Input('p-label') label?: string;

--- a/projects/ui/src/lib/components/po-field/po-select/po-select.component.spec.ts
+++ b/projects/ui/src/lib/components/po-field/po-select/po-select.component.spec.ts
@@ -143,6 +143,24 @@ describe('PoSelectComponent:', () => {
 
   describe('Properties:', () => {
 
+    it('ngAfterViewInit: should call `focus` if `autoFocus` is true.', () => {
+      component.autoFocus = true;
+
+      const spyFocus = spyOn(component, 'focus');
+      component.ngAfterViewInit();
+
+      expect(spyFocus).toHaveBeenCalled();
+    });
+
+    it('ngAfterViewInit: shouldn´t call `focus` if `autoFocus` is false.', () => {
+      component.autoFocus = false;
+
+      const spyFocus = spyOn(component, 'focus');
+      component.ngAfterViewInit();
+
+      expect(spyFocus).not.toHaveBeenCalled();
+    });
+
     it('isInvisibleSelectNative: should return `true` if `isMobile` and `readonly` are `true`', () => {
       component.isMobile = true;
       component.readonly = true;

--- a/projects/ui/src/lib/components/po-field/po-select/po-select.component.ts
+++ b/projects/ui/src/lib/components/po-field/po-select/po-select.component.ts
@@ -1,4 +1,4 @@
-import { ChangeDetectionStrategy, ChangeDetectorRef, ContentChild, Component, DoCheck, ElementRef, forwardRef, HostListener,
+import { AfterViewInit, ChangeDetectionStrategy, ChangeDetectorRef, ContentChild, Component, DoCheck, ElementRef, forwardRef, HostListener,
   IterableDiffers, Renderer2, ViewChild } from '@angular/core';
 import { NG_VALUE_ACCESSOR, NG_VALIDATORS } from '@angular/forms';
 
@@ -54,7 +54,7 @@ const poSelectContentPositionDefault = 'bottom';
     PoControlPositionService
   ]
 })
-export class PoSelectComponent extends PoSelectBaseComponent implements DoCheck {
+export class PoSelectComponent extends PoSelectBaseComponent implements AfterViewInit, DoCheck {
 
   displayValue;
   isMobile: any = isMobile();
@@ -120,6 +120,12 @@ export class PoSelectComponent extends PoSelectBaseComponent implements DoCheck 
     if (this.open && charCode === PoKeyCodeEnum.tab) {
       $event.preventDefault();
       this.toggleButton();
+    }
+  }
+
+  ngAfterViewInit() {
+    if (this.autoFocus) {
+      this.focus();
     }
   }
 


### PR DESCRIPTION
**Po Select**

**DTHFUI-2486**
_____________________________________________________________________________

**PR Checklist**

- [x] Código
- [x] Testes unitários
- [x] Documentação
- [ ] Samples

**Qual o comportamento atual?**
Como usuário eu gostaria de abrir um formulário com o componente já focado para que ajudasse a navegação do usuário. Hoje isso não é possível.

**Qual o novo comportamento?**
Agora o componente também permite inicializar focado ao definir p-auto-focus.

**Simulação**
Definir p-auto-focus em algum sample do componente.