### PR TITLE
feat(page-dynamic-search): adiciona a propriedade p-literals

### DIFF
--- a/projects/templates/src/lib/components/po-page-dynamic-search/index.ts
+++ b/projects/templates/src/lib/components/po-page-dynamic-search/index.ts
@@ -1,4 +1,5 @@
 export * from './po-page-dynamic-search.component';
 export * from './po-page-dynamic-search.interface';
+export * from './po-page-dynamic-search-literals.interface';
 
 export * from './po-page-dynamic-search.module';

--- a/projects/templates/src/lib/components/po-page-dynamic-search/po-advanced-filter/po-advanced-filter-base.component.spec.ts
+++ b/projects/templates/src/lib/components/po-page-dynamic-search/po-advanced-filter/po-advanced-filter-base.component.spec.ts
@@ -1,9 +1,17 @@
-import { PoAdvancedFilterBaseComponent } from './po-advanced-filter-base.component';
-
+import * as utilsFunctions from './../../../utils/util';
 import { expectPropertiesValues } from '../../../util-test/util-expect.spec';
+import { PoLanguageService } from '../../../../../../ui/src/lib/services/po-language/po-language.service';
+
+import { PoAdvancedFilterBaseComponent, poAdvancedFiltersLiteralsDefault } from './po-advanced-filter-base.component';
 
 describe('PoAdvancedFilterBaseComponent', () => {
-  const component = new PoAdvancedFilterBaseComponent();
+  let component;
+
+  const languageService = new PoLanguageService();
+
+  beforeEach(() => {
+    component = new PoAdvancedFilterBaseComponent(languageService);
+  });
 
   it('should be created', () => {
     expect(component).toBeTruthy();
@@ -21,6 +29,114 @@ describe('PoAdvancedFilterBaseComponent', () => {
       const validValues = [ [{ property: 'Teste 1' }], [{ property: 'Teste 2' }] ];
 
       expectPropertiesValues(component, 'filters', validValues, validValues);
+    });
+
+    describe('literals:', () => {
+      const poLocaleDefault = utilsFunctions.poLocaleDefault;
+
+      it('should be in portuguese if browser is setted with an unsupported language', () => {
+        component['language'] = 'zw';
+
+        component.literals = {};
+
+        expect(component.literals).toEqual(poAdvancedFiltersLiteralsDefault[poLocaleDefault]);
+      });
+
+      it('should be in portuguese if browser is setted with `pt`', () => {
+        component['language'] = 'pt';
+
+        component.literals = {};
+
+        expect(component.literals).toEqual(poAdvancedFiltersLiteralsDefault.pt);
+      });
+
+      it('should be in english if browser is setted with `en`', () => {
+        component['language'] = 'en';
+
+        component.literals = {};
+
+        expect(component.literals).toEqual(poAdvancedFiltersLiteralsDefault.en);
+      });
+
+      it('should be in spanish if browser is setted with `es`', () => {
+        component['language'] = 'es';
+
+        component.literals = {};
+
+        expect(component.literals).toEqual(poAdvancedFiltersLiteralsDefault.es);
+      });
+
+      it('should be in russian if browser is setted with `ru`', () => {
+        component['language'] = 'ru';
+
+        component.literals = {};
+
+        expect(component.literals).toEqual(poAdvancedFiltersLiteralsDefault.ru);
+      });
+
+      it('should accept custom literals', () => {
+        component['language'] = poLocaleDefault;
+
+        const customLiterals = Object.assign({}, poAdvancedFiltersLiteralsDefault[poLocaleDefault]);
+
+        customLiterals.title = 'Filtro avançado';
+        customLiterals.cancelLabel = 'Fechar';
+        customLiterals.confirmLabel = 'Aplicar';
+
+        component.literals = customLiterals;
+
+        expect(component.literals).toEqual(customLiterals);
+      });
+
+      it('should update property with default literals if is setted with invalid values', () => {
+        const invalidValues = [null, undefined, false, true, '', 'literals', 0, 10, [], [1, 2], () => {}];
+
+        component['language'] = 'pt';
+
+        expectPropertiesValues(component, 'literals', invalidValues, poAdvancedFiltersLiteralsDefault[poLocaleDefault]);
+      });
+
+      it('should get literals directly from poAdvancedFiltersLiteralsDefault if it not initialized', () => {
+        component['language'] = 'pt';
+
+        expect(component.literals).toEqual(poAdvancedFiltersLiteralsDefault['pt']);
+      });
+    });
+
+  });
+
+  describe('Methods:', () => {
+
+    it('getValuesFromForm: should return all items that property isn´t undefined or ``.', () => {
+      component.filter = { name: 'name', birthdate: 'Birthdate', age: '', Adress: undefined };
+
+      const filteredItems = { name: 'name', birthdate: 'Birthdate' };
+
+      expect(component['getValuesFromForm']()).toEqual(filteredItems);
+    });
+
+    it('primaryAction: should emit `searchEvent` and call `getValuesFromForm` and `poModal.close`', () => {
+      component.poModal = <any> { close: () => {} };
+
+      spyOn(component.searchEvent, 'emit');
+      spyOn(component.poModal, 'close');
+      spyOn(component, <any> 'getValuesFromForm');
+
+      component.primaryAction.action();
+
+      expect(component.searchEvent.emit).toHaveBeenCalled();
+      expect(component.poModal.close).toHaveBeenCalled();
+      expect(component['getValuesFromForm']).toHaveBeenCalled();
+    });
+
+    it('secondaryAction: should call `poModal.close`', () => {
+      component.poModal = <any> { close: () => {} };
+
+      spyOn(component.poModal, 'close');
+
+      component.secondaryAction.action();
+
+      expect(component.poModal.close).toHaveBeenCalled();
     });
 
   });

--- a/projects/templates/src/lib/components/po-page-dynamic-search/po-advanced-filter/po-advanced-filter-literals.interface.ts
+++ b/projects/templates/src/lib/components/po-page-dynamic-search/po-advanced-filter/po-advanced-filter-literals.interface.ts
@@ -1,0 +1,19 @@
+/**
+ * @docsPrivate
+ *
+ * @description
+ *
+ * Interface para definição das literais usadas no `po-advanced-filter`.
+ */
+export interface PoAdvancedFilterLiterals {
+
+  /** Título do filtro avançado. */
+  title?: string;
+
+  /** Texto exibido no botão de cancelamento do filtro avaçando. */
+  cancelLabel?: string;
+
+  /** Texto exibido no botão de confirmação do filtro avaçando. */
+  confirmLabel?: string;
+
+}

--- a/projects/templates/src/lib/components/po-page-dynamic-search/po-advanced-filter/po-advanced-filter.component.spec.ts
+++ b/projects/templates/src/lib/components/po-page-dynamic-search/po-advanced-filter/po-advanced-filter.component.spec.ts
@@ -1,9 +1,9 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { FormsModule } from '@angular/forms';
 
-import { configureTestSuite } from './../../../util-test/util-expect.spec';
-
 import { PoDynamicModule, PoFieldModule, PoModalModule } from '@portinari/portinari-ui';
+
+import { configureTestSuite } from './../../../util-test/util-expect.spec';
 
 import { PoAdvancedFilterBaseComponent } from './po-advanced-filter-base.component';
 import { PoAdvancedFilterComponent } from './po-advanced-filter.component';
@@ -40,34 +40,6 @@ describe('PoAdvancedFilterComponent', () => {
   });
 
   describe('Methods:', () => {
-
-    it('primaryAction: should emit `searchEvent` and call `getValuesFromForm` and `poModal.close`', () => {
-      spyOn(component.searchEvent, 'emit');
-      spyOn(component.poModal, 'close');
-      spyOn(component, 'getValuesFromForm');
-
-      component.primaryAction.action();
-
-      expect(component.searchEvent.emit).toHaveBeenCalled();
-      expect(component.poModal.close).toHaveBeenCalled();
-      expect(component.getValuesFromForm).toHaveBeenCalled();
-    });
-
-    it('secondaryAction: should call `poModal.close`', () => {
-      spyOn(component.poModal, 'close');
-
-      component.secondaryAction.action();
-
-      expect(component.poModal.close).toHaveBeenCalled();
-    });
-
-    it('getValuesFromForm: should return all items if no property is undefined or ``', () => {
-      component.filter = { name: 'name', birthdate: 'Birthdate', age: '', Adress: undefined };
-
-      const filteredItems = { name: 'name', birthdate: 'Birthdate' };
-
-      expect(component.getValuesFromForm()).toEqual(filteredItems);
-    });
 
     it('open: should call `poModal.open` and set `filter` with {}', () => {
       component.filter = filters;

--- a/projects/templates/src/lib/components/po-page-dynamic-search/po-advanced-filter/po-advanced-filter.component.ts
+++ b/projects/templates/src/lib/components/po-page-dynamic-search/po-advanced-filter/po-advanced-filter.component.ts
@@ -1,6 +1,6 @@
 import { Component, ViewChild } from '@angular/core';
 
-import { PoDynamicFormComponent, PoModalAction, PoModalComponent } from '@portinari/portinari-ui';
+import { PoDynamicFormComponent, PoLanguageService } from '@portinari/portinari-ui';
 
 import { PoAdvancedFilterBaseComponent } from './po-advanced-filter-base.component';
 
@@ -22,38 +22,10 @@ import { PoAdvancedFilterBaseComponent } from './po-advanced-filter-base.compone
 })
 export class PoAdvancedFilterComponent extends PoAdvancedFilterBaseComponent {
 
-  filter = {};
-
-  @ViewChild(PoModalComponent, { static: true }) poModal: PoModalComponent;
-
   @ViewChild(PoDynamicFormComponent, { static: true }) poDynamicForm: PoDynamicFormComponent;
 
-  primaryAction: PoModalAction = {
-    action: () => {
-      const models = this.getValuesFromForm();
-
-      this.searchEvent.emit(models);
-      this.poModal.close();
-    },
-    label: this.literals.primaryActionLabel
-  };
-
-  secondaryAction: PoModalAction = {
-    action: () => {
-      this.poModal.close();
-    },
-    label: this.literals.secondaryActionLabel
-  };
-
-  // Retorna os models dos campos preenchidos
-  getValuesFromForm() {
-    Object.keys(this.filter).forEach(property => {
-      if (this.filter[property] === undefined || this.filter[property] === '') {
-        delete this.filter[property];
-      }
-    });
-
-    return this.filter;
+  constructor(languageService: PoLanguageService) {
+    super(languageService);
   }
 
   open() {

--- a/projects/templates/src/lib/components/po-page-dynamic-search/po-page-dynamic-search-base.component.spec.ts
+++ b/projects/templates/src/lib/components/po-page-dynamic-search/po-page-dynamic-search-base.component.spec.ts
@@ -1,9 +1,19 @@
-import { PoPageDynamicSearchBaseComponent } from './po-page-dynamic-search-base.component';
-
+import * as utilsFunctions from './../../utils/util';
 import { expectPropertiesValues } from '../../util-test/util-expect.spec';
+import { PoLanguageService } from './../../../../../ui/src/lib/services/po-language/po-language.service';
 
-describe('PoPageDynamicSearchBaseComponent', () => {
-  const component = new PoPageDynamicSearchBaseComponent();
+import { PoAdvancedFilterLiterals } from './po-advanced-filter/po-advanced-filter-literals.interface';
+import { PoPageDynamicSearchLiterals } from './po-page-dynamic-search-literals.interface';
+import { PoPageDynamicSearchBaseComponent, poPageDynamicSearchLiteralsDefault } from './po-page-dynamic-search-base.component';
+
+describe('PoPageDynamicSearchBaseComponent:', () => {
+  let component;
+
+  const languageService = new PoLanguageService();
+
+  beforeEach(() => {
+    component = new PoPageDynamicSearchBaseComponent(languageService);
+  });
 
   it('should be created', () => {
     expect(component).toBeTruthy();
@@ -21,6 +31,100 @@ describe('PoPageDynamicSearchBaseComponent', () => {
       const validValues = [ [{ property: 'Teste 1' }], [{ property: 'Teste 2' }] ];
 
       expectPropertiesValues(component, 'filters', validValues, validValues);
+    });
+
+    describe('p-literals:', () => {
+      const poLocaleDefault = utilsFunctions.poLocaleDefault;
+
+      it('should be in portuguese if browser is setted with an unsupported language', () => {
+        component['language'] = 'zw';
+
+        component.literals = {};
+
+        expect(component.literals).toEqual(poPageDynamicSearchLiteralsDefault[poLocaleDefault]);
+      });
+
+      it('should be in portuguese if browser is setted with `pt`', () => {
+        component['language'] = 'pt';
+
+        component.literals = {};
+
+        expect(component.literals).toEqual(poPageDynamicSearchLiteralsDefault.pt);
+      });
+
+      it('should be in english if browser is setted with `en`', () => {
+        component['language'] = 'en';
+
+        component.literals = {};
+
+        expect(component.literals).toEqual(poPageDynamicSearchLiteralsDefault.en);
+      });
+
+      it('should be in spanish if browser is setted with `es`', () => {
+        component['language'] = 'es';
+
+        component.literals = {};
+
+        expect(component.literals).toEqual(poPageDynamicSearchLiteralsDefault.es);
+      });
+
+      it('should be in russian if browser is setted with `ru`', () => {
+        component['language'] = 'ru';
+
+        component.literals = {};
+
+        expect(component.literals).toEqual(poPageDynamicSearchLiteralsDefault.ru);
+      });
+
+      it('should accept custom literals', () => {
+        component['language'] = poLocaleDefault;
+
+        const customLiterals = Object.assign({}, poPageDynamicSearchLiteralsDefault[poLocaleDefault]);
+
+        customLiterals.filterTitle = 'Filtro avançado';
+        customLiterals.disclaimerGroupTitle = 'Filtros aplicados:';
+
+        component.literals = customLiterals;
+
+        expect(component.literals).toEqual(customLiterals);
+      });
+
+      it('should update property with default literals if is setted with invalid values', () => {
+        const invalidValues = [null, undefined, false, true, '', 'literals', 0, 10, [], [1, 2], () => {}];
+
+        component['language'] = poLocaleDefault;
+
+        expectPropertiesValues(component, 'literals', invalidValues, poPageDynamicSearchLiteralsDefault[poLocaleDefault]);
+      });
+
+      it('should get literals directly from poPageDynamicSearchLiteralsDefault if it not initialized', () => {
+        component['language'] = 'pt';
+
+        expect(component.literals).toEqual(poPageDynamicSearchLiteralsDefault['pt']);
+      });
+
+    });
+
+  });
+
+  describe('Methods:', () => {
+
+    it('setAdvancedFilterLiterals: should set `advancedFilterLiterals` with `pageDynamicSearchLiterals`.', () => {
+      const title = 'Filtro avançado';
+      const cancelLabel = 'Fechar';
+      const confirmLabel = 'Confirmar';
+
+      const expectedValue: PoAdvancedFilterLiterals = { title, cancelLabel, confirmLabel };
+
+      const pageDynamicSearchLiterals: PoPageDynamicSearchLiterals = {
+        filterCancelLabel: cancelLabel,
+        filterConfirmLabel: confirmLabel,
+        filterTitle: title
+      };
+
+      component['setAdvancedFilterLiterals'](pageDynamicSearchLiterals);
+
+      expect(component.advancedFilterLiterals).toEqual(expectedValue);
     });
 
   });

--- a/projects/templates/src/lib/components/po-page-dynamic-search/po-page-dynamic-search-base.component.ts
+++ b/projects/templates/src/lib/components/po-page-dynamic-search/po-page-dynamic-search-base.component.ts
@@ -1,25 +1,46 @@
 import { EventEmitter, Input, Output } from '@angular/core';
 
-import { PoBreadcrumb, PoDynamicFormField, PoPageAction } from '@portinari/portinari-ui';
+import { PoBreadcrumb, PoDynamicFormField, PoLanguageService, PoPageAction } from '@portinari/portinari-ui';
 
-import { browserLanguage, poLocaleDefault } from '../../utils/util';
+import { poLocaleDefault } from '../../utils/util';
+
+import { PoPageDynamicSearchLiterals } from './po-page-dynamic-search-literals.interface';
+import { poAdvancedFiltersLiteralsDefault } from './po-advanced-filter/po-advanced-filter-base.component';
+import { PoAdvancedFilterLiterals } from './po-advanced-filter/po-advanced-filter-literals.interface';
 
 export const poPageDynamicSearchLiteralsDefault = {
-  en: {
+  en: <PoPageDynamicSearchLiterals> {
     disclaimerGroupTitle: 'Displaying results filtered by:',
-    filterSettingsPlaceholder: 'Search',
-    quickSearchLabel: 'Quick search:'
+    filterTitle: poAdvancedFiltersLiteralsDefault.en.title,
+    filterCancelLabel: poAdvancedFiltersLiteralsDefault.en.cancelLabel,
+    filterConfirmLabel: poAdvancedFiltersLiteralsDefault.en.confirmLabel,
+    quickSearchLabel: 'Quick search:',
+    searchPlaceholder: 'Search'
   },
-  es: {
+  es: <PoPageDynamicSearchLiterals> {
     disclaimerGroupTitle: 'Presentando resultados filtrados por:',
-    filterSettingsPlaceholder: 'Buscar',
-    quickSearchLabel: 'Búsqueda rápida:'
+    filterTitle: poAdvancedFiltersLiteralsDefault.es.title,
+    filterCancelLabel: poAdvancedFiltersLiteralsDefault.es.cancelLabel,
+    filterConfirmLabel: poAdvancedFiltersLiteralsDefault.es.confirmLabel,
+    quickSearchLabel: 'Búsqueda rápida:',
+    searchPlaceholder: 'Buscar',
   },
-  pt: {
+  pt: <PoPageDynamicSearchLiterals> {
     disclaimerGroupTitle: 'Apresentando resultados filtrados por:',
-    filterSettingsPlaceholder: 'Pesquisar',
-    quickSearchLabel: 'Pesquisa rápida:'
-  }
+    filterTitle: poAdvancedFiltersLiteralsDefault.pt.title,
+    filterCancelLabel: poAdvancedFiltersLiteralsDefault.pt.cancelLabel,
+    filterConfirmLabel: poAdvancedFiltersLiteralsDefault.pt.confirmLabel,
+    quickSearchLabel: 'Pesquisa rápida:',
+    searchPlaceholder: 'Pesquisar'
+  },
+  ru: <PoPageDynamicSearchLiterals> {
+    disclaimerGroupTitle: 'Отображение результатов, отфильтрованных по:',
+    filterTitle: poAdvancedFiltersLiteralsDefault.ru.title,
+    filterCancelLabel: poAdvancedFiltersLiteralsDefault.ru.cancelLabel,
+    filterConfirmLabel: poAdvancedFiltersLiteralsDefault.ru.confirmLabel,
+    quickSearchLabel: 'Быстрый поиск:',
+    searchPlaceholder: 'исследование'
+  },
 };
 
 /**
@@ -31,17 +52,73 @@ export const poPageDynamicSearchLiteralsDefault = {
 export class PoPageDynamicSearchBaseComponent {
 
   private _filters: Array<PoDynamicFormField> = [];
+  private _literals: PoPageDynamicSearchLiterals;
 
-  literals = {
-    ...poPageDynamicSearchLiteralsDefault[poLocaleDefault],
-    ...poPageDynamicSearchLiteralsDefault[browserLanguage()]
-  };
+  advancedFilterLiterals: PoAdvancedFilterLiterals;
+
+  private language: string;
 
   /** Nesta propriedade deve ser definido um array de objetos que implementam a interface `PoPageAction`. */
   @Input('p-actions') actions?: Array<PoPageAction> = [];
 
   /** Objeto com propriedades do breadcrumb. */
   @Input('p-breadcrumb') breadcrumb?: PoBreadcrumb = { items: [] };
+
+  /**
+   * @optional
+   *
+   * @description
+   *
+   * Objeto com as literais usadas no `po-page-dynamic-search`.
+   *
+   * Existem duas maneiras de customizar o componente, passando um objeto com todas as literais disponíveis:
+   *
+   * ```
+   *  const customLiterals: PoPageDynamicSearchLiterals = {
+   *    disclaimerGroupTitle: 'Filtros aplicados:',
+   *    filterTitle: 'Filtro avançado',
+   *    filterCancelLabel: 'Fechar',
+   *    filterConfirmLabel: 'Aplicar',
+   *    quickSearchLabel: 'Valor pesquisado:',
+   *    searchPlaceholder: 'Pesquise aqui'
+   *  };
+   * ```
+   *
+   * Ou passando apenas as literais que deseja customizar:
+   *
+   * ```
+   *  const customLiterals: PoPageDynamicSearchLiterals = {
+   *    filterTitle: 'Filtro avançado'
+   *  };
+   * ```
+   *
+   * E para carregar as literais customizadas, basta apenas passar o objeto para o componente.
+   *
+   * ```
+   * <po-page-dynamic-search
+   *   [p-literals]="customLiterals">
+   * </po-page-dynamic-search>
+   * ```
+   *
+   * > O valor padrão será traduzido de acordo com o idioma configurado no [`PoI18nService`](/documentation/po-i18n) ou *browser*.
+   */
+  @Input('p-literals') set literals(value: PoPageDynamicSearchLiterals) {
+    if (value instanceof Object && !(value instanceof Array)) {
+      this._literals = {
+        ...poPageDynamicSearchLiteralsDefault[poLocaleDefault],
+        ...poPageDynamicSearchLiteralsDefault[this.language],
+        ...value
+      };
+    } else {
+      this._literals = poPageDynamicSearchLiteralsDefault[this.language];
+    }
+
+    this.setAdvancedFilterLiterals(this.literals);
+  }
+
+  get literals() {
+    return this._literals || poPageDynamicSearchLiteralsDefault[this.language];
+  }
 
   /**
    * @optional
@@ -75,5 +152,17 @@ export class PoPageDynamicSearchBaseComponent {
 
   /** Evento disparado ao realizar uma busca pelo campo de pesquisa rápida, o mesmo será chamado repassando o valor digitado. */
   @Output('p-quick-search') quickSearch?: EventEmitter<string> = new EventEmitter();
+
+  constructor(languageService: PoLanguageService) {
+    this.language = languageService.getShortLanguage();
+  }
+
+  protected setAdvancedFilterLiterals(literals: PoPageDynamicSearchLiterals) {
+    this.advancedFilterLiterals = {
+      cancelLabel: literals.filterCancelLabel,
+      confirmLabel: literals.filterConfirmLabel,
+      title: literals.filterTitle
+    };
+  }
 
 }

--- a/projects/templates/src/lib/components/po-page-dynamic-search/po-page-dynamic-search-literals.interface.ts
+++ b/projects/templates/src/lib/components/po-page-dynamic-search/po-page-dynamic-search-literals.interface.ts
@@ -1,0 +1,28 @@
+/**
+ * @usedBy PoPageDynamicSearchComponent
+ *
+ * @description
+ *
+ * Interface para definição das literais usadas no `po-page-dynamic-search`.
+ */
+export interface PoPageDynamicSearchLiterals {
+
+  /** Título do grupo de *disclaimers* que será exibido após realizar alguma busca. */
+  disclaimerGroupTitle?: string;
+
+  /** Texto exibido no botão para cancelamento da busca avaçanda. */
+  filterCancelLabel?: string;
+
+  /** Texto exibido no botão para confirmação da busca avaçanda. */
+  filterConfirmLabel?: string;
+
+  /** Título da busca avançada. */
+  filterTitle?: string;
+
+  /** Texto do *disclaimer* que será exibido em conjunto com o valor preenchido no campo de busca rápida. */
+  quickSearchLabel?: string;
+
+  /** Mensagem que aparecerá enquanto o campo de busca rápida não estiver preenchido. */
+  searchPlaceholder?: string;
+
+}

--- a/projects/templates/src/lib/components/po-page-dynamic-search/po-page-dynamic-search.component.html
+++ b/projects/templates/src/lib/components/po-page-dynamic-search/po-page-dynamic-search.component.html
@@ -7,9 +7,9 @@
 
   <po-advanced-filter
     [p-filters]="filters"
+    [p-literals]="advancedFilterLiterals"
     (p-search-event)="onAdvancedSearch($event)">
   </po-advanced-filter>
 
   <ng-content></ng-content>
-
 </po-page-list>

--- a/projects/templates/src/lib/components/po-page-dynamic-search/po-page-dynamic-search.component.spec.ts
+++ b/projects/templates/src/lib/components/po-page-dynamic-search/po-page-dynamic-search.component.spec.ts
@@ -51,7 +51,7 @@ describe('PoPageDynamicSearchComponent:', () => {
 
     it('get filterSettings: should return `filterSettings` with `advancedAction` equal to `undefined` if haven`t filters', () => {
       const result = { action: 'onAction', advancedAction: undefined, ngModel: 'quickFilter',
-        placeholder: component.literals.filterSettingsPlaceholder };
+        placeholder: component.literals.searchPlaceholder };
 
       expect(component.filterSettings).toEqual(result);
     });
@@ -63,7 +63,7 @@ describe('PoPageDynamicSearchComponent:', () => {
 
       component.filters = filters;
       const result = { action: 'onAction', advancedAction: 'onAdvancedAction', ngModel: 'quickFilter',
-        placeholder: component.literals.filterSettingsPlaceholder };
+        placeholder: component.literals.searchPlaceholder };
 
       expect(component.filterSettings).toEqual(result);
     });
@@ -336,6 +336,14 @@ describe('PoPageDynamicSearchComponent:', () => {
       const result = component['getFilterValueToDisclaimer'](field, value);
 
       expect(result).toBe('test value 1');
+    });
+
+    it('ngOnInit: should call setAdvancedFilterLiterals with component.literals', () => {
+      spyOn(component, <any> 'setAdvancedFilterLiterals');
+
+      component.ngOnInit();
+
+      expect(component['setAdvancedFilterLiterals']).toHaveBeenCalledWith(component.literals);
     });
 
   });

--- a/projects/templates/src/lib/components/po-page-dynamic-search/po-page-dynamic-search.component.ts
+++ b/projects/templates/src/lib/components/po-page-dynamic-search/po-page-dynamic-search.component.ts
@@ -1,6 +1,6 @@
-import { Component, ViewChild } from '@angular/core';
+import { Component, OnInit, ViewChild } from '@angular/core';
 
-import { PoDisclaimerGroup, PoDynamicFieldType, PoDynamicFormField, PoPageFilter } from '@portinari/portinari-ui';
+import { PoDisclaimerGroup, PoDynamicFieldType, PoDynamicFormField, PoLanguageService, PoPageFilter } from '@portinari/portinari-ui';
 
 import { capitalizeFirstLetter, getBrowserLanguage } from '../../utils/util';
 
@@ -27,7 +27,7 @@ import { PoPageDynamicSearchBaseComponent } from './po-page-dynamic-search-base.
   selector: 'po-page-dynamic-search',
   templateUrl: './po-page-dynamic-search.component.html'
 })
-export class PoPageDynamicSearchComponent extends PoPageDynamicSearchBaseComponent {
+export class PoPageDynamicSearchComponent extends PoPageDynamicSearchBaseComponent implements OnInit {
 
   private readonly _disclaimerGroup: PoDisclaimerGroup = {
     change: this.onChangeDisclaimerGroup.bind(this),
@@ -39,7 +39,7 @@ export class PoPageDynamicSearchComponent extends PoPageDynamicSearchBaseCompone
     action: 'onAction',
     advancedAction: 'onAdvancedAction',
     ngModel: 'quickFilter',
-    placeholder: this.literals.filterSettingsPlaceholder
+    placeholder: this.literals.searchPlaceholder
   };
 
   // Flag to control when changeDisclaimerGroup should be called
@@ -49,14 +49,22 @@ export class PoPageDynamicSearchComponent extends PoPageDynamicSearchBaseCompone
 
   @ViewChild(PoAdvancedFilterComponent, { static: true }) poAdvancedFilter: PoAdvancedFilterComponent;
 
+  constructor(languageService: PoLanguageService) {
+    super(languageService);
+  }
+
+  ngOnInit() {
+    this.setAdvancedFilterLiterals(this.literals);
+  }
+
   get disclaimerGroup() {
-    return Object.assign({}, this._disclaimerGroup);
+    return Object.assign({}, this._disclaimerGroup, { title: this.literals.disclaimerGroupTitle });
   }
 
   get filterSettings() {
     this._filterSettings.advancedAction = this.filters.length === 0 ? undefined : 'onAdvancedAction';
 
-    return Object.assign({}, this._filterSettings);
+    return Object.assign({}, this._filterSettings, { placeholder: this.literals.searchPlaceholder });
   }
 
   onAction() {

--- a/projects/templates/src/lib/components/po-page-dynamic-search/po-page-dynamic-search.module.ts
+++ b/projects/templates/src/lib/components/po-page-dynamic-search/po-page-dynamic-search.module.ts
@@ -3,7 +3,7 @@ import { FormsModule } from '@angular/forms';
 import { NgModule } from '@angular/core';
 import { RouterModule } from '@angular/router';
 
-import { PoDynamicModule, PoModalModule, PoPageModule } from '@portinari/portinari-ui';
+import { PoDynamicModule, PoLanguageModule, PoModalModule, PoPageModule } from '@portinari/portinari-ui';
 
 import { PoAdvancedFilterComponent } from './po-advanced-filter/po-advanced-filter.component';
 import { PoPageDynamicSearchComponent } from './po-page-dynamic-search.component';
@@ -20,6 +20,7 @@ import { PoPageDynamicSearchComponent } from './po-page-dynamic-search.component
     RouterModule,
 
     PoDynamicModule,
+    PoLanguageModule,
     PoModalModule,
     PoPageModule
   ],

--- a/projects/templates/src/lib/components/po-page-dynamic-search/samples/sample-po-page-dynamic-search-hiring-processes/sample-po-page-dynamic-search-hiring-processes.component.html
+++ b/projects/templates/src/lib/components/po-page-dynamic-search/samples/sample-po-page-dynamic-search-hiring-processes/sample-po-page-dynamic-search-hiring-processes.component.html
@@ -3,6 +3,7 @@
   [p-actions]="actions"
   [p-breadcrumb]="breadcrumb"
   [p-filters]="filters"
+  [p-literals]="literals"
   (p-change-disclaimers)="onChangeDisclaimers($event)"
   (p-quick-search)="onQuickSearch($event)"
   (p-advanced-search)="onAdvancedSearch($event)">

--- a/projects/templates/src/lib/components/po-page-dynamic-search/samples/sample-po-page-dynamic-search-hiring-processes/sample-po-page-dynamic-search-hiring-processes.component.ts
+++ b/projects/templates/src/lib/components/po-page-dynamic-search/samples/sample-po-page-dynamic-search-hiring-processes/sample-po-page-dynamic-search-hiring-processes.component.ts
@@ -1,6 +1,8 @@
 import { Component, OnInit } from '@angular/core';
 import { Router } from '@angular/router';
 
+import { PoPageDynamicSearchLiterals } from '@portinari/portinari-templates';
+
 import {
   PoBreadcrumb,
   PoPageAction,
@@ -41,6 +43,12 @@ export class SamplePoPageDynamicSearchHiringProcessesComponent implements OnInit
     { property: 'city', gridColumns: 6 },
     { property: 'job', label: 'Job Description', options: this.jobDescriptionOptions, gridColumns: 6 },
   ];
+
+  readonly literals: PoPageDynamicSearchLiterals = {
+    filterConfirmLabel: 'Aplicar',
+    filterTitle: 'Filtro avançado',
+    quickSearchLabel: 'Valor pesquisado:'
+  };
 
   constructor(
     private sampleHiringProcessesService: SamplePoPageDynamicSearchHiringProcessesService,

--- a/projects/ui/src/lib/services/index.ts
+++ b/projects/ui/src/lib/services/index.ts
@@ -2,5 +2,6 @@ export * from './services.module';
 
 export * from './po-component-injector/index';
 export * from './po-dialog/index';
+export * from './po-language/index';
 export * from './po-i18n/index';
 export * from './po-notification/index';


### PR DESCRIPTION
**PAGE DYNAMIC SEARCH**

**DTHFUI-2079**
_____________________________________________________________________________

**PR Checklist**

- [x] Código
- [x] Testes unitários
- [x] Documentação
- [x] Samples

**Qual o comportamento atual?**
Não possuia a propriedade p-literals.

**Qual o novo comportamento?**
Adiciona a propriedade p-literals, possibilitando customizar a tradução
padrão.

Também utiliza a linguagem definida no PoI18n para
fazer as traduções default.


**Simulação**
Utilizar documentação do portal.