### PR TITLE
docs(http-interceptor): melhora a documentação do funcionamento

### DIFF
--- a/docs/guides/api.md
+++ b/docs/guides/api.md
@@ -1,0 +1,189 @@
+[comment]: # (@label Guia de implementação de APIs)
+[comment]: # (@link guides/api)
+
+## Conteúdo
+
+- [Introdução](guides/api#introduction)
+- [Formato das mensagens de resposta](guides/api#responseMessage)
+  - [Mensagens de erro](guides/api#errorMessages)
+  - [Mensagens de sucesso](guides/api#successMessages)
+  - [Mensagens de sucesso para coleções](guides/api#successMessagesForCollections)
+- [Formato das requisições para coleções](guides/api#collections)
+  - [Ordenação](guides/api#order)
+  - [Filtros](guides/api#filters)
+  - [Paginação](guides/api#pagination)
+
+
+<a id="introduction"></a>
+## Introdução
+
+Este guia tem a finalidade de exibir os modelos de requisições e respostas HTTP que o Portinari UI utiliza em seus componentes e *interceptors*.
+
+
+<a id="responseMessage"></a>
+## Formato das mensagens de resposta
+Alguns componentes utilizam `endpoints` para poder buscar os itens. Para isso, é necessário que o formato no qual estes itens serão devolvidos seja padronizado, para uma comunicação mais efetiva. A seguir serão apresentados o formato de mensagem de resposta esperado pelos `endpoints`.
+
+<a id="errorMessages"></a>
+### Mensagens de erro
+
+Para todas as mensagens que representam um erro (códigos HTTP 4xx e 5xx) deve-se retornar obrigatoriamente os campos a seguir, caso deseje apresentá-las:
+
+```
+{
+    code: "Código identificador do erro",
+    message: "Literal no idioma da requisição descrevendo o erro para o cliente",
+    detailedMessage: "Mensagem técnica e mais detalhada do erro"
+}
+```
+
+Opcionalmente pode-se retornar os campos:
+
+- `helpUrl`: link para a documentação do erro;
+- `type`: pode ser informado os seguintes valores: `success`, `information`, `warning` e `error`;
+- `details`: lista de objetos de erro (recursiva) com mais detalhes sobre o erro principal.
+
+```
+{
+    code: "Código identificador do erro",
+    type: "error"
+    message: "Literal no idioma da requisição descrevendo o erro para o cliente",
+    detailedMessage: "Mensagem técnica e mais detalhada do erro",
+    helpUrl: "link para a documentação do error",
+    details [
+        {
+            code: "Código identificador do erro",
+            message: "Literal no idioma da requisição descrevendo o erro para o cliente",
+            detailedMessage: "Mensagem técnica e mais detalhada do erro"
+        },
+        {
+            code: "Código identificador do erro",
+            message: "Literal no idioma da requisição descrevendo o erro para o cliente",
+            detailedMessage: "Mensagem técnica e mais detalhada do erro"
+        },
+        {
+            code: "Código identificador do erro",
+            message: "Literal no idioma da requisição descrevendo o erro para o cliente",
+            detailedMessage: "Mensagem técnica e mais detalhada do erro"
+        }
+    ]
+}
+```
+
+<a id="successMessages"></a>
+### Mensagens de sucesso
+
+Mensagens de sucesso (código HTTP 2xx) devem retornar diretamente a entidade que representa o objeto resultante da operação do *endpoint*. Exemplo:
+
+```
+GET http://portinari-example.com.br/api/users/10
+
+{
+    id: 10,
+    name: "John",
+    surname: "Doe",
+    age: 25,
+    country: "US"
+}
+```
+
+Opcionalmente, o atributo `_messages` pode ser incluído no objeto retornado para fornecer alguma informação complementar ao processamento realizado (mensagens de aviso, de negócio, etc). 
+
+O formato do objeto de mensagem segue o padrão anteriormente descrito, para mensagens de erro.
+
+```
+GET http://portinari-example.com.br/api/users/10
+ 
+{
+    id: 10,
+    name: "John",
+    surname: "Doe",
+    age: 25,
+    country: "US",
+    _messages: [{
+      code: "INFO",
+      type: "information"
+      message: "Esta é uma mensagem informativa",
+      detailedMessage: "Mais detalhes sobre esta mensagem podem ser vistos aqui."
+    }]
+}
+```
+
+<a id="successMessagesForCollections"></a>
+#### Mensagens de sucesso para coleções
+
+Nos casos em que o resultado da operação do *endpoint* representa uma coleção (lista de itens), os itens devem estar agrupados em um objeto com as propriedades `hasNext`, indicando se existe uma próxima página com mais registros para aquela coleção e `items` que representam a lista de itens retornados.
+
+```
+{
+  hasNext: true,
+  items: [
+    {},
+    {},
+    ...
+  ]
+}
+```
+Para o retorno de coleções, também é possível incluir o atributo `_messages`, conforme segue:
+
+```
+{
+  hasNext: true,
+  items: [
+    {},
+    {},
+    ...
+  ],
+  _messages: [{
+    code: "INFO",
+    type: "information",
+    message: "Uma mensagem informativa.",
+    detailedMessage: "Detalhes relativos a mensagem."
+  }]
+}
+```
+
+<a id="collections"></a>
+## Formato das requisições para as coleções
+
+Os *endpoints* também podem receber parâmetros na requisição que servem para especificar o tipo de resposta desejada, por exemplo: ordenação. A seguir, serão apresentados os parâmetros que poderão ser enviados nessas requisições.
+
+<a id="order"></a>
+### Ordenação
+
+Quando algum componente, como `po-lookup`, realizar alguma ordenação será enviado o parâmetro  `order`, com as seguintes características:
+
+- campos precedidos por um sinal de subtração (-) devem ser ordenados de forma decrescente;
+- campos que omitirem o sinal (subtração) devem ser ordenados de forma crescente.
+
+Por exemplo, a seguinte requisição deve retornar a lista de usuários ordenados pelo nome de forma crescente e então pela idade de forma decrescente e pelo sobrenome de forma crescente:
+
+```
+GET http://portinari-example.com.br/api/users?order=name,-age,surname
+```
+
+<a id="filters"></a>
+### Filtros
+
+Aos realizar um filtro será enviado um parâmetro no formato `property=value`:
+
+``` GET http://portinari-example.com.br/api/users?name=john&surname=doe ```
+
+Caso não houver campos a serem filtrados, será enviado o parâmetro `filter`:
+
+``` GET http://portinari-example.com.br/api/users?filter=john```
+
+
+<a id="pagination"></a>
+### Paginação
+
+A paginação é definida pelos parâmetros `page` e `pageSize`, respeitando as seguintes regras: 
+
+- o valor do parâmetro `page` deve ser um valor numérico (maior que zero) representando a página solicitada;
+- o valor do parâmetro `pageSize` deve ser um valor numérico (maior que zero) representando o total de registros retornados na consulta;
+- os parâmetros de paginação devem obedecer a semântica de multiplicador, ou seja, se o cliente solicitou `page=2` com um `pageSize=20` deve-se retornar os registros de 21 até 40;
+- a resposta de uma requisição com paginação deve retornar um atributo indicando se existe uma próxima página disponível conforme descrito na [mensagem de sucesso de coleções](#successMessagesForCollections) e esse atributo deve ter o nome `hasNext`.
+
+Por exemplo, a seguinte requisição deve retornar a quarta página de registros (dos registros 31 a 40 inclusive) de usuários:
+
+``` GET http://portinari-example.com.br/api/users/?page=4&pageSize=10 ```

--- a/projects/ui/src/lib/interceptors/po-http-interceptor/po-http-interceptor-base.service.ts
+++ b/projects/ui/src/lib/interceptors/po-http-interceptor/po-http-interceptor-base.service.ts
@@ -15,12 +15,15 @@ const NO_MESSAGE_HEADER_PARAM = 'X-Portinari-No-Message';
 /**
  * @description
  *
- * O serviço Portinari Http Interceptor realiza o tratamento de requisições HTTP conforme o padrão do
- * [**Guia de implementação das APIs TOTVS**](http://tdn.totvs.com/pages/viewpage.action?pageId=484701395) para adaptá-lo
- * ao modelo do PO.
+ * O *interceptor* tem a finalidade de exibir notificações com mensagens na tela, baseado nas respostas das requisições HTTP.
  *
- * > Para o correto funcionamento do interceptor `po-http-interceptor`, deve ser importado o módulo `BrowserAnimationsModule` no
- * > módulo principal da sua aplicação.
+ * Pode ser utilizado para dar feedback das ações do usuário como, por exemplo: erro de autorização, mensagens de regras de negócio,
+ * atualizações de registros, erro quando o servidor estiver indisponível e entre outros.
+ *
+ * ## Configuração
+ *
+ * Para o correto funcionamento do interceptor `po-http-interceptor`, deve ser importado o `BrowserAnimationsModule` no
+ * módulo principal da sua aplicação.
  *
  * Módulo da aplicação:
  * ```
@@ -45,45 +48,6 @@ const NO_MESSAGE_HEADER_PARAM = 'X-Portinari-No-Message';
  * export class AppModule { }
  * ```
  *
- * ### Funcionamento do interceptor
- *
- * Ao analisar o objeto `_messages` retornado pela requisição, o serviço exibirá notificações com mensagens na tela.
- * Os retornos de erros com códigos 4xx e 5xx são tratados automaticamente, sem a necessidade de incluir o `_messages`.
- *
- * É possível dispensar a notificação para o usuário utilizando-se no cabeçalho da requisição os parâmetros listados abaixo com o valor
- * igual a `true`:
- *
- * - `X-Portinari-No-Message`: Não exibe notificações de erro e/ou sucesso.
- *
- * - **Depreciado** `X-Portinari-No-Error`: não mostra notificações de erro com códigos `4xx` e `5xx`.
- *
- * ```
- * ...
- *  const headers = { 'X-Portinari-No-Message': 'true' };
- *
- *  this.http.get(`/customers/1`, { headers: headers });
- * ...
- *
- * ```
- *
- * Mais detalhes no tópico sobre cabeçalhos customizados no
- * [**Guia de implementação das APIs TOTVS**](http://tdn.totvs.com/pages/viewpage.action?pageId=484701395)
- *
- * > Após a validação no interceptor, os parâmetros serão removidos do cabeçalho da requisição.
- *
- * O `Content-Type` deve ser `application/json` e a estrutura de mensagem recebida pelo serviço deve seguir o
- * [**Guia de implementação das APIs TOTVS**](http://tdn.totvs.com/pages/viewpage.action?pageId=484701395)
- * (em Mensagens de sucesso para coleções), exemplo:
- *  - _messages: lista de mensagens ou objeto de mensagem, resultante do serviço.
- *    - type: success, warning, error, e information (será exibido a `tag` apenas se esta propriedade possuir valor);
- *    - code: título ou código da mensagem;
- *    - message: texto da mensagem;
- *    - detailedMessage: detalhamento do erro ou informativo;
- *
- * Ao clicar na ação 'Detalhes' no
- * [`po-notification`](/documentation/po-notification) os detalhes das mensagens de sucesso e de erro são apresentados em
- * um [`po-modal`](/documentation/po-modal) com um [`po-accordion`](/documentation/po-accordion) que possui um item por mensagem.
- *
  * Ao importar o módulo `PoModule` na aplicação, o `po-http-interceptor` é automaticamente configurado sem a necessidade
  * de qualquer configuração extra.
  *
@@ -107,6 +71,70 @@ const NO_MESSAGE_HEADER_PARAM = 'X-Portinari-No-Message';
  *
  * }
  * ```
+ *
+ * ## Como usar
+ *
+ * Para exibir as noticações é necessário informar a mensagem no retorno da requisição. A estrutura da mensagem
+ * é feita com base no status da resposta, conforme será apresentado nos próximos tópicos.
+ *
+ * ### Estrutura das mensagens
+ *
+ * #### Mensagens de sucesso `2xx`
+ *
+ * Para exibir mensagens ao retornar uma lista ou um item, deve-se incluir a propriedade `_messages` no objeto de retorno.
+ * Por exemplo:
+ * ```
+ * {
+ *   "_messages": [
+ *     {
+ *       "type": "success" || "warning" || "error" || "information" (será exibido a `tag` apenas se esta propriedade possuir valor),
+ *       "code": "título ou código da mensagem",
+ *       "message": "texto da mensagem",
+ *       "detailedMessage": "detalhamento da mensagem"
+ *     }
+ *   ]
+ * }
+ * ```
+ *
+ * #### Mensagens de erro `4xx` ou `5xx`
+ *
+ * Ao retornar erro, o objeto não necessita ter `_messages`, deve-se retornar o objeto diretamente:
+ *
+ * ```
+ * {
+ *    "code": "título ou código da mensagem",
+ *    "message": "texto da mensagem",
+ *    "detailedMessage": "detalhamento da mensagem"
+ * }
+ * ```
+ *
+ * Também é possível informar as seguintes propriedades:
+ *
+ * - `helpUrl`: link para a documentação do erro;
+ *    - Caso for informado, será exibido uma ação de "Ajuda" na notificação, para isso não deverá ter a propriedade `detailedMessage`.
+ * - `details`: Uma lista de objetos de mensagem (recursiva) com mais detalhes sobre a mensagem principal.
+ *
+ * > Veja o [Guia de implementação de APIs](guides/api) para mais detalhes sobre a estrutura das mensagens.
+ *
+ * ### Cabeçalho
+ *
+ * É possível dispensar a notificação para o usuário utilizando no cabeçalho da requisição os parâmetros listados abaixo com o valor
+ * igual a `true`:
+ *
+ * - `X-Portinari-No-Message`: Não exibe notificações de erro e/ou sucesso.
+ *
+ * - **Depreciado** `X-Portinari-No-Error`: não mostra notificações de erro com códigos `4xx` e `5xx`.
+ *
+ * ```
+ * ...
+ *  const headers = { 'X-Portinari-No-Message': 'true' };
+ *
+ *  this.http.get(`/customers/1`, { headers: headers });
+ * ...
+ *
+ * ```
+ *
+ * > Após a validação no *interceptor*, os parâmetros serão removidos do cabeçalho da requisição.
  *
  */
 export abstract class PoHttpInterceptorBaseService implements HttpInterceptor {


### PR DESCRIPTION
**HTTP INTERCEPTOR**

**DTHFUI-2862**
_____________________________________________________________________________

**PR Checklist**

- [ ] Código
- [ ] Testes unitários
- [ ] Documentação
- [ ] Samples

**Qual o comportamento atual?**
N/A

**Qual o novo comportamento?**
Adiciona o documento, Guia de implementação de APIs para ser utilizado como referencia.

E melhorado a documentação do http-interceptor, adicionando exemplos dos dados informados e mencionado propriedades omitidas anteriormente.


**Simulação**
Avaliar documentação do portal.


PR PORTAL:
https://totvstfs.visualstudio.com/THF/_git/thf-portal-portinari-temp/pullrequest/21037?_a=overview