### PR TITLE
refactor(fields): remove propriedade p-focus

### DIFF
--- a/projects/ui/src/lib/components/po-field/po-datepicker/po-datepicker-base.component.ts
+++ b/projects/ui/src/lib/components/po-field/po-datepicker/po-datepicker-base.component.ts
@@ -157,24 +157,6 @@ export abstract class PoDatepickerBaseComponent implements ControlValueAccessor,
     this.validateModel(convertDateToISOExtended(this.date, this.hour));
   }
 
-  /**
-   * @optional
-   *
-   * @deprecated 2.0.0
-   * @description
-   *
-   * **Deprecated**
-   *
-   * > Esta propriedade está depreciada e será excluída na versão 2.0.0, utilize a propriedade `p-auto-focus`.
-   *
-   * Aplica foco no elemento ao ser iniciado.
-   *
-   * @default `false`
-   */
-  @Input('p-focus') set oldfocus(focus: boolean) {
-    this.autoFocus = focus;
-  }
-
   /** Habilita ação para limpar o campo. */
   clean?: boolean = false;
   @Input('p-clean') set setClean(clean: string) {

--- a/projects/ui/src/lib/components/po-field/po-input/po-input-base.component.ts
+++ b/projects/ui/src/lib/components/po-field/po-input/po-input-base.component.ts
@@ -134,24 +134,6 @@ export abstract class PoInputBaseComponent implements ControlValueAccessor, Vali
     this.validateModel();
   }
 
-  /**
-   * @optional
-   *
-   * @deprecated 2.0.0
-   * @description
-   *
-   * **Deprecated**
-   *
-   * > Esta propriedade está depreciada e será excluída na versão 2.0.0, utilize a propriedade `p-auto-focus`.
-   *
-   * Aplica foco no elemento ao ser iniciado.
-   *
-   * @default `false`
-   */
-  @Input('p-focus') set oldfocus(focus: boolean) {
-    this.autoFocus = focus;
-  }
-
   /** Se verdadeiro, o campo receberá um botão para ser limpo. */
   clean?: boolean = false;
   @Input('p-clean') set setClean(clean: string) {

--- a/projects/ui/src/lib/components/po-field/po-lookup/po-lookup-base.component.ts
+++ b/projects/ui/src/lib/components/po-field/po-lookup/po-lookup-base.component.ts
@@ -246,24 +246,6 @@ export abstract class PoLookupBaseComponent implements ControlValueAccessor, OnD
   }
 
   /**
-   * @optional
-   *
-   * @deprecated 2.0.0
-   * @description
-   *
-   * **Deprecated**
-   *
-   * > Esta propriedade está depreciada e será excluída na versão 2.0.0, utilize a propriedade `p-auto-focus`.
-   *
-   * Aplica foco no elemento ao ser iniciado.
-   *
-   * @default `false`
-   */
-  @Input('p-focus') set oldfocus(focus: boolean) {
-    this.autoFocus = focus;
-  }
-
-  /**
    * @description
    *
    * Indica que o campo será desabilitado.

--- a/projects/ui/src/lib/components/po-field/po-multiselect/po-multiselect-base.component.ts
+++ b/projects/ui/src/lib/components/po-field/po-multiselect/po-multiselect-base.component.ts
@@ -262,24 +262,6 @@ export abstract class PoMultiselectBaseComponent implements ControlValueAccessor
   /**
    * @optional
    *
-   * @deprecated 2.0.0
-   * @description
-   *
-   * **Deprecated**
-   *
-   * > Esta propriedade está depreciada e será excluída na versão 2.0.0, utilize a propriedade `p-auto-focus`.
-   *
-   * Aplica foco no elemento ao ser iniciado.
-   *
-   * @default `false`
-   */
-  @Input('p-focus') set oldfocus(focus: boolean) {
-    this.autoFocus = focus;
-  }
-
-  /**
-   * @optional
-   *
    * @description
    *
    * Define o modo de pesquisa utilizado no campo de busca, quando habilitado.

--- a/projects/ui/src/lib/components/po-field/po-textarea/po-textarea-base.component.ts
+++ b/projects/ui/src/lib/components/po-field/po-textarea/po-textarea-base.component.ts
@@ -137,24 +137,6 @@ export abstract class PoTextareaBaseComponent implements ControlValueAccessor, V
   /**
    * @optional
    *
-   * @deprecated 2.0.0
-   * @description
-   *
-   * **Deprecated**
-   *
-   * > Esta propriedade está depreciada e será excluída na versão 2.0.0, utilize a propriedade `p-auto-focus`.
-   *
-   * Aplica foco no elemento ao ser iniciado.
-   *
-   * @default `false`
-   */
-  @Input('p-focus') set oldfocus(focus: boolean) {
-    this.autoFocus = focus;
-  }
-
-  /**
-   * @optional
-   *
    * @description
    *
    * Indica a quantidade mínima de caracteres que o campo aceita.


### PR DESCRIPTION
**Fields**

**DTHFUI-3090**
_____________________________________________________________________________

**PR Checklist**

- [x] Código
- [ ] Testes unitários
- [x] Documentação
- [ ] Samples

**Qual o comportamento atual?**
Apesar de depreciada, a propriedade p-focus ainda era habilitada até a versão 1.28.0.

**Qual o novo comportamento?**
A propriedade p-focus foi depreciada e os componentes afetados são: datepicker, decimal, email, input, login, lookup, multiselect, number, password, textarea e url

**Simulação**
Basta testar qualquer componente citado acima com a propriedade excluída.