### PR TITLE
feat(dynamic-form): DTHFUI-2598

### DIFF
--- a/projects/ui/src/lib/components/po-dynamic/po-dynamic-form/po-dynamic-form-base.component.ts
+++ b/projects/ui/src/lib/components/po-dynamic/po-dynamic-form/po-dynamic-form-base.component.ts
@@ -39,7 +39,7 @@ export class PoDynamicFormBaseComponent {
    * - Caso o *type* informado seja *boolean* o componente criado será o `po-switch`.
    * - Caso o *type* informado seja *currency* e não seja informado um *mask* ou *pattern* o componente criado será o `po-decimal`,
    * caso seja informado um *mask* ou *pattern* o componente criado será o `po-input`.
-   * - Caso o *type* informado seja *number* e não seja informado um *mask* ou *pattern* o componente criado será o `po-decimal`, caso seja
+   * - Caso o *type* informado seja *number* e não seja informado um *mask* ou *pattern* o componente criado será o `po-number`, caso seja
    * informado um *mask* ou *pattern* o componente criado será o `po-input`.
    * - Caso a lista possua a propriedade `options` e a mesma possua até 3 itens o componente criado será o `po-radio-group`
    * ou `po-checkbox-group` se informar a propriedade `optionsMulti`.

--- a/projects/ui/src/lib/components/po-dynamic/po-dynamic-form/po-dynamic-form-field.interface.ts
+++ b/projects/ui/src/lib/components/po-dynamic/po-dynamic-form/po-dynamic-form-field.interface.ts
@@ -27,6 +27,15 @@ export interface PoDynamicFormField extends PoDynamicField {
   /** Define a obrigatoriedade do campo. */
   required?: boolean;
 
+  /**
+   * Define se a indicação de campo opcional será exibida.
+   *
+   * > A indicação não será exibida, se:
+   * - O campo for `required`, ou;
+   * - Não possuir `help` e `label`.
+   */
+  optional?: boolean;
+
   /** Lista de opções que serão exibidos em um componente, podendo selecionar uma opção. */
   options?: Array<string> | Array<PoSelectOption> | Array<PoMultiselectOption>;
 
@@ -134,5 +143,12 @@ export interface PoDynamicFormField extends PoDynamicField {
    * ```
    */
   params?: any;
+
+  /**
+   * Mensagem que será apresentada quando o campo ficar inválido.
+   *
+   * > Esta mensagem não é apresentada quando o campo estiver vazio, mesmo que ele seja requerido.
+   */
+  errorMessage?: string;
 
 }

--- a/projects/ui/src/lib/components/po-dynamic/po-dynamic-form/po-dynamic-form-fields/po-dynamic-form-fields.component.html
+++ b/projects/ui/src/lib/components/po-dynamic/po-dynamic-form/po-dynamic-form-fields/po-dynamic-form-fields.component.html
@@ -10,11 +10,13 @@
       [ngClass]="field.componentClass"
       p-clean
       [p-disabled]="isDisabled(field)"
+      [p-error-pattern]="field.errorMessage"
       [p-focus]="field.focus"
       [p-help]="field.help"
       [p-label]="field.label"
       [p-max-date]="field.maxValue"
       [p-min-date]="field.minValue"
+      [p-optional]="field.optional"
       [p-required]="field.required"
       (p-change)="onChangeField(field)">
     </po-datepicker>
@@ -25,12 +27,14 @@
       [ngClass]="field.componentClass"
       p-clean
       [p-disabled]="isDisabled(field)"
+      [p-error-pattern]="field.errorMessage"
       [p-focus]="field.focus"
       [p-help]="field.help"
       [p-label]="field.label"
       [p-mask]="field.mask"
       [p-maxlength]="field.maxLength"
       [p-minlength]="field.minLength"
+      [p-optional]="field.optional"
       [p-pattern]="field.pattern"
       [p-required]="field.required"
       (p-change)="onChangeField(field)">
@@ -49,6 +53,7 @@
       [p-max]="field.maxValue"
       [p-maxlength]="field.maxLength"
       [p-minlength]="field.minLength"
+      [p-optional]="field.optional"
       [p-required]="field.required"
       (p-change)="onChangeField(field)">
     </po-number>
@@ -62,6 +67,7 @@
       [p-focus]="field.focus"
       [p-help]="field.help"
       [p-label]="field.label"
+      [p-optional]="field.optional"
       [p-required]="field.required"
       (p-change)="onChangeField(field)">
     </po-decimal>
@@ -74,6 +80,7 @@
       [p-disabled]="isDisabled(field)"
       [p-help]="field.help"
       [p-label]="field.label"
+      [p-optional]="field.optional"
       [p-options]="field.options"
       [p-required]="field.required"
       (p-change)="onChangeField(field)">
@@ -88,6 +95,7 @@
       [p-disabled]="isDisabled(field)"
       [p-help]="field.help"
       [p-label]="field.label"
+      [p-optional]="field.optional"
       [p-options]="field.options"
       [p-required]="field.required"
       (p-change)="onChangeField(field)">
@@ -116,6 +124,7 @@
       [p-filter-service]="field.optionsService"
       [p-help]="field.help"
       [p-label]="field.label"
+      [p-optional]="field.optional"
       [p-required]="field.required"
       (p-change)="onChangeField(field)">
     </po-combo>
@@ -133,6 +142,7 @@
       [p-focus]="field.focus"
       [p-help]="field.help"
       [p-label]="field.label"
+      [p-optional]="field.optional"
       [p-required]="field.required"
       (p-change)="onChangeField(field)">
     </po-lookup>
@@ -146,6 +156,7 @@
       [p-disabled]="isDisabled(field)"
       [p-help]="field.help"
       [p-label]="field.label"
+      [p-optional]="field.optional"
       [p-options]="field.options"
       [p-required]="field.required"
       (p-change)="onChangeField(field)">
@@ -159,6 +170,7 @@
       [p-focus]="field.focus"
       [p-help]="field.help"
       [p-label]="field.label"
+      [p-optional]="field.optional"
       [p-options]="field.options"
       [p-required]="field.required"
       (p-change)="onChangeField(field)">
@@ -174,6 +186,7 @@
       [p-label]="field.label"
       [p-maxlength]="field.maxLength"
       [p-minlength]="field.minLength"
+      [p-optional]="field.optional"
       [p-required]="field.required"
       [p-rows]="field.rows"
       (p-change)="onChangeField(field)">
@@ -185,14 +198,17 @@
       [ngClass]="field.componentClass"
       p-clean
       [p-disabled]="isDisabled(field)"
+      [p-error-pattern]="field.errorMessage"
       [p-focus]="field.focus"
       [p-help]="field.help"
       [p-label]="field.label"
       [p-maxlength]="field.maxLength"
       [p-minlength]="field.minLength"
+      [p-optional]="field.optional"
+      [p-pattern]="field.pattern"
       [p-required]="field.required"
       (p-change)="onChangeField(field)">
-  </po-password>
+    </po-password>
 
   </ng-container>
 </div>

--- a/projects/ui/src/lib/components/po-dynamic/po-dynamic-form/samples/sample-po-dynamic-form-register/sample-po-dynamic-form-register.component.ts
+++ b/projects/ui/src/lib/components/po-dynamic/po-dynamic-form/samples/sample-po-dynamic-form-register/sample-po-dynamic-form-register.component.ts
@@ -14,12 +14,25 @@ export class SamplePoDynamicFormRegisterComponent implements OnInit {
 
   fields: Array<PoDynamicFormField> = [
     { property: 'name', divider: 'PERSONAL DATA', required: true, minLength: 4, maxLength: 50, gridColumns: 6, gridSmColumns: 12 },
-    { property: 'birthday', type: 'date', gridColumns: 6, gridSmColumns: 12 },
+    { property: 'birthday',
+      label: 'Date of birth',
+      type: 'date',
+      gridColumns: 6,
+      gridSmColumns: 12,
+      maxValue: '2010-01-01',
+      errorMessage: 'The date must be before the year 2010.'
+    },
     { property: 'cpf', label: 'CPF', mask: '999.999.999-99', gridColumns: 6, gridSmColumns: 12, visible: false },
     { property: 'cnpj', label: 'CNPJ', mask: '99.999.999/9999-99', gridColumns: 6, gridSmColumns: 12, visible: false },
     { property: 'genre', gridColumns: 6, gridSmColumns: 12, options: ['Male', 'Female', 'Other'] },
     { property: 'shortDescription', label: 'Short Description', gridColumns: 12, gridSmColumns: 12, rows: 5 },
-    { property: 'secretKey', label: 'Secret Key', gridColumns: 6, secret: true },
+    { property: 'secretKey',
+      label: 'Secret Key',
+      gridColumns: 6,
+      secret: true,
+      pattern: '[a-zA]{5}[Z0-9]{3}',
+      errorMessage: 'At least 5 alphabetic and 3 numeric characters are required.'
+    },
     { property: 'email', divider: 'CONTACTS', gridColumns: 6 },
     { property: 'phone', mask: '(99) 99999-9999', gridColumns: 6 },
     { property: 'address', gridColumns: 6 },
@@ -39,6 +52,7 @@ export class SamplePoDynamicFormRegisterComponent implements OnInit {
       divider: 'MORE INFO',
       gridColumns: 6,
       gridSmColumns: 12,
+      optional: true,
       options: ['Soccer', 'Basketball', 'Bike', 'Yoga', 'Travel', 'Run'],
       optionsMulti: true
     },
@@ -47,6 +61,7 @@ export class SamplePoDynamicFormRegisterComponent implements OnInit {
       gridColumns: 6,
       gridSmColumns: 12,
       label: 'Favorite hero',
+      optional: true,
       searchService: 'https://thf.totvs.com.br/sample/api/comboOption/heroes',
       columns: [ { property: 'nickname', label: 'Hero' }, { property: 'label', label: 'Name' }]
     },

--- a/projects/ui/src/lib/components/po-field/po-multiselect/po-multiselect-base.component.ts
+++ b/projects/ui/src/lib/components/po-field/po-multiselect/po-multiselect-base.component.ts
@@ -208,6 +208,12 @@ export abstract class PoMultiselectBaseComponent implements ControlValueAccessor
    *
    * Nesta propriedade deve ser definida uma lista de objetos que implementam a interface PoMultiselectOption.
    * Esta lista deve conter os valores e os labels que serão apresentados na tela.
+   *
+   * > Para atualizar a lista de opções do `po-multiselect` dinamicamente deve-se utilizar dados imutáveis.
+   * Exemplo de adição de um novo item com spread:
+   * ```
+   * this.options = [...this.options, { label: 'Example', value: 'example' }];
+   * ```
    */
   @Input('p-options') set options(options: Array<PoMultiselectOption>) {
     this._options = options;

--- a/projects/ui/src/lib/components/po-field/po-multiselect/samples/sample-po-multiselect-labs/sample-po-multiselect-labs.component.ts
+++ b/projects/ui/src/lib/components/po-field/po-multiselect/samples/sample-po-multiselect-labs/sample-po-multiselect-labs.component.ts
@@ -45,7 +45,7 @@ export class SamplePoMultiselectLabsComponent implements OnInit {
   }
 
   addOption() {
-    this.options.push(this.option);
+    this.options = [...this.options, {...this.option}];
     this.option = {label: undefined, value: undefined};
   }
 


### PR DESCRIPTION
**DYNAMIC-FORM**

**DTHFUI-2598**
_____________________________________________________________________________

**PR Checklist**

- [x] Código
- [ ] Testes unitários
- [x] Documentação
- [x] Samples

**Qual o comportamento atual?**
Atualmente não é possível customizar as mensagens exibidas na identificação de campos inválidos.

**Qual o novo comportamento?**
Criada nova propriedade `errorMessage` na interface `PoDynamicFormField` que permite customizar as mensagens exibidas na identificação de campos inválidos.

**Simulação**
Simular no Sample Register do Dynamic-form no Portal, nos campos:
- Date of birth - passando uma data superior ao ano de 2010.
- Secret Key - campo validado através de uma regex.