### PR TITLE
fix(tooltip): corrige o compartilhamento do serviço de posição

### DIFF
--- a/projects/ui/src/lib/directives/po-tooltip/po-tooltip-control-position.service.spec.ts
+++ b/projects/ui/src/lib/directives/po-tooltip/po-tooltip-control-position.service.spec.ts
@@ -1,0 +1,14 @@
+import { PoControlPositionService } from '../../services/po-control-position/po-control-position.service';
+
+import { PoTooltipControlPositionService } from './po-tooltip-control-position.service';
+
+describe('PoTooltipControlPositionService:', () => {
+  const service = new PoTooltipControlPositionService();
+
+  it('should be created', () => {
+
+    expect(service).toBeTruthy();
+    expect(PoTooltipControlPositionService instanceof PoControlPositionService);
+  });
+
+});

--- a/projects/ui/src/lib/directives/po-tooltip/po-tooltip-control-position.service.ts
+++ b/projects/ui/src/lib/directives/po-tooltip/po-tooltip-control-position.service.ts
@@ -1,0 +1,6 @@
+import { Injectable } from '@angular/core';
+
+import { PoControlPositionService } from '../../services/po-control-position/po-control-position.service';
+
+@Injectable()
+export class PoTooltipControlPositionService extends PoControlPositionService { }

--- a/projects/ui/src/lib/directives/po-tooltip/po-tooltip.directive.spec.ts
+++ b/projects/ui/src/lib/directives/po-tooltip/po-tooltip.directive.spec.ts
@@ -157,11 +157,15 @@ describe('PoTooltipDirective', () => {
     expect(document.body.querySelectorAll('.po-arrow-test2').length).toBeTruthy();
   });
 
-  it('should call hideTooltip in mouseleave', () => {
+  it('should call hideTooltip in mouseleave', fakeAsync(() => {
     spyOn(directive, 'hideTooltip');
+
     directive.onMouseLeave();
+
+    tick(100);
+
     expect(directive.hideTooltip).toHaveBeenCalled();
-  });
+  }));
 
   it('should call update Text', () => {
     directive.lastTooltipText = 'abc';

--- a/projects/ui/src/lib/directives/po-tooltip/po-tooltip.directive.ts
+++ b/projects/ui/src/lib/directives/po-tooltip/po-tooltip.directive.ts
@@ -1,7 +1,7 @@
 import { Directive, ElementRef, HostListener, OnInit, Renderer2 } from '@angular/core';
 
-import { PoControlPositionService } from './../../services/po-control-position/po-control-position.service';
 import { PoTooltipBaseDirective } from './po-tooltip-base.directive';
+import { PoTooltipControlPositionService } from './po-tooltip-control-position.service';
 
 /**
  * @docsExtends PoTooltipBaseDirective
@@ -26,7 +26,7 @@ import { PoTooltipBaseDirective } from './po-tooltip-base.directive';
  */
 @Directive({
   selector: '[p-tooltip]',
-  providers: [ PoControlPositionService ]
+  providers: [ PoTooltipControlPositionService ]
 })
 export class PoTooltipDirective extends PoTooltipBaseDirective implements OnInit {
 
@@ -43,7 +43,7 @@ export class PoTooltipDirective extends PoTooltipBaseDirective implements OnInit
 
   constructor(private elementRef: ElementRef,
               private renderer: Renderer2,
-              private poControlPosition: PoControlPositionService) {
+              private poControlPosition: PoTooltipControlPositionService) {
 
     super();
   }

--- a/projects/ui/src/lib/directives/po-tooltip/po-tooltip.directive.ts
+++ b/projects/ui/src/lib/directives/po-tooltip/po-tooltip.directive.ts
@@ -71,7 +71,11 @@ export class PoTooltipDirective extends PoTooltipBaseDirective implements OnInit
   }
 
   @HostListener('mouseleave') onMouseLeave() {
-    this.hideTooltip();
+    // necessita do timeout para conseguir adicionar ".po-invisible", pois quando tem alguns elementos
+    // próximos com tooltips e ficar passando o mouse em cima, os mesmos não estavam ficando invisiveis.
+    setTimeout(() => {
+      this.hideTooltip();
+    });
   }
 
   private addArrow(arrowDirection) {


### PR DESCRIPTION
**Tooltip**

**DTHFUI-2360**
_____________________________________________________________________________

**PR Checklist**

- [ ] Código
- [ ] Testes unitários
- [ ] Documentação
- [ ] Samples

**Qual o comportamento atual?**
Ao utilizar o p-tooltip diretamente em um componente como o po-combo,
acabam compartilhando o mesmo injectable, sobreescrevendo as propriedades definidas em ambos.

https://angular.io/guide/hierarchical-dependency-injection#directive-and-component

**Qual o novo comportamento?**
Foi criado um serviço especifico para o tooltip para não houver problemas de utilizar o mesmo injectable.

**Simulação**
```
  <po-combo
    name="combo"
    class="po-md-6"
    p-tooltip="teste do p-tooltip"
    p-tooltip-position="right"
    p-label="Portinari Combo"
    [p-options]="[{ value: 'Option 1' }, { value: 'Option 2' }, { value: 'Option 3' }, { value: 'Option 4' }]">
  </po-combo>
```

2º commit:

Utilizar o po-rich-text sem o mesmo estar com PROD.

Passar o mouse diversas vezes sobre as ações do componente e verificar se mantem algum aberto.