### PR TITLE
feat(code-editor): adiciona propriedade `p-suggestions`

### DIFF
--- a/projects/code-editor/karma.conf.js
+++ b/projects/code-editor/karma.conf.js
@@ -22,15 +22,15 @@ module.exports = function (config) {
       thresholds: {
         emitWarning: false, // set to 'true' to not fail the test command when thresholds are not met
         global: {
-          statements: 86,
-          branches: 84,
-          functions: 79,
-          lines: 86
+          statements: 95,
+          branches: 95,
+          functions: 95,
+          lines: 95
         }, each: {
-          statements: 70,
-          branches: 70,
-          lines: 70,
-          functions: 70
+          statements: 90,
+          branches: 90,
+          lines: 90,
+          functions: 90
         }
       }
     },

--- a/projects/code-editor/src/lib/components/po-code-editor/interfaces/po-code-editor-registerable-suggestion.interface.ts
+++ b/projects/code-editor/src/lib/components/po-code-editor/interfaces/po-code-editor-registerable-suggestion.interface.ts
@@ -1,0 +1,29 @@
+/**
+ * @usedBy PoCodeEditorRegister, PoCodeEditorComponent
+ *
+ * @description
+ *
+ * Interface para configuração da lista de sugestão do autocomplete do code editor.
+ */
+export interface PoCodeEditorRegisterableSuggestion {
+
+  /** Texto que será exibido na lista de sugestões. */
+  label: string;
+
+  /** Texto que será inserido no editor ao selecionar a sugestão exibida pelo autocomplete. */
+  insertText: string;
+
+  /** Texto de ajuda que será exibido caso o usuário deseje ver mais informações sobre a sugestão. */
+  documentation?: string;
+}
+
+/**
+ * @usedBy PoCodeEditorRegister, PoCodeEditorRegisterable
+ *
+ * @description
+ *
+ * Interface do objeto usado pelo monaco para lisa de sugestão do autocomplete do code editor.
+ */
+export interface PoCodeEditorRegisterableSuggestionType {
+  provideCompletionItems: () => ({ suggestions: Array<PoCodeEditorRegisterableSuggestion>});
+}

--- a/projects/code-editor/src/lib/components/po-code-editor/interfaces/po-code-editor-registerable.interface.ts
+++ b/projects/code-editor/src/lib/components/po-code-editor/interfaces/po-code-editor-registerable.interface.ts
@@ -1,4 +1,5 @@
 import { PoCodeEditorRegisterableOptions } from './po-code-editor-registerable-options.interface';
+import { PoCodeEditorRegisterableSuggestionType } from './po-code-editor-registerable-suggestion.interface';
 
 /**
  * @usedBy PoCodeEditorRegister
@@ -14,5 +15,8 @@ export interface PoCodeEditorRegisterable {
 
   /** Opções de configuração da sintaxe customizada. */
   options: PoCodeEditorRegisterableOptions;
+
+  /** Lista de sugestões para a função de autocomplete. */
+  suggestions?: PoCodeEditorRegisterableSuggestionType;
 
 }

--- a/projects/code-editor/src/lib/components/po-code-editor/po-code-editor-base.component.spec.ts
+++ b/projects/code-editor/src/lib/components/po-code-editor/po-code-editor-base.component.spec.ts
@@ -1,12 +1,14 @@
 import { expectPropertiesValues } from './../../util-test/util-expect.spec';
 
 import { PoCodeEditorBaseComponent } from './po-code-editor-base.component';
