### PR TITLE
fix(table): corrige erro no console do IE/EDGE

### DIFF
--- a/projects/ui/src/lib/components/po-table/po-table.component.spec.ts
+++ b/projects/ui/src/lib/components/po-table/po-table.component.spec.ts
@@ -2100,6 +2100,18 @@ describe('PoTableComponent:', () => {
       expect(component.columnCountForMasterDetail).toBe(countColumns);
     });
 
+    it('columnCount: should return `1` if haven`t headers', () => {
+      const expectedValue = 1;
+
+      component.items = [];
+      component.columns = [];
+      component.selectable = false;
+      component.hideDetail = false;
+      component.actions = [];
+
+      expect(component.columnCount).toBe(expectedValue);
+    });
+
     it('columnCount: should count the number columns of table', () => {
       component.columns = columnsWithDetail;
       component.selectable = true;

--- a/projects/ui/src/lib/components/po-table/po-table.component.ts
+++ b/projects/ui/src/lib/components/po-table/po-table.component.ts
@@ -123,11 +123,13 @@ export class PoTableComponent extends PoTableBaseComponent implements AfterViewI
   }
 
   get columnCount() {
-    return (this.mainColumns.length +
+    const columnCount = (this.mainColumns.length +
       (this.actions.length > 0 ? 1 : 0) +
       (this.selectable ? 1 : 0) +
       (!this.hideDetail && this.columnMasterDetail !== undefined ? 1 : 0)
     );
+
+    return columnCount || 1;
   }
 
   get columnCountForMasterDetail() {


### PR DESCRIPTION
**Table**

**DTHFUI-2802**
_____________________________________________________________________________

**PR Checklist**

- [ ] Código
- [ ] Testes unitários
- [ ] Documentação
- [ ] Samples

**Qual o comportamento atual?**
Ao utilizar uma tabela sem definição de colunas e items
estava ocasionando erro no console no IE/EDGE,
decorrente do colSpan 0 que era informado, quando não possuia headers.

Componentes afetados eram:
PoLookup,
PoTable,
PoPageDynamicTable

**Qual o novo comportamento?**
Corrige o erro no console log disparado no IE/EDGE decorrente de um calculo incorreto
sobre o colSpan na tabela.

**Simulação**
Rodar o Portal, usar os componentes PoLookup, PoTable e PoPageDynamicTable e avaliar se o erro é disparado. (IE/EDGE)

Também é possivel usar localmente porém sem dados, exemplo:
```
<po-table></po-table>
```