### PR TITLE
fix(multiselect): corrige mutabilidade no sample labs

### DIFF
--- a/projects/ui/src/lib/components/po-field/po-multiselect/po-multiselect-base.component.ts
+++ b/projects/ui/src/lib/components/po-field/po-multiselect/po-multiselect-base.component.ts
@@ -208,6 +208,12 @@ export abstract class PoMultiselectBaseComponent implements ControlValueAccessor
    *
    * Nesta propriedade deve ser definida uma lista de objetos que implementam a interface PoMultiselectOption.
    * Esta lista deve conter os valores e os labels que serão apresentados na tela.
+   *
+   * > Para atualizar a lista de opções do `po-multiselect` dinamicamente deve-se utilizar dados imutáveis.
+   * Exemplo de adição de um novo item com spread:
+   * ```
+   * this.options = [...this.options, { label: 'Example', value: 'example' }];
+   * ```
    */
   @Input('p-options') set options(options: Array<PoMultiselectOption>) {
     this._options = options;

--- a/projects/ui/src/lib/components/po-field/po-multiselect/samples/sample-po-multiselect-labs/sample-po-multiselect-labs.component.ts
+++ b/projects/ui/src/lib/components/po-field/po-multiselect/samples/sample-po-multiselect-labs/sample-po-multiselect-labs.component.ts
@@ -45,7 +45,7 @@ export class SamplePoMultiselectLabsComponent implements OnInit {
   }
 
   addOption() {
-    this.options.push(this.option);
+    this.options = [...this.options, {...this.option}];
     this.option = {label: undefined, value: undefined};
   }
 


### PR DESCRIPTION
**MULTISELECT**

**DTHFUI-2543**
_____________________________________________________________________________

**PR Checklist**

- [x] Código
- [x] Testes unitários
- [ ] Documentação
- [ ] Samples

**Qual o comportamento atual?**
Atualmente o componente não está validando as opções quando as mesmas são incluídas dinamicamente, pois as validações são chamadas apenas no set da propriedade.

**Qual o novo comportamento?**
Foi incluído o método de validação no hook ngDoCheck() e agora, mesmo com as opções incluídas dinamicamente as validações são chamadas e dessa forma o comportamento foi corrigido. 

**Simulação**
Simular no sample labs do multiselect no portal