### PR TITLE
fix(pages):  corrige comportamento dos botões de ação que não estão abrindo urls externas

### DIFF
--- a/projects/ui/src/lib/components/po-page/po-page-default/po-page-default.component.spec.ts
+++ b/projects/ui/src/lib/components/po-page/po-page-default/po-page-default.component.spec.ts
@@ -4,6 +4,9 @@ import { RouterTestingModule } from '@angular/router/testing';
 import { Router } from '@angular/router';
 
 import { changeBrowserInnerWidth, configureTestSuite } from '../../../util-test/util-expect.spec';
+
+import * as UtilsFunction from '../../../utils/util';
+
 import { PoBreadcrumbModule } from '../../po-breadcrumb/po-breadcrumb.module';
 import { PoButtonModule } from '../../po-button';
 import { PoDropdownModule } from '../../po-dropdown/po-dropdown.module';
@@ -299,6 +302,16 @@ describe('PoPageDefaultComponent desktop', () => {
   });
 
   describe('Methods', () => {
+
+    it('callAction: should open an external URL in a new tab in the browser by calling Utils`s openExternalLink method', () => {
+      const url = 'http://portinari.io';
+
+      spyOn(UtilsFunction, 'openExternalLink');
+
+      component.callAction({ label: 'Portinari', url });
+
+      expect(UtilsFunction.openExternalLink).toHaveBeenCalledWith(url);
+    });
 
     it('actionIsDisabled: should return boolean value', () => {
       const action = { disabled: true };

--- a/projects/ui/src/lib/components/po-page/po-page-default/po-page-default.component.ts
+++ b/projects/ui/src/lib/components/po-page/po-page-default/po-page-default.component.ts
@@ -1,7 +1,7 @@
 import { AfterContentInit, Component, OnChanges, Renderer2, SimpleChange, ViewContainerRef } from '@angular/core';
 import { Router } from '@angular/router';
 
-import { callFunction, isTypeof } from '../../../utils/util';
+import { callFunction, isExternalLink, isTypeof, openExternalLink } from '../../../utils/util';
 import { PoPageAction } from '../po-page-action.interface';
 
 import { PoPageDefaultBaseComponent } from './po-page-default-base.component';
@@ -68,8 +68,7 @@ export class PoPageDefaultComponent extends PoPageDefaultBaseComponent implement
 
   callAction(item: PoPageAction): void {
     if (item.url) {
-
-      this.router.navigate([item.url]);
+      isExternalLink(item.url) ? openExternalLink(item.url) : this.router.navigate([item.url]);
     } else if (item.action) {
       callFunction(item.action, this.parentRef);
     }

--- a/projects/ui/src/lib/components/po-page/po-page-default/samples/sample-po-page-default-dashboard/sample-po-page-default-dashboard.component.ts
+++ b/projects/ui/src/lib/components/po-page/po-page-default/samples/sample-po-page-default-dashboard/sample-po-page-default-dashboard.component.ts
@@ -31,7 +31,9 @@ export class SamplePoPageDefaultDashboardComponent {
 
   public readonly actions: Array<PoPageAction> = [
     { label: 'Share', action: this.modalOpen, icon: 'po-icon-share' },
-    { label: 'Disable notification', action: this.disableNotification, disabled: () => this.isSubscribed },
+    { label: 'GitHub', url: 'https://github.com/portinariui/portinari-angular' },
+    { label: 'Components', url: '/documentation' },
+    { label: 'Disable notification', action: this.disableNotification, disabled: () => this.isSubscribed }
   ];
 
   public readonly breadcrumb: PoBreadcrumb = {

--- a/projects/ui/src/lib/components/po-page/po-page-list/po-page-list.component.spec.ts
+++ b/projects/ui/src/lib/components/po-page/po-page-list/po-page-list.component.spec.ts
@@ -6,6 +6,8 @@ import { RouterTestingModule } from '@angular/router/testing';
 
 import { changeBrowserInnerWidth, configureTestSuite } from '../../../util-test/util-expect.spec';
 
+import * as UtilsFunction from '../../../utils/util';
+
 import { PoBreadcrumbModule } from '../../po-breadcrumb/po-breadcrumb.module';
 import { PoButtonModule } from '../../po-button/po-button.module';
 import { PoDisclaimerGroupModule } from './../../po-disclaimer-group/po-disclaimer-group.module';
@@ -481,6 +483,16 @@ describe('PoPageListComponent - Desktop:', () => {
   });
 
   describe('Methods:', () => {
+
+    it('callAction: should open an external URL in a new tab in the browser by calling Utils`s openExternalLink method', () => {
+      const url = 'http://portinari.io';
+
+      spyOn(UtilsFunction, 'openExternalLink');
+
+      component.callAction({ label: 'Portinari', url });
+
+      expect(UtilsFunction.openExternalLink).toHaveBeenCalledWith(url);
+    });
 
     it('actionIsDisabled: should return boolean value', () => {
       const action = { disabled: true };

--- a/projects/ui/src/lib/components/po-page/po-page-list/po-page-list.component.ts
+++ b/projects/ui/src/lib/components/po-page/po-page-list/po-page-list.component.ts
@@ -3,7 +3,7 @@ import {
 } from '@angular/core';
 import { Router } from '@angular/router';
 
-import { callFunction, isTypeof } from '../../../utils/util';
+import { callFunction, isExternalLink, isTypeof, openExternalLink } from '../../../utils/util';
 import { PoLanguageService } from './../../../services/po-language/po-language.service';
 
 import { PoPageAction } from '../po-page-action.interface';
@@ -85,7 +85,7 @@ export class PoPageListComponent extends PoPageListBaseComponent implements Afte
 
   callAction(item: PoPageAction): void {
     if (item.url) {
-      this.router.navigate([item.url]);
+      isExternalLink(item.url) ? openExternalLink(item.url) : this.router.navigate([item.url]);
     } else if (item.action) {
       callFunction(item.action, this.parentRef);
     }

--- a/projects/ui/src/lib/components/po-page/po-page-list/samples/sample-po-page-list-hiring-processes/sample-po-page-list-hiring-processes.component.ts
+++ b/projects/ui/src/lib/components/po-page/po-page-list/samples/sample-po-page-list-hiring-processes/sample-po-page-list-hiring-processes.component.ts
@@ -30,7 +30,8 @@ export class SamplePoPageListHiringProcessesComponent implements OnInit {
   statusOptions: Array<PoCheckboxGroupOption>;
 
   public readonly actions: Array<PoPageAction> = [
-    { label: 'Hire', action: this.hireCandidate, disabled: this.disableHireButton.bind(this) }
+    { label: 'Hire', action: this.hireCandidate, disabled: this.disableHireButton.bind(this) },
+    { label: 'Legislation', url: 'https://www.usa.gov/labor-laws' }
   ];
 
   public readonly breadcrumb: PoBreadcrumb = {


### PR DESCRIPTION
**PO-PAGE-DEFAULT E PO-PAGE-LIST**

**DTHFUI-2848**
_____________________________________________________________________________

**PR Checklist**

- [x] Código
- [x] Testes unitários
- [ ] Documentação
- [x] Samples

**Qual o comportamento atual?**
Hoje não é possível abrir uma url externa através dos botões de ação do componente po-page-default e do po-page-list.

**Qual o novo comportamento?**
Foi implementada uma validação que permite a abertura de url's externas tanto no componente po-page default quanto no po-page-list.

**Simulação**
Verificar nos samples de caso de uso do Portal:
- Po-page-default - Portinari Page Default - Dashboard
- Po-page-list - Portinari Page List - Hiring Processes