### PR TITLE
docs(loading-overlay): documenta como utilizar p-screen-lock="false" 

### DIFF
--- a/projects/ui/src/lib/components/po-loading/po-loading-overlay/po-loading-overlay-base.component.ts
+++ b/projects/ui/src/lib/components/po-loading/po-loading-overlay/po-loading-overlay-base.component.ts
@@ -38,7 +38,20 @@ export class PoLoadingOverlayBaseComponent {
    *
    * @description
    *
-   * Define se o _overlay_ será aplicado a um container ou a página inteira.
+   * Define se o *overlay* será aplicado a um *container* ou a página inteira.
+   *
+   * Para utilizar o componente como um *container*, o elemento pai deverá receber uma posição relativa, por exemplo:
+   *
+   * ```
+   * <div style="position: relative">
+   *
+   *  <po-chart [p-series]="[{ value: 10, category: 'Example' }]">
+   *  </po-chart>
+   *
+   *  <po-loading-overlay>
+   *  </po-loading-overlay>
+   * </div>
+   * ```
    *
    * @default `false`
    */


### PR DESCRIPTION
**LOADING OVERLAY**

**DTHFUI-2602**
_____________________________________________________________________________

**PR Checklist**

- [ ] Código
- [ ] Testes unitários
- [x] Documentação
- [ ] Samples

**Qual o comportamento atual?**
Atualmente não informa a necessidade de utilizar posição relativa ao elemento pai.

**Qual o novo comportamento?**
Documentado a necessidade de utilizar o position: relative ao elemento pai caso utilizar a propriedade p-screen-lock como false.

**Simulação**
Avaliar documentação da propriedade p-screen-lock.