### PR TITLE
fix(page-list): corrige busca avançada em russo

### DIFF
--- a/projects/ui/src/lib/components/po-page/po-page-list/po-page-list.component.spec.ts
+++ b/projects/ui/src/lib/components/po-page/po-page-list/po-page-list.component.spec.ts
@@ -550,6 +550,12 @@ describe('PoPageListComponent - Desktop:', () => {
         expect(component['initializeFixedLiterals']()).toBe('Búsqueda avanzada');
       });
 
+      it('should return the advanced filter label by `ru` language.', () => {
+        component['language'] = 'ru';
+
+        expect(component['initializeFixedLiterals']()).toBe('полный поиск');
+      });
+
     });
 
   });

--- a/projects/ui/src/lib/components/po-page/po-page-list/po-page-list.component.ts
+++ b/projects/ui/src/lib/components/po-page/po-page-list/po-page-list.component.ts
@@ -158,6 +158,9 @@ export class PoPageListComponent extends PoPageListBaseComponent implements Afte
       },
       es: {
         advancedSearch: 'Búsqueda avanzada'
+      },
+      ru: {
+        advancedSearch: 'полный поиск'
       }
     };
 


### PR DESCRIPTION
**Po Page List**

**DTHFUI-2842**
_____________________________________________________________________________

**PR Checklist**

- [x] Código
- [x] Testes unitários
- [ ] Documentação
- [ ] Samples

**Qual o comportamento atual?**
Ao selecionar o idioma russo, a palavra "busca avançada" acabava não aparecendo.


**Qual o novo comportamento?**
Agora o usuário pode utilizar o idioma russo.

**Simulação**
Pode ser simulado no sample, basta alterar o idioma do navegador.