### PR TITLE
feat(assets): cria link press kit no portal

### DIFF
--- a/docs/guides/press-kit.md
+++ b/docs/guides/press-kit.md
@@ -1,0 +1,116 @@
+[comment]: # (@label Press Kit)
+[comment]: # (@link guides/press-kit)
+
+## Logomarca
+
+A licença para uso das variações de logomarca do **Portinari** é seguida de acordo com a [CC BY 4.0](https://creativecommons.org/licenses/by/4.0/). Ou seja, pode-se utilizá-las como convier e para qualquer uso, como por exemplo na impressão em camisetas, divulgação em websites, etc.
+
+<div class="docs-presskit-row po-mt-5 po-mb-5">
+  <div>
+    <img src="./assets/po-logos/po_color_bg_txt.svg" width="128" height="128" alt="Logo Portinari com texto e segundo plano degradê">
+  </div>
+  <div class="po-ml-md-2">
+    <h3>Versão com texto e segundo plano degradê</h3>
+    <p>Logo Portinari com segundo plano degradê (png) - <a href="./assets/po-logos/po_color_bg_txt.png" download>Download</a></p>
+    <p>Logo Portinari com segundo plano degradê (svg) - <a href="./assets/po-logos/po_color_bg_txt.svg" download>Download</a></p>
+  </div>
+</div>
+
+<div class="docs-presskit-row po-mb-5">
+  <div>
+    <img src="./assets/po-logos/po_color_bg.svg" width="128" height="128" alt="Logo Portinari sem texto e segundo plano degradê">
+  </div>
+  <div class="po-ml-md-2">
+    <h3>Versão sem texto e segundo plano degradê</h3>
+    <p>Logo Portinari com segundo plano degradê (png) - <a href="./assets/po-logos/po_color_bg.png" download>Download</a></p>
+    <p>Logo Portinari com segundo plano degradê (svg) - <a href="./assets/po-logos/po_color_bg.svg" download>Download</a></p>
+  </div>
+</div>
+
+<div class="docs-presskit-row po-mb-5">
+  <div>
+    <img src="./assets/po-logos/po_color_txt.svg" width="128" height="128" alt="Logo Portinari degradê com texto">
+  </div>
+  <div class="po-ml-md-2">
+    <h3>Versão degradê com texto</h3>
+    <p>Logo Portinari degradê (png) - <a href="./assets/po-logos/po_color_txt.png" download>Download</a></p>
+    <p>Logo Portinari degradê (svg) - <a href="./assets/po-logos/po_color_txt.svg" download>Download</a></p>
+  </div>
+</div>
+
+<div class="docs-presskit-row po-mb-5">
+  <div>
+    <img src="./assets/po-logos/po_color.svg" width="128" height="128" alt="Logo Portinari degradê sem texto">
+  </div>
+  <div class="po-ml-md-2">
+    <h3>Versão degradê sem texto</h3>
+    <p>Logo Portinari degradê (png) - <a href="./assets/po-logos/po_color.png" download>Download</a></p>
+    <p>Logo Portinari degradê (svg) - <a href="./assets/po-logos/po_color.svg" download>Download</a></p>
+  </div>
+</div>
+
+<div class="docs-presskit-row po-mb-5">
+  <div>
+    <img src="./assets/po-logos/po_black_txt.svg" width="128" height="128" alt="Logo Portinari preto com texto">
+  </div>
+  <div class="po-ml-md-2">
+    <h3>Versão preto com texto</h3>
+    <p>Logo Portinari preto (png) - <a href="./assets/po-logos/po_black_txt.png" download>Download</a></p>
+    <p>Logo Portinari preto (svg) - <a href="./assets/po-logos/po_black_txt.svg" download>Download</a></p>
+  </div>
+</div>
+
+<div class="docs-presskit-row po-mb-5">
+  <div>
+    <img src="./assets/po-logos/po_black.svg" width="128" height="128" alt="Logo Portinari preto sem texto">
+  </div>
+  <div class="po-ml-md-2">
+    <h3>Versão preto sem texto</h3>
+    <p>Logo Portinari preto (png) - <a href="./assets/po-logos/po_black.png" download>Download</a></p>
+    <p>Logo Portinari preto (svg) - <a href="./assets/po-logos/po_black.svg" download>Download</a></p>
+  </div>
+</div>
+
+<div class="docs-presskit-row po-mb-5">
+  <div>
+    <img src="./assets/po-logos/po_inverse_txt.svg" width="128" height="128" alt="Logo Portinari com texto e segundo plano preto">
+  </div>
+  <div class="po-ml-md-2">
+    <h3>Versão branco com segundo plano preto</h3>
+    <p>Logo Portinari branco (png) - <a href="./assets/po-logos/po_inverse_txt.png" download>Download</a></p>
+    <p>Logo Portinari branco (svg) - <a href="./assets/po-logos/po_inverse_txt.svg" download>Download</a></p>
+  </div>
+</div>
+
+<div class="docs-presskit-row po-mb-5">
+  <div>
+    <img src="./assets/po-logos/po_inverse.svg" width="128" height="128" alt="Logo Portinari branco sem texto e segundo plano preto">
+  </div>
+  <div class="po-ml-md-2">
+    <h3>Versão branco com segundo plano preto e sem texto</h3>
+    <p>Logo Portinari branco (png) - <a href="./assets/po-logos/po_inverse.png" download>Download</a></p>
+    <p>Logo Portinari branco (svg) - <a href="./assets/po-logos/po_inverse.svg" download>Download</a></p>
+  </div>
+</div>
+
+<div class="docs-presskit-row po-mb-5">
+  <div>
+    <img src="./assets/po-logos/po_white_mock_bg_txt.png" width="128" height="128" alt="Logo Portinari branco com texto e segundo plano transparente">
+  </div>
+  <div class="po-ml-md-2">
+    <h3>Versão branco com segundo plano transparente</h3>
+    <p>Logo Portinari branco (png) - <a href="./assets/po-logos/po_white_txt.png" download>Download</a></p>
+    <p>Logo Portinari branco (svg) - <a href="./assets/po-logos/po_white_txt.svg" download>Download</a></p>
+  </div>
+</div>
+
+<div class="docs-presskit-row po-mb-5">
+  <div>
+    <img src="./assets/po-logos/po_white_mock_bg.png" width="128" height="128" alt="Logo Portinari branco sem texto e segundo plano transparente">
+  </div>
+  <div class="po-ml-md-2">
+    <h3>Versão branco com segundo plano transparente e sem texto</h3>
+    <p>Logo Portinari branco (png) - <a href="./assets/po-logos/po_white.png" download>Download</a></p>
+    <p>Logo Portinari branco (svg) - <a href="./assets/po-logos/po_white.svg" download>Download</a></p>
+  </div>
+</div>


### PR DESCRIPTION

** Portinari UI **

**DTHFUI-3033**
_____________________________________________________________________________

**PR Checklist**

- [ ] Código
- [ ] Testes unitários
- [ ] Documentação
- [ ] Samples

**Qual o comportamento atual?**


**Qual o novo comportamento?**
Criado `press-kit.md` contendo links para download da logomarca Portinari no Portal

**Simulação**
Visualizar no Portal em conjunto com a PR contida no repositótio `thf-portal-portinari-temp`