### PR TITLE
fix(page-login): ajusta quebra de layout no popover no idioma russo

### DIFF
--- a/projects/templates/src/lib/components/po-page-login/po-page-login-base.component.ts
+++ b/projects/templates/src/lib/components/po-page-login/po-page-login-base.component.ts
@@ -110,7 +110,7 @@ export const poPageLoginLiteralsDefault = {
     forgotYourPassword: 'Забыли пароль?',
     ifYouTryHarder: 'Если вы безуспешно попытаетесь войти еще ',
     attempts: '{0} раз(а) ',
-    yourUserWillBeBlocked: 'Ваш пользователь будет заблокирован, и Вы останетесь на 24 часа без возможности доступа :(',
+    yourUserWillBeBlocked: 'Ваш пользователь будет заблокирован, и Вы останетесь на 24 часа без возможности доступа :(',
     createANewPasswordNow: 'Лучше создайте новый пароль сейчас! Вы сможете сразу войти в систему.',
     iForgotMyPassword: 'Я забыл свой пароль'
   }


### PR DESCRIPTION
**Po Page Login**

**DTHFUI-2204**
_____________________________________________________________________________

**PR Checklist**

- [x] Código
- [ ] Testes unitários
- [ ] Documentação
- [ ] Samples

**Qual o comportamento atual?**
Ao alterar o idioma para russo, é gerado um scroll horizontal no popover de aviso de bloqueio pois não há quebra de linha em uma das frases.

**Qual o novo comportamento?**
Corrigido e agora as quebras de linha funcionam normalmente.

**Simulação**
Simular utilizando o sample labs do Portal, basta preencher um valor na propriedade `Exceeded Attempts Warning` e mudar o idioma para russo.