### PR TITLE
docs(code-editor-register): corrige objeto de exemplo customEditor

### DIFF
--- a/projects/code-editor/src/lib/components/po-code-editor/po-code-editor-register.service.ts
+++ b/projects/code-editor/src/lib/components/po-code-editor/po-code-editor-register.service.ts
@@ -18,7 +18,7 @@ import { PoCodeEditorRegisterableOptions } from './interfaces/po-code-editor-reg
  * import { PoCodeEditorModule, PoCodeEditorRegisterable } from '@portinari/portinari-code-editor';
  *
  * const customEditor: PoCodeEditorRegisterable = {
- *   language: 'terraform'
+ *   language: 'terraform',
  *   options: {
  *     keywords: ['resource', 'provider', 'variable', 'output', 'module', 'true', 'false'],
  *     operators: ['{', '}', '(', ')', '[', ']', '?', ':'],


### PR DESCRIPTION
**PoCodeEditorRegister**

**#257**
_____________________________________________________________________________

**PR Checklist**

- [ ] Código
- [ ] Testes unitários
- [x] Documentação
- [ ] Samples

**Qual o comportamento atual?**
No exemplo da documentação está faltando um virgula após declarar a "language" na construção do objeto customEditor.

**Qual o novo comportamento?**
Incluido a virgula que estava faltando após declarar a "language" na construção do objeto customEditor.

**Simulação**
N/A
