### PR TITLE
feat(page-dynamic-edit): implementa a propriedade p-load

### DIFF
--- a/projects/templates/src/lib/components/po-page-dynamic-edit/index.ts
+++ b/projects/templates/src/lib/components/po-page-dynamic-edit/index.ts
@@ -1,5 +1,7 @@
 export * from './po-page-dynamic-edit.component';
 export * from './interfaces/po-page-dynamic-edit-actions.interface';
 export * from './interfaces/po-page-dynamic-edit-field.interface';
+export * from './interfaces/po-page-dynamic-edit-metadata.interface';
+export * from './interfaces/po-page-dynamic-edit-options.interface';
 
 export * from './po-page-dynamic-edit.module';

--- a/projects/templates/src/lib/components/po-page-dynamic-edit/interfaces/po-page-dynamic-edit-metadata.interface.ts
+++ b/projects/templates/src/lib/components/po-page-dynamic-edit/interfaces/po-page-dynamic-edit-metadata.interface.ts
@@ -9,7 +9,6 @@ import { PoPageDynamicEditOptions } from './po-page-dynamic-edit-options.interfa
  *
  * <a id="po-page-dynamic-edit-metadata"></a>
  *
- * Interface para o metadata de uma página dinâmica.
  */
 export interface PoPageDynamicEditMetadata extends PoPageDynamicEditOptions {
 

--- a/projects/templates/src/lib/components/po-page-dynamic-edit/interfaces/po-page-dynamic-edit-options.interface.ts
+++ b/projects/templates/src/lib/components/po-page-dynamic-edit/interfaces/po-page-dynamic-edit-options.interface.ts
@@ -3,6 +3,13 @@ import { PoBreadcrumb } from '@portinari/portinari-ui';
 import { PoPageDynamicEditField } from './po-page-dynamic-edit-field.interface';
 import { PoPageDynamicEditActions } from './po-page-dynamic-edit-actions.interface';
 
+/**
+ * @usedBy PoPageDynamicEditComponent
+ *
+ * @description
+ *
+ * Interface para as propriedades de uma página dinâmica.
+ */
 export interface PoPageDynamicEditOptions {
 
   /**

--- a/projects/templates/src/lib/components/po-page-dynamic-table/po-page-dynamic-table.component.ts
+++ b/projects/templates/src/lib/components/po-page-dynamic-table/po-page-dynamic-table.component.ts
@@ -323,7 +323,7 @@ export class PoPageDynamicTableComponent extends PoPageDynamicListBaseComponent 
   private loadData(params: { page?: number, search?: string } = {}) {
     if (!this.serviceApi) {
       this.poNotification.error(this.literals.loadDataErrorNotification);
-      return throwError(this.literals.loadDataErrorNotification);
+      return EMPTY;
     }
 
     const orderParam = this.getOrderParam(this.sortedColumn);


### PR DESCRIPTION
**Page Dynamic Edit**

**DTHFUI-2615**
_____________________________________________________________________________

**PR Checklist**

- [x] Código
- [x] Testes unitários
- [x] Documentação
- [ ] Samples

**Qual o comportamento atual?**

Como desenvolvedor eu gostaria de poder executar uma função quando o page  é inicializado para permitir que eu configure o page de acordo com o perfil do usuário.

**Qual o novo comportamento?**

Criada propriedade p-load: atributo que será executado quando o page for carregado:

- Function: executa a função que o desenvolvedor definiu;
- string: url que deve ser chamada via POST;

- RETORNO: o retorno para os 2 tipos é o mesmo, um objeto que contenha as ações (actions), configuração dos fields (fields), título (title) e breadcrumbs (breadcrumb);

**Simulação**

O desenvolvedor utilizará da seguinte forma

```
// load para configurar o page com API
<po-page-dynamic-edit
  p-title="Persons" 
  p-load="/api/v1/page-load/person">
</po-page-dynamic-edit>

// load para configurar o page com uma função
<po-page-dynamic-edit 
  p-title="Persons"
  [p-load]="loadPage">
</po-page-dynamic-edit>

loadPage() {
  // essa função poderia estar na API e as configurações viriam do request.body
  return {
              title:  'New Title',
              breadcrumb: {
                items: [
                  { label:  'Test' },
                  { label:  'Test2' }
                ]
              }
  };
}
```