+import { PoCodeEditorRegisterableSuggestion } from './interfaces/po-code-editor-registerable-suggestion.interface';
 
 class PoCodeEditorTestComponent extends PoCodeEditorBaseComponent {
   writeValue(value: any) { }
   setLanguage(value: any) { }
   setReadOnly(value: any) { }
   setTheme(value: any) { }
+  setSuggestions(value: any) { }
 }
 
 describe('PoCodeEditorBaseComponent', () => {
@@ -27,6 +29,49 @@ describe('PoCodeEditorBaseComponent', () => {
     spyOn(component, 'setLanguage');
     expectPropertiesValues(component, 'language', validValues, validValues);
     expect(component.setLanguage).toHaveBeenCalled();
+  });
+
+  it('shouldn`t call `setLanguage` when setting `language` with a configured editor', () => {
+    const language = 'java';
+
+    component.editor = undefined;
+
+    spyOn(component, 'setLanguage');
+
+    component.language = language;
+
+    expect(component.setLanguage).not.toHaveBeenCalled();
+  });
+
+  it('should call `setSuggestions` when setting `suggestions` with a configured editor', () => {
+    const suggestions: Array<PoCodeEditorRegisterableSuggestion> = [
+      { label: 'po', insertText: 'Portinari UI'},
+      { label: 'ng', insertText: 'Angular', documentation: 'Framework Javascript.'}
+    ];
+
+    component.editor = {};
+
+    spyOn(component, 'setSuggestions');
+
+    component.suggestions = suggestions;
+
+    expect(component.setSuggestions).toHaveBeenCalled();
+    expect(component.suggestions).toEqual(suggestions);
+  });
+
+  it('shouldn`t call `setSuggestions` when setting `suggestions` with a configured editor', () => {
+    const suggestions: Array<PoCodeEditorRegisterableSuggestion> = [
+      { label: 'po', insertText: 'Portinari UI'}
+    ];
+
+    component.editor = undefined;
+
+    spyOn(component, 'setSuggestions');
+
+    component.suggestions = suggestions;
+
+    expect(component.setSuggestions).not.toHaveBeenCalled();
+    expect(component.suggestions).toEqual(suggestions);
   });
 
   it('should set show-diff', () => {
@@ -59,6 +104,30 @@ describe('PoCodeEditorBaseComponent', () => {
 
     expectPropertiesValues(component, 'readonly', booleanValidFalseValues, false);
     expectPropertiesValues(component, 'readonly', booleanValidTrueValues, true);
+  });
+
+  it('should call `setReadOnly` when setting `readonly` with a configured editor', () => {
+    const readonly = true;
+
+    component.editor = {};
+
+    spyOn(component, 'setReadOnly');
+
+    component.readonly = readonly;
+
+    expect(component.setReadOnly).toHaveBeenCalled();
+  });
+
+  it('shouldn`t call `setReadOnly` when setting `readonly` with a configured editor', () => {
+    const readonly = true;
+
+    component.editor = undefined;
+
+    spyOn(component, 'setReadOnly');
+
+    component.readonly = readonly;
+
+    expect(component.setReadOnly).not.toHaveBeenCalled();
   });
 
   it('should set height', () => {

--- a/projects/code-editor/src/lib/components/po-code-editor/po-code-editor-base.component.ts
+++ b/projects/code-editor/src/lib/components/po-code-editor/po-code-editor-base.component.ts
@@ -1,6 +1,8 @@
 import { Input } from '@angular/core';
 import { ControlValueAccessor } from '@angular/forms';
 
+import { PoCodeEditorRegisterableSuggestion } from './interfaces/po-code-editor-registerable-suggestion.interface';
+
 const PO_CODE_EDITOR_THEMES = ['vs-dark', 'vs', 'hc-black'];
 const PO_CODE_EDITOR_THEME_DEFAULT = 'vs';
 
@@ -60,6 +62,7 @@ export abstract class PoCodeEditorBaseComponent implements ControlValueAccessor 
   private _language = 'plainText';
   private _readonly: boolean = false;
   private _showDiff: boolean = false;
+  private _suggestions: Array<PoCodeEditorRegisterableSuggestion>;
   private _theme = PO_CODE_EDITOR_THEME_DEFAULT;
 
   editor: any;
@@ -147,6 +150,38 @@ export abstract class PoCodeEditorBaseComponent implements ControlValueAccessor 
    *
    * @description
    *
+   * Lista de sugestões usadas pelo autocomplete dentro do editor.
+   *
+   * Para visualizar a lista de sugestões use o comando `CTRL + SPACE`.
+   *
+   * Caso o editor esteja usando uma linguagem que já tenha uma lista de sugestões pré definida, o valor passado será adicionado
+   * a lista pré existente, aumentando as opções para o usuário.
+   *
+   * ```
+   *  <po-code-editor
+   *    [p-suggestions]="[{ label: 'po', insertText: 'Portinari UI' }, { label: 'ng', insertText: 'Angular' }]">
+   *  </po-code-editor>
+   * ```
+   *
+   * Ao fornecer uma lista de sugestões é possível acelerar a escrita de scripts pelos usuários.
+   */
+  @Input('p-suggestions') set suggestions(values: Array<PoCodeEditorRegisterableSuggestion>) {
+    this._suggestions = values;
+
+    if (this.editor && this._suggestions) {
+      this.setSuggestions(this._suggestions);
+    }
+  }
+
+  get suggestions(): Array<PoCodeEditorRegisterableSuggestion> {
+    return this._suggestions;
+  }
+
+  /**
+   * @optional
+   *
+   * @description
+   *
    * Define um tema para o editor.
    *
    * Temas válidos:
@@ -189,7 +224,9 @@ export abstract class PoCodeEditorBaseComponent implements ControlValueAccessor 
     return `${this._height}px`;
   }
 
+  /* istanbul ignore next */
   onTouched = (value: any) => {};
+  /* istanbul ignore next */
   onChangePropagate = (value: any) => {};
 
   getOptions() {
@@ -211,6 +248,8 @@ export abstract class PoCodeEditorBaseComponent implements ControlValueAccessor 
   abstract setTheme(value: any);
 
   abstract setReadOnly(value: any);
+
+  abstract setSuggestions(value: any);
 
   protected convertToBoolean(val: any): boolean {
     if (typeof val === 'string') {

--- a/projects/code-editor/src/lib/components/po-code-editor/po-code-editor-register.service.ts
+++ b/projects/code-editor/src/lib/components/po-code-editor/po-code-editor-register.service.ts
@@ -2,6 +2,7 @@ import { Injectable } from '@angular/core';
 
 import { PoCodeEditorRegisterable } from './interfaces/po-code-editor-registerable.interface';
 import { PoCodeEditorRegisterableOptions } from './interfaces/po-code-editor-registerable-options.interface';
+import { PoCodeEditorRegisterableSuggestionType } from './interfaces/po-code-editor-registerable-suggestion.interface';
 
 /**
  * @description
@@ -17,6 +18,23 @@ import { PoCodeEditorRegisterableOptions } from './interfaces/po-code-editor-reg
  * ```
  * import { PoCodeEditorModule, PoCodeEditorRegisterable } from '@portinari/portinari-code-editor';
  *
+ * declare const monaco: any; // Importante para usar configurações com tipos definidos pelo Monaco
+ *
+ * // A função `provideCompletionItems` precisa ser exportada para ser compatível com AOT.
+ * export function provideCompletionItems() {
+ *   const suggestions = [{
+ *     label: 'terraform',
+ *     insertText: '#terraform language'
+ *   }, {
+ *     label: 'server',
+ *     insertText: 'server ${1:ip}',
+ *     // Insere uma sugestão do tipo Snippet
+ *     insertTextRules: monaco.languages.CompletionItemInsertTextRule.InsertAsSnippet
+ *   }];
+ *
+ *   return { suggestions: suggestions };
+ * }
+ *
  * const customEditor: PoCodeEditorRegisterable = {
  *   language: 'terraform'
  *   options: {
@@ -27,10 +45,9 @@ import { PoCodeEditorRegisterableOptions } from './interfaces/po-code-editor-reg
  *     tokenizer: {
  *      ...
  *     }
- *   }
+ *   },
+ *   suggestions: { provideCompletionItems: provideCompletionItems }
  * };
- * As configurações para o registro de uma nova sintaxe no Monaco code editor podem ser encontradas em
- * [**Monaco Editor**](https://microsoft.github.io/monaco-editor/playground.html#extending-language-services-custom-languages).
  *
  * @NgModule({
  *   declarations: [],
@@ -41,6 +58,9 @@ import { PoCodeEditorRegisterableOptions } from './interfaces/po-code-editor-reg
  *   bootstrap: [AppComponent]
  * })
  * ```
+ *
+ * > As configurações para o registro de uma nova sintaxe no Monaco code editor podem ser encontradas em
+ * > [**Monaco Editor**](https://microsoft.github.io/monaco-editor/playground.html#extending-language-services-custom-languages).
  */
 @Injectable()
 export class PoCodeEditorRegister implements PoCodeEditorRegisterable {
@@ -48,7 +68,10 @@ export class PoCodeEditorRegister implements PoCodeEditorRegisterable {
   /** Sintaxe a ser registrada. */
   language: string;
 
-  /** Opções da sintaxe para registro no po-code-editor */
+  /** Opções da sintaxe para registro no po-code-editor. */
   options: PoCodeEditorRegisterableOptions;
+
+  /** Lista de sugestões para a função de autocomplete (CTRL + SPACE). */
+  suggestions?: PoCodeEditorRegisterableSuggestionType;
 
 }

--- a/projects/code-editor/src/lib/components/po-code-editor/po-code-editor.component.spec.ts
+++ b/projects/code-editor/src/lib/components/po-code-editor/po-code-editor.component.spec.ts
@@ -73,26 +73,104 @@ describe('PoCodeEditorComponent', () => {
     expect(fakeThis.setMonacoLanguage).toHaveBeenCalledTimes(1);
   });
 
-  it('should call monaco register sintax', () => {
+  it('should call monaco `register` sintax', () => {
     const fakeThis = {
       codeEditorRegister: {
-        language: 'terraform'
+        language: 'terraform',
+        options: {},
+        suggestions: {}
       }
     };
 
     (<any>window).monaco = {
       languages: {
         register: () => {},
-        setMonarchTokensProvider: () => {}
+        setMonarchTokensProvider: () => {},
+        registerCompletionItemProvider: () => {}
       },
     };
 
     spyOn((<any>window).monaco.languages, <any>'register');
     spyOn((<any>window).monaco.languages, <any>'setMonarchTokensProvider');
+    spyOn((<any>window).monaco.languages, <any>'registerCompletionItemProvider');
 
     component['registerCustomLanguage'].call(fakeThis);
     expect((<any>window).monaco.languages.register).toHaveBeenCalled();
     expect((<any>window).monaco.languages.setMonarchTokensProvider).toHaveBeenCalled();
+    expect((<any>window).monaco.languages.registerCompletionItemProvider).toHaveBeenCalled();
+  });
+
+  it('shouldn`t call monaco `register` without a defined language', () => {
+    const fakeThis = {
+      codeEditorRegister: {
+        language: undefined,
+        options: {},
+        suggestions: {}
+      }
+    };
+
+    (<any>window).monaco = {
+      languages: {
+        register: () => {},
+        setMonarchTokensProvider: () => {},
+        registerCompletionItemProvider: () => {}
+      },
+    };
+
+    spyOn((<any>window).monaco.languages, <any>'register');
+    spyOn((<any>window).monaco.languages, <any>'setMonarchTokensProvider');
+    spyOn((<any>window).monaco.languages, <any>'registerCompletionItemProvider');
+
+    component['registerCustomLanguage'].call(fakeThis);
+    expect((<any>window).monaco.languages.register).not.toHaveBeenCalled();
+    expect((<any>window).monaco.languages.setMonarchTokensProvider).not.toHaveBeenCalled();
+    expect((<any>window).monaco.languages.registerCompletionItemProvider).not.toHaveBeenCalled();
+  });
+
+  it('shouldn`t call monaco `setMonarchTokensProvider` without a defined options', () => {
+    const fakeThis = {
+      codeEditorRegister: {
+        language: 'PoLanguage',
+        options: undefined,
+        suggestions: {}
+      }
+    };
+
+    (<any>window).monaco = {
+      languages: {
+        register: () => {},
+        setMonarchTokensProvider: () => {},
+        registerCompletionItemProvider: () => {}
+      },
+    };
+
+    spyOn((<any>window).monaco.languages, <any>'setMonarchTokensProvider');
+
+    component['registerCustomLanguage'].call(fakeThis);
+    expect((<any>window).monaco.languages.setMonarchTokensProvider).not.toHaveBeenCalled();
+  });
+
+  it('shouldn`t call monaco `registerCompletionItemProvider` without a defined suggestions', () => {
+    const fakeThis = {
+      codeEditorRegister: {
+        language: 'PoLanguage',
+        options: {},
+        suggestions: undefined
+      }
+    };
+
+    (<any>window).monaco = {
+      languages: {
+        register: () => {},
+        setMonarchTokensProvider: () => {},
+        registerCompletionItemProvider: () => {}
+      },
+    };
+
+    spyOn((<any>window).monaco.languages, <any>'registerCompletionItemProvider');
+
+    component['registerCustomLanguage'].call(fakeThis);
+    expect((<any>window).monaco.languages.registerCompletionItemProvider).not.toHaveBeenCalled();
   });
 
   it('should init monaco in ngDoCheck', () => {

--- a/projects/code-editor/src/lib/components/po-code-editor/po-code-editor.component.ts
+++ b/projects/code-editor/src/lib/components/po-code-editor/po-code-editor.component.ts
@@ -3,6 +3,7 @@ import { NG_VALUE_ACCESSOR } from '@angular/forms';
 
 import { PoCodeEditorBaseComponent } from './po-code-editor-base.component';
 import { PoCodeEditorRegister } from './po-code-editor-register.service';
+import { PoCodeEditorRegisterableSuggestion } from './interfaces/po-code-editor-registerable-suggestion.interface';
 
 let loadedMonaco: boolean = false;
 let loadPromise: Promise<void>;
@@ -61,6 +62,7 @@ export class PoCodeEditorComponent extends PoCodeEditorBaseComponent implements 
 
   ngAfterViewInit(): void {
     if (loadedMonaco) {
+      /* istanbul ignore next */
       loadPromise.then(() => {
         setTimeout( () => {
           if (this.el.nativeElement.offsetWidth) {
@@ -75,6 +77,7 @@ export class PoCodeEditorComponent extends PoCodeEditorBaseComponent implements 
       loadedMonaco = true;
       loadPromise = new Promise<void>((resolve: any) => {
 
+        /* istanbul ignore next */
         const onGotAmdLoader: any = () => {
           (<any>window).require.config({ paths: { 'vs': './assets/monaco/vs' } });
           (<any>window).require(['vs/editor/editor.main'], () => {
@@ -151,6 +154,18 @@ export class PoCodeEditorComponent extends PoCodeEditorBaseComponent implements 
     this.editor.updateOptions({readOnly: readOnly});
   }
 
+  /* istanbul ignore next */
+  setSuggestions(suggestions: Array<PoCodeEditorRegisterableSuggestion>) {
+    if (!suggestions) {
+      return;
+    }
+
+    monaco.languages.registerCompletionItemProvider(
+      this.language,
+      { provideCompletionItems: () => ({ suggestions: suggestions }) }
+    );
+  }
+
   writeValue(value) {
     this.value = value && value instanceof Array ? value[0] : value;
     this.modifiedValue = value && value instanceof Array && value.length > 0 ? value[1] : '';
@@ -185,6 +200,7 @@ export class PoCodeEditorComponent extends PoCodeEditorBaseComponent implements 
     }
     setTimeout(() => {
       this.setLanguage(this.language);
+      this.setSuggestions(this.suggestions);
     }, 500);
   }
 
@@ -196,8 +212,20 @@ export class PoCodeEditorComponent extends PoCodeEditorBaseComponent implements 
   private registerCustomLanguage() {
     if (this.codeEditorRegister.language) {
       monaco.languages.register({ id: this.codeEditorRegister.language });
-      monaco.languages.setMonarchTokensProvider(this.codeEditorRegister.language,
-                                                this.codeEditorRegister.options);
+
+      if (this.codeEditorRegister.options) {
+        monaco.languages.setMonarchTokensProvider(
+          this.codeEditorRegister.language,
+          this.codeEditorRegister.options
+        );
+      }
+
+      if (this.codeEditorRegister.suggestions) {
+        monaco.languages.registerCompletionItemProvider(
+          this.codeEditorRegister.language,
+          this.codeEditorRegister.suggestions
+        );
+      }
     }
   }
 }

--- a/projects/code-editor/src/lib/components/po-code-editor/samples/sample-po-code-editor-terraform/sample-po-code-editor-terraform.constant.ts
+++ b/projects/code-editor/src/lib/components/po-code-editor/samples/sample-po-code-editor-terraform/sample-po-code-editor-terraform.constant.ts
@@ -1,5 +1,49 @@
 import { PoCodeEditorRegisterable } from '@portinari/portinari-code-editor';
 
+declare const monaco: any;
+
+/** Definição da lista de sugestões para o autocomplete.
+ *
+ * > A função `provideCompletionItems` precisa ser exportada para ser compatível com AOT.
+ *
+ * Documentação: https://microsoft.github.io/monaco-editor/playground.html#extending-language-services-custom-languages
+ */
+export function provideCompletionItems() {
+  const suggestions = [
+    {
+      label: 'terraform',
+      kind: monaco.languages.CompletionItemKind.Text,
+      insertText: '#terraform language'
+    }, {
+      label: 'resource',
+      documentation: 'Read more in https://www.terraform.io/docs/configuration/resources.html',
+      insertText: [
+        'resource "${1:instance}" "${2:type}" {',
+        '\tami           = "${3:ami}"',
+        '\tinstance_type = "${4:instance_type}"',
+        '}'
+      ].join('\n'),
+      insertTextRules: monaco.languages.CompletionItemInsertTextRule.InsertAsSnippet
+    }, {
+      label: 'provider',
+      documentation: 'Read more in https://www.terraform.io/docs/configuration/providers.html',
+      insertText: [
+        'provider "${1:name}" {',
+        '\tproject = "${2:project}"',
+        '\tregion  = "${3:region}"',
+        '}'
+      ].join('\n'),
+      insertTextRules: monaco.languages.CompletionItemInsertTextRule.InsertAsSnippet
+    }, {
+      label: 'server',
+      insertText: 'server ${1:ip}',
+      insertTextRules: monaco.languages.CompletionItemInsertTextRule.InsertAsSnippet
+    }
+  ];
+
+  return { suggestions: suggestions };
+}
+
 /** Definindo propriedades de uma nova sintaxe. */
 export const customRegister: PoCodeEditorRegisterable = {
 
@@ -43,6 +87,6 @@ export const customRegister: PoCodeEditorRegisterable = {
         ['', '', '@pop'],
       ],
     },
-  }
-
+  },
+  suggestions: { provideCompletionItems: provideCompletionItems }
 };

--- a/projects/code-editor/src/lib/components/po-code-editor/samples/sample-po-code-editor-terraform/sample-po-code-editor-terraform.module.ts
+++ b/projects/code-editor/src/lib/components/po-code-editor/samples/sample-po-code-editor-terraform/sample-po-code-editor-terraform.module.ts
@@ -3,13 +3,28 @@
  */
 
 // import { NgModule } from '@angular/core';
-
 // import { HttpClientModule } from '@angular/common/http';
-
-// import { PoModule } from '@portinari/portinari-ui';
 //
+// import { PoModule } from '@portinari/portinari-ui';
 // import { PoCodeEditorModule, PoCodeEditorRegisterable } from '@portinari/portinari-code-editor';
-
+//
+// declare const monaco: any; // Importante para usar configurações com tipos definidos pelo Monaco
+//
+// /** A função `provideCompletionItems` precisa ser exportada para ser compatível com AOT. */
+// export function provideCompletionItems() {
+//   const suggestions = [{
+//     label: 'terraform',
+//     insertText: '#terraform language'
+//   }, {
+//     label: 'server',
+//     insertText: 'server ${1:ip}',
+//     // Insere uma sugestão do tipo Snippet
+//     insertTextRules: monaco.languages.CompletionItemInsertTextRule.InsertAsSnippet
+//   }];
+//
+//   return { suggestions: suggestions };
+// }
+//
 // const customRegister: PoCodeEditorRegisterable = {
 //   language: 'terraform'
 //   options: {
@@ -20,13 +35,13 @@
 //     tokenizer: {
 //      ...
 //     }
-//   }
+//   },
+//   suggestions: { provideCompletionItems: provideCompletionItems }
 // };
 //
 // @NgModule({
 //   imports: [
 //     HttpClientModule,
-
 //     PoModule,
 //     PoCodeEditorModule.forRegister(customRegister)
 //   ],


### PR DESCRIPTION
**Code Editor**

**DTHFUI-2797**
_____________________________________________________________________________

**PR Checklist**

- [x] Código
- [x] Testes unitários
- [x] Documentação
- [x] Samples

**Qual o comportamento atual?**

Não permite criar uma lista de sugestões para o autocomplete.

**Qual o novo comportamento?**

Além de adicionar a propriedade `p-suggestions` ao componente, foram
adicionados alguns testes para aumentar o coverage do componente
garantido mais qualidade ao código.

Com essa nova funcionalidade o desenvolvedor pode adicionar uma lista
de sugestões para o autocomplete (além de snippets) quando cria uma nova
sintaxe ou diretamente a uma linguagem já existentes diretamente no
componente.

**Simulação**

Criar uma página com o componente e adicionar sugestões para o mesmo e usar a tecla CTRL+SPACE para ver a lista de sugestões:

```
<po-code-editor
  [p-suggestions]="[{ label: 'po', insertText: 'Portinari UI' }, { label: 'ng', insertText: 'Angular' }]">
</po-code-editor>
```
